### PR TITLE
Added get and patch metadata methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,12 +190,32 @@ api.updateUserPassword("my-user-id", "johnthisisyournewpassword!shhh", false, fu
 
 > Note: Result is not the password but a string with a success message.
 
+### api.getUserMetadata(userId, callback)
+
+This method retrieves the metadata for a user. `metadata` is an object that includes custom fields for the user referenced by `userId`.
+
+~~~js
+api.getUserMetadata("a-user-id", function(err, metadata) {
+  // returns error if there was a problem, otherwise the user's metadata
+});
+~~~
+
 ### api.updateUserMetadata(userId, metadata, callback)
 
-This method updates the metadata for a user. `metadata` is an object, and the fields in that object will be set on the user referenced by `userId`.
+This method updates the metadata for a user. `metadata` is an object, and the fields in that object will be set on the user referenced by `userId`. **Note:** the entire `metadata` object is replaced with this method. To update select fields, use the `patchUserMetadata` method.
 
 ~~~js
 api.updateUserMetadata("a-user-id", {my_special_data: {a: "b", c: "d"}}, function(err) {
+  // if there was a problem, err will be non-null
+});
+~~~
+
+### api.patchUserMetadata(userId, metadata, callback)
+
+This method patches the metadata for a user. `metadata` is an object, and only the fields included in the patch will be updated for the user referenced by `userId`.
+
+~~~js
+api.patchUserMetadata("a-user-id", {my_special_data: {a: "e"}}, function(err) {
   // if there was a problem, err will be non-null
 });
 ~~~

--- a/lib/api.js
+++ b/lib/api.js
@@ -311,6 +311,33 @@ api.updateUserPassword = function(accessToken, userId, newPassword, verify, cb) 
   });
 };
 
+api.getUserMetadata = function(accessToken, userId, cb) {
+  var options = {
+    url: this.apiUrl + '/users/' + userId + '/metadata',
+    headers: {
+      'Authorization': 'Bearer ' + accessToken,
+    }
+  };
+
+  request.get(options, function(err, res, data) {
+    if (err) {
+      return cb(err);
+    }
+
+    if (res.statusCode.toString().substr(0, 1) !== '2') {
+      return cb(new ApiError(data, res.statusCode));
+    }
+
+    try {
+      data = JSON.parse(data);
+    } catch (e) {
+      return cb(e);
+    }
+
+    return cb(null, data);    
+  });
+};
+
 api.updateUserMetadata = function(accessToken, userId, metadata, cb) {
   var options = {
     url: this.apiUrl + '/users/' + userId + '/metadata',
@@ -321,6 +348,28 @@ api.updateUserMetadata = function(accessToken, userId, metadata, cb) {
   };
 
   request.put(options, function(err, res, data) {
+    if (err) {
+      return cb(err);
+    }
+
+    if (res.statusCode.toString().substr(0, 1) !== '2') {
+      return cb(new ApiError(data, res.statusCode));
+    }
+
+    return cb();
+  });
+};
+
+api.patchUserMetadata = function(accessToken, userId, metadata, cb) {
+  var options = {
+    url: this.apiUrl + '/users/' + userId + '/metadata',
+    headers: {
+      'Authorization': 'Bearer ' + accessToken,
+    },
+    json: metadata,
+  };
+
+  request.patch(options, function(err, res, data) {
     if (err) {
       return cb(err);
     }


### PR DESCRIPTION
PR created in response to **ask.auth0.com** discussion here:
https://ask.auth0.com/t/how-do-i-delete-a-custom-user-metadata-property/60/3
**Note:** the `GET /api/users/{user_id}/metadata` method is not yet documented in the [API Explorer](https://docs.auth0.com/api).
