### PR TITLE
Add support for returning entire response from Utils.getRequestPromise

### DIFF
--- a/src/auth/UsersManager.js
+++ b/src/auth/UsersManager.js
@@ -155,7 +155,7 @@ UsersManager.prototype.impersonate = function (userId, settings, cb) {
     headers: this.headers,
     data: data,
     url: url
-  });
+  }, true);
 
   // Use callback if given.
   if (cb instanceof Function) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -54,7 +54,7 @@ utils.wrapPropertyMethod = function (Parent, name, propertyMethod) {
  * @method    getRequestPromise
  * @memberOf  module:utils
  */
-utils.getRequestPromise = function (settings) {
+utils.getRequestPromise = function (settings, wholeResponse) {
   return new Promise(function (resolve, reject) {
     var method = settings.method.toLowerCase();
     var req = request[method](settings.url);
@@ -73,7 +73,7 @@ utils.getRequestPromise = function (settings) {
         return;
       }
 
-      resolve(res.body);
+      resolve(wholeResponse ? res : res.body );
     });
   });
 };


### PR DESCRIPTION
Some Auth0 endpoints do not return their content in the response body, so it's important to return the entire response (lazy approach) or the specific field required for various calls. In this case, I care about the `text` property from w/in the impersonation function. This PR allows my callback to access the response & handle the rest of the flow properly.
