### PR TITLE
Fix users.impersonate in Authentication client

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,15 @@ This client must be used to access Auth0's [Authentication API](https://auth0.co
 
 The **AuthenticationClient** constructor takes an *optional* client ID, if specified it will be used as default value for all endpoints that accept a client ID.
 
+It takes another *optional* access token, if specified it will be used as default value for the [impersonation endpoint](https://auth0.com/docs/auth-api#!#post--users--user_id--impersonate) that requires an access token with global client permissions.
+
 ~~~js
 var AuthenticationClient = require('auth0').AuthenticationClient;
 
 var auth0 = new AuthenticationClient({
   domain: '{YOUR_ACCOUNT}.auth0.com',
-  clientId: '{OPTIONAL_CLIENT_ID}'
+  clientId: '{OPTIONAL_CLIENT_ID}',
+  accessToken: '{OPTIONAL_ACCESS_TOKEN}'
 });
 ~~~
 

--- a/src/auth/UsersManager.js
+++ b/src/auth/UsersManager.js
@@ -128,6 +128,15 @@ UsersManager.prototype.getInfo = function (accessToken, cb) {
 UsersManager.prototype.impersonate = function (userId, settings, cb) {
   var url = this.baseUrl + '/users/' + userId + '/impersonate';
   var data = extend({ client_id: this.clientId }, settings);
+  var headers = extend({}, this.headers);
+
+  if (this.accessToken === null || this.accessToken === undefined) {
+    throw new ArgumentError('An access token is required (none given to the constructor)');
+  }
+
+  if (typeof this.accessToken !== 'string' || this.accessToken.trim().length === 0) {
+    throw new ArgumentError('Invalid access token given to the constructor');
+  }
 
   if (userId === null || userId === undefined) {
     throw new ArgumentError('You must specify a user ID');
@@ -151,10 +160,12 @@ UsersManager.prototype.impersonate = function (userId, settings, cb) {
     throw new ArgumentError('protocol field is required');
   }
 
+  // Send the global client access token in the Authorization header.
+  headers['Authorization'] = 'Bearer ' + this.accessToken;
   // Perform the request.
   var promise = getRequestPromise({
     method: 'POST',
-    headers: this.headers,
+    headers: headers,
     data: data,
     url: url
   });

--- a/src/auth/UsersManager.js
+++ b/src/auth/UsersManager.js
@@ -14,6 +14,7 @@ var ArgumentError = require('../exceptions').ArgumentError;
  * @param  {String}   options.baseUrl       The auth0 account URL.
  * @param  {String}   [options.headers]     Default request headers.
  * @param  {String}   [options.clientId]    Default client ID.
+ * @param  {String}   [options.accessToken] Default accessToken.
  */
 var UsersManager = function (options) {
   if (typeof options !== 'object') {
@@ -27,6 +28,7 @@ var UsersManager = function (options) {
   this.baseUrl = options.baseUrl;
   this.headers = options.headers;
   this.clientId = options.clientId;
+  this.accessToken = options.accessToken;
 };
 
 

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -31,19 +31,23 @@ var BASE_URL_FORMAT = 'https://%s';
  * @example <caption>
  *   The <b>AuthenticationClient</b> constructor takes an <i>optional</i> client
  *   ID, if specified it will be used as default value for all endpoints that
- *   accept a client ID.
+ *   accept a client ID. It takes another <i>optional</i> access token,
+ *   if specified it will be used as default value for the impersonation endpoint
+ *   that requires an access token with global client permissions.
  * </caption>
  *
  * var AuthenticationClient = require('auth0'). AuthenticationClient;
  * var auth0 = new AuthenticationClient({
  *   domain: '{YOUR_ACCOUNT}.auth0.com',
  *   clientId: '{OPTIONAL_CLIENT_ID}'
+ *   accessToken: '{OPTIONAL_ACCESS_TOKEN}'
  * });
  *
- * @param   {Object}  options             Options for the Authentication Client
- *                                        SDK.
- * @param   {String}  options.domain      AuthenticationClient server domain.
- * @param   {String}  [options.clientId]  Default client ID.
+ * @param   {Object}  options               Options for the Authentication Client
+ *                                          SDK.
+ * @param   {String}  options.domain        AuthenticationClient server domain.
+ * @param   {String}  [options.clientId]    Default client ID.
+ * @param   {String}  [options.accessToken] Default access token.
  */
 var AuthenticationClient = function (options) {
   if (!options || typeof options !== 'object') {
@@ -62,7 +66,8 @@ var AuthenticationClient = function (options) {
       'User-agent': 'node.js/' + process.version.replace('v', ''),
       'Content-Type': 'application/json'
     },
-    baseUrl: util.format(BASE_URL_FORMAT, options.domain)
+    baseUrl: util.format(BASE_URL_FORMAT, options.domain),
+    accessToken: options.accessToken
   };
 
   if (options.telemetry !== false) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -73,7 +73,8 @@ utils.getRequestPromise = function (settings) {
         return;
       }
 
-      if (res.header['content-type'].substr(0, 5) === 'text/') {
+      if (res.header['content-type']
+      && res.header['content-type'].substr(0, 5) === 'text/') {
         return resolve(res.text);
       }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -73,6 +73,10 @@ utils.getRequestPromise = function (settings) {
         return;
       }
 
+      if (res.header['content-type'].substr(0, 5) === 'text/') {
+        return resolve(res.text);
+      }
+
       resolve(res.body);
     });
   });

--- a/test/auth/users-manager.tests.js
+++ b/test/auth/users-manager.tests.js
@@ -4,6 +4,7 @@ var Promise = require('bluebird');
 
 var BASE_URL = 'https://tenant.auth0.com';
 var CLIENT_ID = 'TEST_CLIENT_ID';
+var ACCESS_TOKEN = 'TEST_ACCESS_TOKEN'
 
 var ArgumentError = require('../../src/exceptions').ArgumentError;
 var UsersManager = require('../../src/auth/UsersManager');
@@ -15,7 +16,8 @@ describe('UsersManager', function () {
     clientId: CLIENT_ID,
     headers: {
       'Content-Type': 'application/json'
-    }
+    },
+    accessToken: ACCESS_TOKEN,
   };
 
   afterEach(function () {


### PR DESCRIPTION
This fix the [impersonation](https://auth0.com/docs/auth-api#!#post--users--user_id--impersonate) method in Authentication client by:
- passing an optional access token to the authentication constructor, required by the impersonation endpoint
- fixing the utils to resolve the request promise with the `response.text` when the body is not parsed (content-type: `text/xxx`)

Related to issue #59, thanks to @trevan for his help. Feedbacks and questions are welcome, hope this helps :)
