### PR TITLE
getUserBySearch

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -192,15 +192,33 @@ api.getUser = function(accessToken, userId, cb) {
       'Authorization': 'Bearer ' + accessToken,
     }
   };
-  
+
+  request.get(options, function(err, res, data) {
+    if (err) {
+      return cb(err);
+    }
+
+    if (res.statusCode.toString().substr(0, 1) !== '2') {
+      return cb(new ApiError(data, res.statusCode));
+    }
+
+    try {
+      data = JSON.parse(data);
+    } catch (e) {
+      return cb(e);
+    }
+
+    return cb(null, data);
+  });
+};
+
 api.getUserBySearch = function(accessToken, searchCriteria, cb) {
   var options = {
     url: this.apiUrl + '/users?search=' + searchCriteria,
     headers: {
       'Authorization': 'Bearer ' + accessToken,
     }
-  }
-};
+  };
 
   request.get(options, function(err, res, data) {
     if (err) {


### PR DESCRIPTION
I added a 'getUserBySearch' method to the library.  This allows you to get a User via any search criteria that's allowed by the '/users?search={criteria}' API call.

To do this I directly copied the code for 'getUser' and modified the two lines that have the variable 'searchCriteria'.

https://docs.auth0.com/api#get--api-users-search--criteria-
