### PR TITLE
Change Signup CTA to Try Aut0 for Free

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Auth0 helps you to:
 
 ## Create a free Auth0 Account
 
-1. Go to [Auth0](https://auth0.com) and click Sign Up.
+1. Go to [Auth0](https://auth0.com) and click "Try Auth0 for Free".
 2. Use Google, GitHub or Microsoft Account to login.
 
 ## Issue Reporting


### PR DESCRIPTION
There is no Sign Up button in the whole Homepage so i think the CTA should be click "Try Auth0 for Free"
