### PR TITLE
Fix auth/users.getInfo to return JSON (fixes #158)

### DIFF
--- a/src/auth/UsersManager.js
+++ b/src/auth/UsersManager.js
@@ -74,7 +74,8 @@ UsersManager.prototype.getInfo = function (accessToken, cb) {
   var promise = getRequestPromise({
     method: 'GET',
     url: url,
-    headers: headers
+    headers: headers,
+    data: {}
   });
 
   // Use callback if given.


### PR DESCRIPTION
As reported in #158, `auth/users.getInfo` currently returns JSON result in `string` type. This PR fixes this bug so the result is returned in the proper JSON type.