### PR TITLE
Improved readme.md example for management API

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,16 +77,15 @@ Be aware that all methods can be used with promises or callbacks. However, when 
 
 ```js
 // Using callbacks.
-auth0.getUsers(function (err, users) {
+management.getUsers(function (err, users) {
   if (err) {
     // handle error.
   }
   console.log(users);
 });
 
-
 // Using promises.
-auth0
+management
   .getUsers()
   .then(function (users) {
     console.log(users);


### PR DESCRIPTION
In the readme.md it used the 'auth0' variable which was an instance of the 'AuthenticationClient' when making calls to the management API. I changed it to use the 'management' variable which was an instance of ManagementClient.

