### PR TITLE
Remove mocha from "dependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "homepage": "https://github.com/auth0/node-auth0",
   "dependencies": {
     "bluebird": "^2.9.24",
-    "mocha": "^2.2.4",
     "superagent": "^1.1.0",
     "url-join": "0.0.1"
   },


### PR DESCRIPTION
Mocha was added as "dependencies". There is a security issue for it https://nodesecurity.io/advisories/118

This PR removes mocha from "dependencies", it should be only in "devDependencies"

Can you generate a `v2.0.0-alpha.6` version/tag on this branch `v2.0.0-alpha` after merging?