### PR TITLE
Bump request@2.75.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "nock": "~0.27.2"
   },
   "dependencies": {
-    "xtend": "~1.0.3",
-    "request": "~2.72.0",
-    "parse-links": "0.0.1"
+    "parse-links": "0.0.1",
+    "request": "2.75.0",
+    "xtend": "~1.0.3"
   }
 }


### PR DESCRIPTION
Bump `request@2.75.0` in order to sort NSP vulnerabilities found in `tough-cookie@<2.3.0`.

Changelog link: https://github.com/request/request/blob/master/CHANGELOG.md