### PR TITLE
Fixes setTimeout issue that prevented end of execution.

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -57,9 +57,12 @@ Client.prototype.getAccessToken = function(done){
       delete self._currentAccessToken;
     }, 1000 * 60 * 3); //~ 3 minutes
 
-    // Make the timer active but if it's the only item left in the event loop
-    // won't keep the program running.
-    timer.unref();
+    // unref method added in node 0.10.x
+    if (timer && timer.unref) {
+      // Make the timer active but if it's the only item left in the event loop
+      // won't keep the program running.
+      timer.unref();
+    }
 
     done(null, token);
   });


### PR DESCRIPTION
When you created a node.js program that depended on `node-auth0`, after executing everything on the event loop the program didn't close. That was closed because of this:

``` js
setTimeout(function () {
      delete self._currentAccessToken;
    }, 1000 * 60 * 3); //~ 3 hours
```

It basically expires the access token after 3 hours, which makes sense.

I'm adding an [unref](http://nodejs.org/api/timers.html#timers_unref) to the timer so it closes the program if there is nothing else happening in the event loop. As doing many `unref`s on `setTimeout`s timers may have performance issues I'm submitting this for review.
