### PR TITLE
Added tokenProvider functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ var auth0 = new AuthenticationClient({
 ## Management API Client
 The Auth0 Management API is meant to be used by back-end servers or trusted parties performing administrative tasks. Generally speaking, anything that can be done through the Auth0 dashboard (and more) can also be done through this API.
 
-
 Initialize your client class with an API v2 token and a domain.
 
 ```js
@@ -43,7 +42,7 @@ var management = new ManagementClient({
 });
 ```
 
-> When using at browser you should use `telemetry: false`.
+> Note: When using at browser you should use `telemetry: false`.
 
 To obtain a Management API token from your node backend, you can use Client Credentials Grant using your registered Auth0 Non Interactive Clients
 
@@ -70,6 +69,24 @@ auth0.clientCredentialsGrant({
 > Make sure your ClientId is allowed to request tokens from Management API in [Auth0 Dashboard](https://manage.auth0.com/#/apis)
 
 Also you can request a token when the user authenticates using any of our client side SDKs, e.g. [auth0.js](https://github.com/auth0/auth0.js).
+
+Or initialize your client class with the ManagementTokenProvider.
+~~~js
+var ManagementClient = require('auth0').ManagementClient;
+var ManagementTokenProvider = require('auth0').ManagementTokenProvider;
+var auth0 = new ManagementClient({
+  domain: '{YOUR_ACCOUNT}.auth0.com',
+  tokenProvider: new ManagementTokenProvider({
+    clientId: '{YOUR_NON_INTERACTIVE_CLIENT_ID}',
+    clientSecret: '{YOUR_NON_INTERACTIVE_CLIENT_SECRET}',
+    domain: '{YOUR_ACCOUNT}.auth0.com',
+    scope: '{MANAGEMENT_API_SCOPES}',
+    useCache: true //default
+  })
+ });
+~~~
+
+> Note: When using at browser you should use `telemetry: false`.
 
 ## Promises and callbacks
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ var management = new ManagementClient({
 
 > Note: When using at browser you should use `telemetry: false`.
 
+To obtain **automatically** a Management API token via the ManagementClient, you can specify the parameters `clientId`, `clientSecret` (use a Non Interactive Client) and optionally `scope`.
+Behind the scenes the Client Credentials Grant is used to obtain the `access_token` and is by default cached for the duration of the returned `expires_in` value.
+
+```js
+var ManagementClient = require('auth0').ManagementClient;
+var auth0 = new ManagementClient({
+  domain: '{YOUR_ACCOUNT}.auth0.com',
+  clientId: '{YOUR_NON_INTERACTIVE_CLIENT_ID}',
+  clientSecret: '{YOUR_NON_INTERACTIVE_CLIENT_SECRET}',
+  scope: "read:users write:users",
+});
+```
+
+> Make sure your ClientId is allowed to request tokens from Management API in [Auth0 Dashboard](https://manage.auth0.com/#/apis)
+
 To obtain a Management API token from your node backend, you can use Client Credentials Grant using your registered Auth0 Non Interactive Clients
 
 ```js
@@ -65,27 +80,6 @@ auth0.clientCredentialsGrant({
   console.log(response.access_token);
 });
 ```
-
-> Make sure your ClientId is allowed to request tokens from Management API in [Auth0 Dashboard](https://manage.auth0.com/#/apis)
-
-To obtain **automatically** a Management API token via the ManagementClient, you can specify the parameters `clientId`, `clientSecret` (use a Non Interactive Client), `audience` (identifier of the Auth0 Management API) and optionally `scope`.
-Behind the scenes the Client Credentials Grant is used to obtain the `access_token` and is by default cached for the duration of the returned `expires_in` value.
-~~~js
-var ManagementClient = require('auth0').ManagementClient;
-var auth0 = new ManagementClient({
-  domain: '{YOUR_ACCOUNT}.auth0.com',
-  clientId: '{YOUR_NON_INTERACTIVE_CLIENT_ID}',
-  clientSecret: '{YOUR_NON_INTERACTIVE_CLIENT_SECRET}',
-  scope: "read:users write:users",
-  audience: 'https://{YOUR_TENANT_NAME}.auth0.com/api/v2/',
-  tokenProvider: {
-   enableCache: true, // default value
-   cacheTTLInSeconds: 10 // By default the `expires_in` value will be used to determine the cached time of the token
-  }
-});
-~~~
-
-> Note: When using at browser you should use `telemetry: false`.
 
 Also you can request a token when the user authenticates using any of our client side SDKs, e.g. [auth0.js](https://github.com/auth0/auth0.js).
 

--- a/README.md
+++ b/README.md
@@ -68,25 +68,26 @@ auth0.clientCredentialsGrant({
 
 > Make sure your ClientId is allowed to request tokens from Management API in [Auth0 Dashboard](https://manage.auth0.com/#/apis)
 
-Also you can request a token when the user authenticates using any of our client side SDKs, e.g. [auth0.js](https://github.com/auth0/auth0.js).
-
-Or initialize your client class with the ManagementTokenProvider.
+To obtain **automatically** a Management API token via the ManagementClient, you can specify the parameters `clientId`, `clientSecret` (use a Non Interactive Client), `audience` (identifier of the Auth0 Management API) and optionally `scope`.
+Behind the scenes the Client Credentials Grant is used to obtain the `access_token` and is by default cached for the duration of the returned `expires_in` value.
 ~~~js
 var ManagementClient = require('auth0').ManagementClient;
-var ManagementTokenProvider = require('auth0').ManagementTokenProvider;
 var auth0 = new ManagementClient({
   domain: '{YOUR_ACCOUNT}.auth0.com',
-  tokenProvider: new ManagementTokenProvider({
-    clientId: '{YOUR_NON_INTERACTIVE_CLIENT_ID}',
-    clientSecret: '{YOUR_NON_INTERACTIVE_CLIENT_SECRET}',
-    domain: '{YOUR_ACCOUNT}.auth0.com',
-    scope: '{MANAGEMENT_API_SCOPES}',
-    useCache: true //default
-  })
- });
+  clientId: '{YOUR_NON_INTERACTIVE_CLIENT_ID}',
+  clientSecret: '{YOUR_NON_INTERACTIVE_CLIENT_SECRET}',
+  scope: "read:users write:users",
+  audience: 'https://{YOUR_TENANT_NAME}.auth0.com/api/v2/',
+  tokenProvider: {
+   enableCache: true, // default value
+   cacheTTLInSeconds: 10 // By default the `expires_in` value will be used to determine the cached time of the token
+  }
+});
 ~~~
 
 > Note: When using at browser you should use `telemetry: false`.
+
+Also you can request a token when the user authenticates using any of our client side SDKs, e.g. [auth0.js](https://github.com/auth0/auth0.js).
 
 ## Promises and callbacks
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
   "dependencies": {
     "bluebird": "^2.10.2",
     "request": "^2.83.0",
+    "lru-memoizer": "^1.11.1",
+    "object.assign": "^4.0.4",
     "rest-facade": "^1.5.0"
   },
   "devDependencies": {

--- a/src/Auth0RestClient.js
+++ b/src/Auth0RestClient.js
@@ -1,0 +1,71 @@
+var RestClient = require('rest-facade').Client;
+var Promise = require('bluebird');
+var ArgumentError = require('rest-facade').ArgumentError;
+
+var Auth0RestClient = function (resourceUrl, options, provider) {
+  if (resourceUrl === null || resourceUrl === undefined) {
+    throw new ArgumentError('Must provide a Resource Url');
+  }
+
+  if ('string' !== typeof resourceUrl || resourceUrl.length === 0) {
+    throw new ArgumentError('The provided Resource Url is invalid');
+  }
+
+  if (options === null || typeof options !== 'object') {
+    throw new ArgumentError('Must provide options');
+  }
+
+  this.options = options;
+  this.provider = provider;
+  this.restClient = new RestClient(resourceUrl, options);
+
+  this.wrappedProvider = function (method, args) {
+    if (!this.provider) {
+      return this.restClient[method].apply(this.restClient, args);
+    }
+
+    var callback;
+    if(args && args[args.length -1] instanceof Function){
+      callback = args[args.length -1];
+    }
+
+    var self = this;
+    return this.provider.getAccessToken()
+      .then(function (access_token) {
+        self.options.headers['Authorization'] = 'Bearer ' + access_token;
+        return self.restClient[method].apply(self.restClient, args);
+      }).catch(function(err){
+        if(callback){
+          return callback(err);
+        }
+        return Promise.reject(err);
+      });
+  }
+};
+
+Auth0RestClient.prototype.getAll = function ( /* [params], [callback] */ ) {
+  return this.wrappedProvider('getAll', arguments);
+};
+
+
+Auth0RestClient.prototype.get = function ( /* [params], [callback] */ ) {
+  return this.wrappedProvider('get', arguments);
+}
+
+Auth0RestClient.prototype.create = function ( /* [params], [callback] */ ) {
+  return this.wrappedProvider('create', arguments);
+}
+
+Auth0RestClient.prototype.patch = function ( /* [params], [callback] */ ) {
+  return this.wrappedProvider('patch', arguments);
+}
+
+Auth0RestClient.prototype.update = function ( /* [params], [callback] */ ) {
+  return this.wrappedProvider('update', arguments);
+}
+
+Auth0RestClient.prototype.delete = function ( /* [params], [callback] */ ) {
+  return this.wrappedProvider('delete', arguments);
+}
+
+module.exports = Auth0RestClient;

--- a/src/index.js
+++ b/src/index.js
@@ -6,5 +6,6 @@
 
 module.exports = {
   ManagementClient: require('./management'),
-  AuthenticationClient: require('./auth')
+  AuthenticationClient: require('./auth'),
+  ManagementTokenProvider: require('./management/ManagementTokenProvider')
 };

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,5 @@
 
 module.exports = {
   ManagementClient: require('./management'),
-  AuthenticationClient: require('./auth'),
-  ManagementTokenProvider: require('./management/ManagementTokenProvider')
+  AuthenticationClient: require('./auth')
 };

--- a/src/management/BlacklistedTokensManager.js
+++ b/src/management/BlacklistedTokensManager.js
@@ -1,7 +1,6 @@
-var RestClient = require('rest-facade').Client;
 var ArgumentError = require('rest-facade').ArgumentError;
 var utils = require('../utils');
-
+var Auth0RestClient = require('../Auth0RestClient');
 
 /**
  * @class BlacklistedTokensManager
@@ -44,7 +43,7 @@ var BlacklistedTokensManager = function (options) {
    *
    * @type {external:RestClient}
    */
-  this.resource = new RestClient(options.baseUrl + '/blacklists/tokens', clientOptions);
+  this.resource = new Auth0RestClient(options.baseUrl + '/blacklists/tokens', clientOptions, options.tokenProvider);
 };
 
 

--- a/src/management/ClientGrantsManager.js
+++ b/src/management/ClientGrantsManager.js
@@ -1,7 +1,6 @@
-var RestClient = require('rest-facade').Client;
 var ArgumentError = require('rest-facade').ArgumentError;
 var utils = require('../utils');
-
+var Auth0RestClient = require('../Auth0RestClient');
 
 /**
  * @class ClientGrantsManager
@@ -46,7 +45,7 @@ var ClientGrantsManager = function (options) {
    *
    * @type {external:RestClient}
    */
-  this.resource = new RestClient(options.baseUrl + '/client-grants/:id', clientOptions);
+  this.resource = new Auth0RestClient(options.baseUrl + '/client-grants/:id', clientOptions, options.tokenProvider);
 };
 
 

--- a/src/management/ClientsManager.js
+++ b/src/management/ClientsManager.js
@@ -1,7 +1,6 @@
-var RestClient = require('rest-facade').Client;
 var ArgumentError = require('rest-facade').ArgumentError;
 var utils = require('../utils');
-
+var Auth0RestClient = require('../Auth0RestClient');
 
 /**
  * @class ClientsManager
@@ -49,7 +48,7 @@ var ClientsManager = function (options) {
    *
    * @type {external:RestClient}
    */
-  this.resource = new RestClient(options.baseUrl + '/clients/:client_id', clientOptions);
+  this.resource = new Auth0RestClient(options.baseUrl + '/clients/:client_id', clientOptions, options.tokenProvider);
 };
 
 

--- a/src/management/ConnectionsManager.js
+++ b/src/management/ConnectionsManager.js
@@ -1,7 +1,6 @@
-var RestClient = require('rest-facade').Client;
 var ArgumentError = require('rest-facade').ArgumentError;
 var utils = require('../utils');
-
+var Auth0RestClient = require('../Auth0RestClient');
 
 /**
  * @class ConnectionsManager
@@ -43,7 +42,7 @@ var ConnectionsManager = function (options) {
    *
    * @type {external:RestClient}
    */
-  this.resource = new RestClient(options.baseUrl + '/connections/:id ', apiOptions);
+  this.resource = new Auth0RestClient(options.baseUrl + '/connections/:id ', apiOptions, options.tokenProvider);
 };
 
 

--- a/src/management/DeviceCredentialsManager.js
+++ b/src/management/DeviceCredentialsManager.js
@@ -1,7 +1,6 @@
-var RestClient = require('rest-facade').Client;
 var ArgumentError = require('rest-facade').ArgumentError;
 var utils = require('../utils');
-
+var Auth0RestClient = require('../Auth0RestClient');
 
 /**
  * Simple facade for consuming a REST API endpoint.
@@ -49,9 +48,9 @@ var DeviceCredentialsManager = function (options) {
    * {@link https://auth0.com/docs/api/v2#!/Device_Credentials
    *  Auth0 DeviceCredentialsManagers endpoint}.
    *
-   * @type {external:RestDeviceCredentialsManager}
+   * @type {external:RestClient}
    */
-  this.resource = new RestClient(options.baseUrl + '/device-credentials/:id', clientOptions);
+  this.resource = new Auth0RestClient(options.baseUrl + '/device-credentials/:id', clientOptions, options.tokenProvider);
 };
 
 

--- a/src/management/EmailProviderManager.js
+++ b/src/management/EmailProviderManager.js
@@ -1,7 +1,6 @@
-var RestClient = require('rest-facade').Client;
 var ArgumentError = require('rest-facade').ArgumentError;
 var utils = require('../utils');
-
+var Auth0RestClient = require('../Auth0RestClient');
 
 /**
  * Simple facade for consuming a REST API endpoint.
@@ -50,7 +49,7 @@ var EmailProviderManager = function (options) {
    *
    * @type {external:RestClient}
    */
-  this.resource = new RestClient(options.baseUrl + '/emails/provider', clientOptions);
+  this.resource = new Auth0RestClient(options.baseUrl + '/emails/provider', clientOptions, options.tokenProvider);
 };
 
 

--- a/src/management/JobsManager.js
+++ b/src/management/JobsManager.js
@@ -3,9 +3,8 @@ var extend = require('util')._extend;
 var Promise = require('bluebird');
 var fs = require('fs');
 
-var RestClient = require('rest-facade').Client;
 var ArgumentError = require('rest-facade').ArgumentError;
-
+var Auth0RestClient = require('../Auth0RestClient');
 
 /**
  * Simple facade for consuming a REST API endpoint.
@@ -51,7 +50,7 @@ var JobsManager = function (options){
    *
    * @type {external:RestClient}
    */
-  this.jobs = new RestClient(options.baseUrl + '/jobs/:id', clientOptions);
+  this.jobs = new Auth0RestClient(options.baseUrl + '/jobs/:id', clientOptions, options.tokenProvider);
 };
 
 

--- a/src/management/LogsManager.js
+++ b/src/management/LogsManager.js
@@ -1,7 +1,6 @@
-var RestClient = require('rest-facade').Client;
 var ArgumentError = require('rest-facade').ArgumentError;
 var utils = require('../utils');
-
+var Auth0RestClient = require('../Auth0RestClient');
 
 /**
  * @class LogsManager
@@ -43,7 +42,7 @@ var LogsManager = function (options) {
    *
    * @type {external:RestClient}
    */
-  this.resource = new RestClient(options.baseUrl + '/logs/:id ', apiOptions);
+  this.resource = new Auth0RestClient(options.baseUrl + '/logs/:id ', apiOptions, options.tokenProvider);
 };
 
 /**

--- a/src/management/ManagementTokenProvider.js
+++ b/src/management/ManagementTokenProvider.js
@@ -1,0 +1,121 @@
+var ArgumentError = require('rest-facade').ArgumentError;
+var assign = Object.assign || require('object.assign');
+var AuthenticationClient = require('../auth');
+var memoizer = require('lru-memoizer');
+var Promise = require('bluebird');
+
+var BASE_URL_FORMAT = 'https://%s';
+var DEFAULT_OPTIONS = { useCache : true };
+
+/**
+ * @class ManagementTokenProvider
+ * Auth0 Management API Token Provider.
+ * @constructor
+ * @memberOf module:management
+ *
+ * @param {Object} options                  Options for the ManagementTokenProvider.
+ * @param {String} options.domain           ManagementClient server domain.
+ * @param {String} options.clientId         Non Interactive Client Id.
+ * @param {String} options.clientSecret     Non Interactive Client Secret.
+ * @param {String} [options.useCache]       Enable caching (default true)
+ * @param {String} [options.scope]          Scope
+ * @example <caption>
+ *   Initialize a Management Token Provider class.
+ * </caption>
+ *
+ * var ManagementTokenProvider = require('auth0').ManagementTokenProvider;
+ * var provider = new ManagementTokenProvider({
+ *   clientId: '{YOUR_NON_INTERACTIVE_CLIENT_ID}',
+ *   clientSecret: '{YOUR_NON_INTERACTIVE_CLIENT_SECRET}',
+ *   domain: '{YOUR_ACCOUNT}.auth0.com'
+ * });
+ */
+var ManagementTokenProvider = function (options) {
+  if (!options || typeof options !== 'object') {
+    throw new ArgumentError('Options must be an object');
+  }
+
+  var params = assign({}, DEFAULT_OPTIONS, options);
+
+  if (!params.clientId || params.clientId.length === 0) {
+    throw new ArgumentError('Must provide a Client Id');
+  }
+
+  if (!params.clientSecret || params.clientSecret.length === 0) {
+    throw new ArgumentError('Must provide a Client Secret');
+  }
+
+  if(typeof params.useCache !== 'boolean'){
+    throw new ArgumentError('The useCache must be a boolean');
+  }
+  
+  this.options = params;
+
+  this.authenticationClient = new AuthenticationClient({
+    domain: params.domain,
+    clientId: params.clientId,
+    clientSecret: params.clientSecret,
+    telemetry: params.telemetry
+  });
+}
+
+/**
+ * Returns the access_token.
+ *
+ * @method    getAccessToken
+ * @memberOf  module:management.ManagementTokenProvider.prototype
+ *
+ * @return {Promise}   Promise returning an access_token.
+ */
+ManagementTokenProvider.prototype.getAccessToken = function () {
+  
+  if(this.options.useCache){
+     return this.getCachedAccessToken(this.options.domain, this.options.clientId, this.options.scope)
+      .then(function (data) {
+        return data.access_token
+      });
+  }else{
+    return this.clientCredentialsGrant(this.options.domain, this.options.scope)
+      .then(function (data) {
+        return data.access_token
+      });
+  }
+}
+
+ManagementTokenProvider.prototype.getCachedAccessToken = Promise.promisify(
+  memoizer({
+    load: function (domain, clientId, scope, callback) {
+      this.clientCredentialsGrant(domain, scope)
+        .then(function (data) {
+          callback(null, data);
+        })
+        .catch(function (err) {
+          callback(err);
+        });
+    },
+    hash: function (domain, clientId, scope) {
+      return domain + '-' + clientId + '-' + scope;
+    },
+    itemMaxAge: function (domain, clientid, scope, data) {
+      // if the expires_in is lower than 10 seconds, do not subtract 10 additional seconds.
+      if (data.expires_in && data.expires_in < 10 /* seconds */){
+        return data.expires_in * 1000;
+      }else if(data.expires_in){
+        // Subtract 10 seconds from expires_in to fetch a new one, before it expires.
+        return data.expires_in * 1000 - 10000/* milliseconds */;
+      }
+      return 3600 * 1000 // 1h; 
+    },
+    max: 100,
+    maxAge: 1000 * 60
+  })
+);
+
+ManagementTokenProvider.prototype.clientCredentialsGrant = function (domain, scope) {
+  return this.authenticationClient.clientCredentialsGrant({
+    audience: 'https://' + domain + '/api/v2/',
+    scope: scope
+  });
+};
+
+module.exports = ManagementTokenProvider;

--- a/src/management/ManagementTokenProvider.js
+++ b/src/management/ManagementTokenProvider.js
@@ -16,8 +16,8 @@ var DEFAULT_OPTIONS = { enableCache: true };
  * @param {String}  options.domain                  ManagementClient server domain.
  * @param {String}  options.clientId                Non Interactive Client Id.
  * @param {String}  options.clientSecret            Non Interactive Client Secret.
- * @param {String}  options.audience                Audience of the Management API.
  * @param {String}  options.scope                   Non Interactive Client Scope.
+ * @param {String}  options.audience                Audience of the Management API.
  * @param {Boolean} [options.enableCache=true]      Enabled or Disable Cache
  * @param {Number}  [options.cacheTTLInSeconds]     By default the `expires_in` value will be used to determine the cached time of the token, this can be overridden.
  */
@@ -27,7 +27,7 @@ var ManagementTokenProvider = function (options) {
   }
 
   var params = assign({}, DEFAULT_OPTIONS, options);
-  
+
   if (!params.domain || params.domain.length === 0) {
     throw new ArgumentError('Must provide a domain');
   }
@@ -44,24 +44,24 @@ var ManagementTokenProvider = function (options) {
     throw new ArgumentError('Must provide a audience');
   }
 
-  if(typeof params.enableCache !== 'boolean'){
-    throw new ArgumentError('enableCache must be a boolean');   
+  if (typeof params.enableCache !== 'boolean'){
+    throw new ArgumentError('enableCache must be a boolean');
   }
-  
-  if(params.enableCache && params.cacheTTLInSeconds){
-    if(typeof params.cacheTTLInSeconds !== 'number'){
+
+  if (params.enableCache && params.cacheTTLInSeconds) {
+    if (typeof params.cacheTTLInSeconds !== 'number') {
       throw new ArgumentError('cacheTTLInSeconds must be a number');
     }
-    
-    if(params.cacheTTLInSeconds <= 0) {
+
+    if (params.cacheTTLInSeconds <= 0) {
       throw new ArgumentError('cacheTTLInSeconds must be a greater than 0');
     }
   }
 
-  if(params.scope && typeof params.scope !== 'string'){
+  if (params.scope && typeof params.scope !== 'string'){
     throw new ArgumentError('scope must be a string');
   }
-  
+
   this.options = params;
   var authenticationClientOptions = {
     domain: this.options.domain,
@@ -69,7 +69,6 @@ var ManagementTokenProvider = function (options) {
     clientSecret: this.options.clientSecret,
     telemetry: this.options.telemetry
   };
-  //console.log('authenticationClientOptions', authenticationClientOptions);
   this.authenticationClient = new AuthenticationClient(authenticationClientOptions);
 }
 

--- a/src/management/ResourceServersManager.js
+++ b/src/management/ResourceServersManager.js
@@ -1,6 +1,6 @@
-var RestClient = require('rest-facade').Client;
 var ArgumentError = require('rest-facade').ArgumentError;
 var utils = require('../utils');
+var Auth0RestClient = require('../Auth0RestClient');
 
 /**
  * @class ResourceServersManager
@@ -48,7 +48,7 @@ var ResourceServersManager = function (options) {
    *
    * @type {external:RestClient}
    */
-  this.resource = new RestClient(options.baseUrl + '/resource-servers/:id', apiOptions);
+  this.resource = new Auth0RestClient(options.baseUrl + '/resource-servers/:id', apiOptions, options.tokenProvider);
 };
 
 /**

--- a/src/management/RulesManager.js
+++ b/src/management/RulesManager.js
@@ -1,7 +1,6 @@
-var RestClient = require('rest-facade').Client;
 var ArgumentError = require('rest-facade').ArgumentError;
 var utils = require('../utils');
-
+var Auth0RestClient = require('../Auth0RestClient');
 
 /**
  * Simple facade for consuming a REST API endpoint.
@@ -50,7 +49,7 @@ var RulesManager = function (options) {
    *
    * @type {external:RestClient}
    */
-  this.resource = new RestClient(options.baseUrl + '/rules/:id ', apiOptions);
+  this.resource = new Auth0RestClient(options.baseUrl + '/rules/:id ', apiOptions, options.tokenProvider);
 };
 
 

--- a/src/management/StatsManager.js
+++ b/src/management/StatsManager.js
@@ -1,6 +1,5 @@
-var RestClient = require('rest-facade').Client;
 var ArgumentError = require('rest-facade').ArgumentError;
-
+var Auth0RestClient = require('../Auth0RestClient');
 
 /**
  * Simple facade for consuming a REST API endpoint.
@@ -44,7 +43,7 @@ var StatsManager = function (options){
    *
    * @type {external:RestClient}
    */
-  this.stats = new RestClient(options.baseUrl + '/stats/:type', clientOptions);
+  this.stats = new Auth0RestClient(options.baseUrl + '/stats/:type', clientOptions, options.tokenProvider);
 };
 
 

--- a/src/management/TenantManager.js
+++ b/src/management/TenantManager.js
@@ -1,5 +1,5 @@
-var RestClient = require('rest-facade').Client;
 var ArgumentError = require('rest-facade').ArgumentError;
+var Auth0RestClient = require('../Auth0RestClient');
 
 
 /**
@@ -44,7 +44,7 @@ var TenantManager = function (options){
    *
    * @type {external:RestClient}
    */
-  this.tenant = new RestClient(options.baseUrl + '/tenants/settings', clientOptions);
+  this.tenant = new Auth0RestClient(options.baseUrl + '/tenants/settings', clientOptions,  options.tokenProvider);
 };
 
 /**

--- a/src/management/TicketsManager.js
+++ b/src/management/TicketsManager.js
@@ -1,5 +1,5 @@
-var RestClient = require('rest-facade').Client;
 var ArgumentError = require('rest-facade').ArgumentError;
+var Auth0RestClient = require('../Auth0RestClient');
 
 
 /**
@@ -33,7 +33,7 @@ var TicketsManager = function (options){
    *
    * @type {external:RestClient}
    */
-  this.ticket = new RestClient(options.baseUrl + '/tickets/:type', clientOptions);
+  this.ticket = new Auth0RestClient(options.baseUrl + '/tickets/:type', clientOptions, options.tokenProvider);
 };
 
 

--- a/src/management/UsersManager.js
+++ b/src/management/UsersManager.js
@@ -1,6 +1,5 @@
-var RestClient = require('rest-facade').Client;
 var ArgumentError = require('rest-facade').ArgumentError;
-
+var Auth0RestClient = require('../Auth0RestClient');
 
 /**
  * Simple facade for consuming a REST API endpoint.
@@ -37,8 +36,8 @@ var UsersManager = function (options){
     headers: options.headers,
     query: { repeatParams: false }
   };
-
-  this.users = new RestClient(options.baseUrl + '/users/:id', clientOptions);
+  
+  this.users = new Auth0RestClient(options.baseUrl + '/users/:id', clientOptions, options.tokenProvider);
 
   /**
    * Provides an abstraction layer for consuming the
@@ -47,28 +46,28 @@ var UsersManager = function (options){
    *
    * @type {external:RestClient}
    */
-  this.multifactor = new RestClient(options.baseUrl + '/users/:id/multifactor/:provider', clientOptions);
+  this.multifactor = new Auth0RestClient(options.baseUrl + '/users/:id/multifactor/:provider', clientOptions, options.tokenProvider);
 
   /**
    * Provides a simple abstraction layer for linking user accounts.
    *
    * @type {external:RestClient}
    */
-  this.identities = new RestClient(options.baseUrl + '/users/:id/identities/:provider/:user_id', clientOptions);
+  this.identities = new Auth0RestClient(options.baseUrl + '/users/:id/identities/:provider/:user_id', clientOptions, options.tokenProvider);
 
   /**
    * Provides a simple abstraction layer for user logs
    *
    * @type {external:RestClient}
    */
-  this.userLogs = new RestClient(options.baseUrl + '/users/:id/logs', clientOptions);
+  this.userLogs = new Auth0RestClient(options.baseUrl + '/users/:id/logs', clientOptions, options.tokenProvider);
 
   /**
    * Provides an abstraction layer for retrieving Guardian enrollments.
    *
    * @type {external:RestClient}
    */
-  this.enrollments = new RestClient(options.baseUrl + '/users/:id/enrollments', clientOptions);
+  this.enrollments = new Auth0RestClient(options.baseUrl + '/users/:id/enrollments', clientOptions, options.tokenProvider);
 };
 
 

--- a/src/management/index.js
+++ b/src/management/index.js
@@ -26,7 +26,7 @@ var ResourceServersManager = require('./ResourceServersManager');
 var ManagementTokenProvider = require('./ManagementTokenProvider');
 
 var BASE_URL_FORMAT = 'https://%s/api/v2';
-
+var MANAGEMENT_API_AUD_FORMAT = 'https://%s/api/v2/';
 
 /**
  * @class ManagementClient
@@ -49,8 +49,8 @@ var BASE_URL_FORMAT = 'https://%s/api/v2';
  *   domain: '{YOUR_ACCOUNT}.auth0.com',
  *   token: '{YOUR_API_V2_TOKEN}'
  * });
- * 
- * 
+ *
+ *
   * @example <caption>
  *   Initialize your client class, by using a Non Interactive Client to fetch an access_token
  *   via the Client Credentials Grant.
@@ -69,18 +69,18 @@ var BASE_URL_FORMAT = 'https://%s/api/v2';
  *  }
  * });
  *
- * @param   {Object}  options                                   Options for the ManagementClient SDK. 
+ * @param   {Object}  options                                   Options for the ManagementClient SDK.
  *          If a token is provided only the domain is required, other parameters are ignored.
- *          If no token is provided domain, clientId, clientSecret and audience are required
- * @param   {String}  options.domain                            ManagementClient server domain.
- * @param   {String}  [options.token]                           API access token. 
- * @param   {String}  [options.clientId]                        Management API Non Interactive Client Id.
- * @param   {String}  [options.clientSecret]                    Management API Non Interactive Client Secret.
- * @param   {String}  [options.audience]                        Management API Audience.
- * @param   {String}  [options.scope]                           Management API Scopes. 
- * @param   {String}  [options.tokenProvider.enableCache=true]  Enabled or Disable Cache.
- * @param   {Number}  [options.cacheTTLInSeconds]               By default the `expires_in` value will be used to determine the cached time of the token, this can be overridden.
- * 
+ *          If no token is provided domain, clientId, clientSecret and scopes are required
+ * @param   {String}  options.domain                              ManagementClient server domain.
+ * @param   {String}  [options.token]                             API access token.
+ * @param   {String}  [options.clientId]                          Management API Non Interactive Client Id.
+ * @param   {String}  [options.clientSecret]                      Management API Non Interactive Client Secret.
+ * @param   {String}  [options.audience]                          Management API Audience. By default is your domain's, e.g. the domain is `tenant.auth0.com` and the audience is `http://tenant.auth0.com/api/v2/`
+ * @param   {String}  [options.scope]                             Management API Scopes.
+ * @param   {String}  [options.tokenProvider.enableCache=true]    Enabled or Disable Cache.
+ * @param   {Number}  [options.tokenProvider.cacheTTLInSeconds]   By default the `expires_in` value will be used to determine the cached time of the token, this can be overridden.
+ *
  */
 var ManagementClient = function (options) {
   if (!options || typeof options !== 'object') {
@@ -91,28 +91,29 @@ var ManagementClient = function (options) {
       throw new ArgumentError('Must provide a domain');
   }
 
+  var baseUrl = util.format(BASE_URL_FORMAT, options.domain);
   var managerOptions = {
     headers: {
       'User-agent': 'node.js/' + process.version.replace('v', ''),
       'Content-Type': 'application/json'
     },
-    baseUrl: util.format(BASE_URL_FORMAT, options.domain)
+    baseUrl: baseUrl
   };
 
-  if(options.token === undefined){
-    var config = assign({}, options);
-    
-    if(options.tokenProvider){
+  if (options.token === undefined) {
+    var config = assign({ audience: util.format(MANAGEMENT_API_AUD_FORMAT, options.domain) }, options);
+
+    if (options.tokenProvider) {
       config.enableCache = options.tokenProvider.enableCache;
       config.cacheTTLInSeconds = options.tokenProvider.cacheTTLInSeconds;
-      delete config.tokenProvider;  
+      delete config.tokenProvider;
     }
 
     this.tokenProvider = new ManagementTokenProvider(config);
     managerOptions.tokenProvider = this.tokenProvider;
-  }else if(typeof options.token !== 'string' || options.token.length === 0){
+  } else if (typeof options.token !== 'string' || options.token.length === 0) {
     throw new ArgumentError('Must provide a token');
-  }else{
+  } else {
     managerOptions.headers['Authorization'] = 'Bearer ' + options.token;
   }
 

--- a/test/auth0-rest-client.tests.js
+++ b/test/auth0-rest-client.tests.js
@@ -1,0 +1,119 @@
+var expect = require('chai').expect;
+var nock = require('nock');
+
+var ArgumentError = require('rest-facade').ArgumentError;
+var ManagementTokenProvider = require('../src/management/ManagementTokenProvider')
+var Auth0RestClient = require('../src/Auth0RestClient');
+
+var API_URL = 'https://tenant.auth0.com';
+
+describe('Auth0RestClient', function () {
+  before(function () {
+    this.providerMock = {
+      getAccessToken: function () {
+        return Promise.resolve('access_token');
+      }
+    }
+  });
+
+  it('should raise an error when no resource Url is provided', function () {
+    expect(Auth0RestClient)
+      .to.throw(ArgumentError, 'Must provide a Resource Url');
+  });
+
+  it('should raise an error when resource Url is invalid', function () {
+    var client = Auth0RestClient.bind(null, '');
+    expect(client)
+      .to.throw(ArgumentError, 'The provided Resource Url is invalid');
+  });
+
+  it('should raise an error when no options is provided', function () {
+    var client = Auth0RestClient.bind(null, '/some-resource');
+    expect(client)
+      .to.throw(ArgumentError, 'Must provide options');
+  });
+
+  it('should accept a callback', function (done) {
+    nock(API_URL).get('/some-resource')
+      .reply(200, { data: 'value' });
+
+    var options = {
+      headers: {}
+    }
+    var client = new Auth0RestClient(API_URL + '/some-resource', options, this.providerMock);
+    client.getAll(function (err, data) {
+      expect(data).to.deep.equal({ data: 'value' });
+      done();
+      nock.cleanAll()
+    });
+  });
+
+  it('should return a promise if no callback is given', function (done) {
+    nock(API_URL).get('/some-resource')
+      .reply(200, { data: 'value' });
+
+    var options = {
+      headers: {}
+    }
+
+    var client = new Auth0RestClient(API_URL + '/some-resource', options, this.providerMock);
+    client.getAll().then(function(data){
+      expect(data).to.deep.equal({ data: 'value' });
+      done();
+      nock.cleanAll()
+    });
+  });
+
+  it('should accept a callback and handle errors', function (done) {
+    var providerMock = {
+      getAccessToken: function () {
+        return Promise.reject(new Error('Some Error'));
+      }
+    }
+
+    nock(API_URL).get('/some-resource')
+      .reply(500);
+
+    var options = {
+      headers: {}
+    }
+    var client = new Auth0RestClient(API_URL + '/some-resource', options, providerMock);
+    client.getAll(function (err, data) {
+      expect(err).to.not.null;
+      expect(err.message).to.be.equal('Some Error');
+      done();
+      nock.cleanAll();
+    });
+  });
+
+  it('should set access token as Authorization header in options object', function (done) {
+     nock(API_URL).get('/some-resource')
+      .reply(200);
+
+    var options = {
+      headers: {}
+    }
+
+    var client = new Auth0RestClient(API_URL + '/some-resource', options, this.providerMock);
+    client.getAll().then(function(data){
+      expect(client.options.headers['Authorization']).to.be.equal('Bearer access_token');
+      done();
+      nock.cleanAll();
+    });
+  });
+
+  it('should catch error when provider.getAccessToken throws an error', function (done) {
+    var providerMock = {
+      getAccessToken: function () {
+        return Promise.reject(new Error('Some Error'));
+      }
+    }
+
+    var client = new Auth0RestClient('/some-resource', {}, providerMock);
+    client.getAll().catch(function (err) {
+      expect(err).to.not.null;
+      expect(err.message).to.be.equal('Some Error');
+      done();
+    })
+  });
+});

--- a/test/auth0.tests.js
+++ b/test/auth0.tests.js
@@ -3,6 +3,7 @@ var expect = require('chai').expect;
 var auth0 = require('../src');
 var AuthenticationClient = require('../src/auth');
 var ManagementClient = require('../src/management');
+var ManagementTokenProvider = require('../src/management/ManagementTokenProvider')
 
 
 describe('Auth0 module', function () {
@@ -18,4 +19,9 @@ describe('Auth0 module', function () {
         .to.equal(ManagementClient);
     });
 
+
+    it('should expose the ManagementTokenProvider', function () {
+      expect(auth0.ManagementTokenProvider)
+        .to.equal(ManagementTokenProvider);
+    });
 });

--- a/test/auth0.tests.js
+++ b/test/auth0.tests.js
@@ -18,10 +18,4 @@ describe('Auth0 module', function () {
       expect(auth0.ManagementClient)
         .to.equal(ManagementClient);
     });
-
-
-    it('should expose the ManagementTokenProvider', function () {
-      expect(auth0.ManagementTokenProvider)
-        .to.equal(ManagementTokenProvider);
-    });
 });

--- a/test/management/management-client.tests.js
+++ b/test/management/management-client.tests.js
@@ -23,23 +23,51 @@ describe('ManagementClient', function () {
         .to.throw(ArgumentError, 'Management API SDK options must be an object');
     });
 
-
     it('should raise an error when the token is not valid', function () {
       var options = { token: '', domain: 'tenant.auth.com' };
       var client = ManagementClient.bind(null, options);
 
       expect(client)
-        .to.throw(ArgumentError, 'An access token must be provided');
+        .to.throw(ArgumentError, 'Must provide a Token');
     });
-
 
     it('should raise an error when the domain is not valid', function () {
-      var client = ManagementClient.bind(null, { token: 'token', domain: '' });
+      var client = ManagementClient.bind(null, { token: 'token' });
 
       expect(client)
-        .to.throw(ArgumentError, 'Must provide a domain');
+        .to.throw(ArgumentError, 'Must provide a Domain');
     });
 
+    it('should raise an error when the token provider does not have a function getAccessToken', function () {
+      var client = ManagementClient.bind(null, { tokenProvider : {} });
+
+      expect(client)
+        .to.throw(ArgumentError, 'Must provide a Domain');
+    });
+
+    it('should raise an error when the domain is not valid and a tokenProvider is specified', function () {
+      var client = ManagementClient.bind(null, { domain: 'domain', tokenProvider: {} });
+
+      expect(client)
+        .to.throw(ArgumentError, 'The tokenProvider does not have a function getAccessToken');
+    });
+
+    it('should raise an error when the token provider does have a property getAccessToken that is not a function', function () {
+      var client = ManagementClient.bind(null, { domain: 'domain', tokenProvider : { getAccessToken: [] } });
+
+      expect(client)
+        .to.throw(ArgumentError, 'The tokenProvider does not have a function getAccessToken');
+    });
+
+    it('should set the tokenProvider instance property if provider is passed', function () {
+      var fakeTokenProvider = { getAccessToken: function(){} };
+      var options = { domain: 'domain', tokenProvider : fakeTokenProvider };
+      var client = new ManagementClient(options);
+
+      expect(client.tokenProvider)
+        .to.exist
+        .to.be.equal(fakeTokenProvider);
+    });
 
     describe('instance properties', function () {
       var manager;

--- a/test/management/management-client.tests.js
+++ b/test/management/management-client.tests.js
@@ -1,4 +1,5 @@
 var expect = require('chai').expect;
+var assign = Object.assign || require('object.assign');
 
 var ManagementClient = require('../../src/management');
 
@@ -13,60 +14,91 @@ var EmailProviderManager = require('../../src/management/EmailProviderManager');
 var JobsManager = require('../../src/management/JobsManager');
 var RulesManager = require('../../src/management/RulesManager');
 var StatsManager = require('../../src/management/StatsManager');
+
 var TenantManager = require('../../src/management/TenantManager');
 
-
 describe('ManagementClient', function () {
+    var withTokenProviderConfig = { 
+      clientId: 'clientId', 
+      clientSecret: 'clientSecret', 
+      domain: 'auth0-node-sdk.auth0.com',
+      audience: 'https://auth0-node-sdk.auth0.com/api/v2/' 
+    };
+
+    var withTokenConfig = { 
+      domain: 'auth0-node-sdk.auth0.com',
+      token: 'fake-token'
+    };
+
+    it('should expose an instance of ManagementClient when withTokenConfig is passed', function () {
+      expect(new ManagementClient(withTokenConfig))
+      .to.exist
+      .to.be.an.instanceOf(ManagementClient);
+    });
+
+    it('should expose an instance of ManagementClient when withTokenProviderConfig is passed', function () {
+      expect(new ManagementClient(withTokenProviderConfig))
+      .to.exist
+      .to.be.an.instanceOf(ManagementClient);
+    });
 
     it('should raise an error when no options object is provided', function () {
       expect(ManagementClient)
         .to.throw(ArgumentError, 'Management API SDK options must be an object');
     });
 
-    it('should raise an error when the token is not valid', function () {
-      var options = { token: '', domain: 'tenant.auth.com' };
-      var client = ManagementClient.bind(null, options);
+    it('should raise an error when the domain is not set', function () {
+      var config = assign({}, withTokenConfig);
+      delete config.domain;
+      var client = ManagementClient.bind(null, config);
 
       expect(client)
-        .to.throw(ArgumentError, 'Must provide a Token');
+        .to.throw(ArgumentError, 'Must provide a domain');
     });
 
     it('should raise an error when the domain is not valid', function () {
-      var client = ManagementClient.bind(null, { token: 'token' });
+      var config = assign({}, withTokenConfig);
+      config.domain = '';
+      var client = ManagementClient.bind(null, config);
 
       expect(client)
-        .to.throw(ArgumentError, 'Must provide a Domain');
+        .to.throw(ArgumentError, 'Must provide a domain');
     });
 
-    it('should raise an error when the token provider does not have a function getAccessToken', function () {
-      var client = ManagementClient.bind(null, { tokenProvider : {} });
+    it('should raise an error when the token is not valid', function () {
+      var config = assign({}, withTokenConfig);
+      config.token = '';
+      var client = ManagementClient.bind(null, config);
 
       expect(client)
-        .to.throw(ArgumentError, 'Must provide a Domain');
+        .to.throw(ArgumentError, 'Must provide a token');
     });
 
-    it('should raise an error when the domain is not valid and a tokenProvider is specified', function () {
-      var client = ManagementClient.bind(null, { domain: 'domain', tokenProvider: {} });
+    it('should raise an error when the token and clientId are not set', function () {
+      var config = assign({}, withTokenProviderConfig);
+      delete config.clientId;
+      var client = ManagementClient.bind(null, config);
 
       expect(client)
-        .to.throw(ArgumentError, 'The tokenProvider does not have a function getAccessToken');
+        .to.throw(ArgumentError, 'Must provide a clientId');
     });
 
-    it('should raise an error when the token provider does have a property getAccessToken that is not a function', function () {
-      var client = ManagementClient.bind(null, { domain: 'domain', tokenProvider : { getAccessToken: [] } });
+    it('should raise an error when the token and clientSecret are not set', function () {
+      var config = assign({}, withTokenProviderConfig);
+      delete config.clientSecret;
+      var client = ManagementClient.bind(null, config);
 
       expect(client)
-        .to.throw(ArgumentError, 'The tokenProvider does not have a function getAccessToken');
+        .to.throw(ArgumentError, 'Must provide a clientSecret');
     });
 
-    it('should set the tokenProvider instance property if provider is passed', function () {
-      var fakeTokenProvider = { getAccessToken: function(){} };
-      var options = { domain: 'domain', tokenProvider : fakeTokenProvider };
-      var client = new ManagementClient(options);
+    it('should raise an error when the token and audience are not set', function () {
+      var config = assign({}, withTokenProviderConfig);
+      delete config.audience;
+      var client = ManagementClient.bind(null, config);
 
-      expect(client.tokenProvider)
-        .to.exist
-        .to.be.equal(fakeTokenProvider);
+      expect(client)
+        .to.throw(ArgumentError, 'Must provide a audience');
     });
 
     describe('instance properties', function () {
@@ -119,7 +151,8 @@ describe('ManagementClient', function () {
       };
 
       before(function () {
-        this.client = new ManagementClient({ token: 'token', domain: 'tenant.auth0.com' });
+        var config = assign({}, withTokenConfig);
+        this.client = new ManagementClient(config);
       });
 
       // Tests common to all managers.
@@ -179,7 +212,8 @@ describe('ManagementClient', function () {
       ];
 
       before(function () {
-        this.client = new ManagementClient({ token: 'token', domain: 'auth0.com' });
+        var config = assign({}, withTokenConfig);
+        this.client = new ManagementClient(config);
       });
 
       for (var i = 0, l = methods.length; i < l; i++) {

--- a/test/management/management-client.tests.js
+++ b/test/management/management-client.tests.js
@@ -18,14 +18,13 @@ var StatsManager = require('../../src/management/StatsManager');
 var TenantManager = require('../../src/management/TenantManager');
 
 describe('ManagementClient', function () {
-    var withTokenProviderConfig = { 
-      clientId: 'clientId', 
-      clientSecret: 'clientSecret', 
-      domain: 'auth0-node-sdk.auth0.com',
-      audience: 'https://auth0-node-sdk.auth0.com/api/v2/' 
+    var withTokenProviderConfig = {
+      clientId: 'clientId',
+      clientSecret: 'clientSecret',
+      domain: 'auth0-node-sdk.auth0.com'
     };
 
-    var withTokenConfig = { 
+    var withTokenConfig = {
       domain: 'auth0-node-sdk.auth0.com',
       token: 'fake-token'
     };
@@ -38,6 +37,13 @@ describe('ManagementClient', function () {
 
     it('should expose an instance of ManagementClient when withTokenProviderConfig is passed', function () {
       expect(new ManagementClient(withTokenProviderConfig))
+      .to.exist
+      .to.be.an.instanceOf(ManagementClient);
+    });
+
+    it('should expose an instance of ManagementClient when withTokenProviderConfig and audience is passed', function () {
+      var config = assign({audience: 'https://auth0-node-sdk.auth0.com/api/v2/'}, withTokenConfig);
+      expect(new ManagementClient(config))
       .to.exist
       .to.be.an.instanceOf(ManagementClient);
     });
@@ -90,15 +96,6 @@ describe('ManagementClient', function () {
 
       expect(client)
         .to.throw(ArgumentError, 'Must provide a clientSecret');
-    });
-
-    it('should raise an error when the token and audience are not set', function () {
-      var config = assign({}, withTokenProviderConfig);
-      delete config.audience;
-      var client = ManagementClient.bind(null, config);
-
-      expect(client)
-        .to.throw(ArgumentError, 'Must provide a audience');
     });
 
     describe('instance properties', function () {

--- a/test/management/management-token-provider.tests.js
+++ b/test/management/management-token-provider.tests.js
@@ -1,0 +1,288 @@
+var expect = require('chai').expect;
+var nock = require('nock');
+var assign = Object.assign || require('object.assign');
+var ArgumentError = require('rest-facade').ArgumentError;
+var APIError = require('rest-facade').APIError;
+
+var ManagementTokenProvider = require('../../src/management/ManagementTokenProvider');
+
+describe('ManagementTokenProvider', function () {
+  var defaultConfig = { clientId: 'clientId', clientSecret: 'clientSecret', 'domain': 'auth0-node-sdk.auth0.com' };
+
+  it('should expose an instance of ManagementTokenProvider', function () {
+    expect(new ManagementTokenProvider(defaultConfig))
+      .to.exist
+      .to.be.an.instanceOf(ManagementTokenProvider);
+  });
+
+  it('should raise an error when no options object is provided', function () {
+    expect(ManagementTokenProvider)
+      .to.throw(ArgumentError, 'Options must be an object');
+  });
+
+  it('should raise an error when the domain is not set', function () {
+    var provider = ManagementTokenProvider.bind(null, { clientId: 'clientId', clientSecret: 'clientSecret' });
+
+    expect(provider)
+      .to.throw(ArgumentError, 'Must provide a domain');
+  });
+
+  it('should raise an error when the domain is not valid', function () {
+    var provider = ManagementTokenProvider.bind(null, { clientId: 'clientId', clientSecret: 'clientSecret', 'domain': '' });
+
+    expect(provider)
+      .to.throw(ArgumentError, 'Must provide a domain');
+  });
+
+  it('should raise an error when the clientId is not set', function () {
+    var provider = ManagementTokenProvider.bind(null, { clientSecret: 'clientSecret', domain: 'domain' });
+
+    expect(provider)
+      .to.throw(ArgumentError, 'Must provide a Client Id');
+  });
+
+  it('should raise an error when the clientId is not valid', function () {
+    var provider = ManagementTokenProvider.bind(null, { clientId: '', clientSecret: 'clientSecret', 'domain': 'domain' });
+
+    expect(provider)
+      .to.throw(ArgumentError, 'Must provide a Client Id');
+  });
+
+  it('should raise an error when the clientSecret is not set', function () {
+    var provider = ManagementTokenProvider.bind(null, { clientId: 'clientId' , domain: 'domain' });
+
+    expect(provider)
+      .to.throw(ArgumentError, 'Must provide a Client Secret');
+  });
+
+  it('should raise an error when the clientSecret is not valid', function () {
+    var provider = ManagementTokenProvider.bind(null, { clientId: 'clientId', clientSecret: '', 'domain': 'domain' });
+
+    expect(provider)
+      .to.throw(ArgumentError, 'Must provide a Client Secret');
+  });
+
+  it('should raise an error when the useCache is not of type boolean', function () {
+    var provider = ManagementTokenProvider.bind(null, { clientId: 'clientId', clientSecret: 'clientSecret', 'domain': 'domain', 'useCache': 'false' });
+
+    expect(provider)
+      .to.throw(ArgumentError, 'The useCache must be a boolean');
+  });
+
+  it('should set useCache to true when not specified', function () {
+      var provider = new ManagementTokenProvider({ clientId: 'clientId', clientSecret: 'clientSecret', 'domain': 'domain' });
+      expect(provider.options.useCache).to.be.true;
+  });
+
+  it('should set useCache to true when passed as true', function () {
+      var provider = new ManagementTokenProvider({ clientId: 'clientId', clientSecret: 'clientSecret', 'domain': 'domain', 'useCache': true });
+      expect(provider.options.useCache).to.be.true;
+  });
+
+  it('should set useCache to false when passed as false', function () {
+      var provider = new ManagementTokenProvider({ clientId: 'clientId', clientSecret: 'clientSecret', 'domain': 'domain', 'useCache': false });
+      expect(provider.options.useCache).to.be.false;
+  });
+
+  it('should handle network errors correctly', function (done) {
+    var config = assign({}, defaultConfig);
+    config.domain = 'domain';
+    var client = new ManagementTokenProvider(config);
+
+    nock('https://' + config.domain)
+      .post('/oauth/token')
+      .reply(401);
+
+    client.getAccessToken()
+      .catch(function(err){
+        expect(err).to.exist
+        done();
+      });
+  }); 
+
+  it('should handle unauthorized errors correctly', function (done) {
+    var client = new ManagementTokenProvider(defaultConfig);
+
+    nock('https://' + defaultConfig.domain)
+      .post('/oauth/token')
+      .reply(401);
+
+    client.getAccessToken()
+      .catch(function(err){
+        expect(err)
+          .to.exist
+          .to.be.an.instanceOf(APIError);
+        expect(err.statusCode).to.be.equal(401);
+        done();
+        nock.cleanAll();
+      });
+  }); 
+
+  it('should return access token', function (done) {
+    var config = assign({}, defaultConfig);
+    config.domain = 'auth0-node-sdk-1.auth0.com'
+    var client = new ManagementTokenProvider(config);
+
+    nock('https://' + config.domain)
+      .post('/oauth/token')
+      .reply(200, {
+        access_token: 'token',
+        expires_in: 3600
+      })
+
+    client.getAccessToken()
+      .then(function(access_token){
+        expect(access_token).to.exist;
+        expect(access_token).to.be.equal('token');
+        done();
+        nock.cleanAll();
+      });
+  }); 
+
+  it('should contain correct body payload', function (done) {
+    var config = assign({}, defaultConfig);
+    config.domain = 'auth0-node-sdk-2.auth0.com'
+    var client = new ManagementTokenProvider(config);
+    
+      nock('https://' + config.domain)
+      .post('/oauth/token',function(body) {
+        
+        expect(body.client_id).to.equal('clientId');
+        expect(body.client_secret).to.equal('clientSecret');
+        expect(body.grant_type).to.equal('client_credentials');
+        expect(body.audience).to.equal('https://auth0-node-sdk-2.auth0.com/api/v2/');
+        return true;
+      })
+      .reply(function(uri, requestBody, cb) {
+        return cb(null, [200, { access_token: 'token', expires_in: 3600 }]);
+      });
+
+    client.getAccessToken()
+      .then(function(data){
+
+        done();
+        nock.cleanAll();
+      });
+  });
+
+  it('should return access token from the cache the second call', function (done) {
+    var config = assign({}, defaultConfig);
+    config.domain = 'auth0-node-sdk-3.auth0.com'
+    var client = new ManagementTokenProvider(config);
+
+    nock('https://' + config.domain)
+      .post('/oauth/token')
+      .once()
+      .reply(200, {
+        access_token: 'access_token',
+        expires_in: 3600
+      });
+
+    client.getAccessToken()
+      .then(function(access_token){
+        expect(access_token).to.exist;
+        expect(access_token).to.be.equal('access_token');
+
+          client.getAccessToken()
+          .then(function(access_token){
+            expect(access_token).to.exist;
+            expect(access_token).to.be.equal('access_token');
+            done();
+            nock.cleanAll();
+          });
+      });
+  }); 
+
+  it('should request new access token when cache is expired', function (done) {
+    var config = assign({}, defaultConfig);
+    config.domain = 'auth0-node-sdk-4.auth0.com'
+    var client = new ManagementTokenProvider(config);
+
+    nock('https://' + config.domain)
+      .post('/oauth/token')
+      .reply(200, {
+        access_token: 'access_token',
+        expires_in: 1 / 40 // 1sec / 40 = 25ms
+      })
+      .post('/oauth/token')
+      .reply(200, {
+        access_token: 'new_access_token',
+        expires_in: 3600
+      })
+
+    client.getAccessToken()
+      .then(function(access_token){
+        expect(access_token).to.exist;
+        expect(access_token).to.be.equal('access_token');
+
+        setTimeout(function() {
+          client.getAccessToken()
+            .then(function(access_token){
+              expect(access_token).to.exist;
+              expect(access_token).to.be.equal('new_access_token');
+              done();
+              nock.cleanAll();
+            });
+        }, 40); // 40ms 
+      });
+  });
+
+  it('should return new access token on the second call when cache is disabled', function (done) {
+    var config = assign({ useCache: false }, defaultConfig);
+    config.domain = 'auth0-node-sdk-3.auth0.com'
+    var client = new ManagementTokenProvider(config);
+
+    nock('https://' + config.domain)
+      .post('/oauth/token')
+      .reply(200, {
+        access_token: 'access_token',
+        expires_in: 3600
+      })
+      .post('/oauth/token')
+      .reply(200, {
+        access_token: 'new_access_token',
+        expires_in: 3600
+      })
+
+    client.getAccessToken()
+      .then(function(access_token){
+        expect(access_token).to.exist;
+        expect(access_token).to.be.equal('access_token');
+
+          client.getAccessToken()
+          .then(function(access_token){
+            expect(access_token).to.exist;
+            expect(access_token).to.be.equal('new_access_token');
+            done();
+            nock.cleanAll();
+          }).catch(function(err){
+            expect.fail();
+            done();
+            nock.cleanAll();
+          });
+      });
+  });
+
+  it('should pass the correct payload in the body of the oauth/token request', function (done) {
+    var config = assign({ scope: 'read:foo read:bar' }, defaultConfig);
+    var client = new ManagementTokenProvider(config); 
+    
+    nock('https://' + config.domain)
+      .post('/oauth/token', function(payload){
+        expect(payload).to.exist; 
+        expect(payload.scope).to.be.equal('read:foo read:bar');
+        expect(payload.client_id).to.be.equal('clientId');
+        expect(payload.client_secret).to.be.equal('clientSecret');
+        expect(payload.grant_type).to.be.equal('client_credentials');
+        expect(payload.audience).to.be.equal('https://auth0-node-sdk.auth0.com/api/v2/');
+        return true;
+      })
+      .reply(200);
+
+    client.getAccessToken()
+      .then(function(access_token){
+        done();
+        nock.cleanAll();
+      });
+  });
+});

--- a/test/management/management-token-provider.tests.js
+++ b/test/management/management-token-provider.tests.js
@@ -7,7 +7,12 @@ var APIError = require('rest-facade').APIError;
 var ManagementTokenProvider = require('../../src/management/ManagementTokenProvider');
 
 describe('ManagementTokenProvider', function () {
-  var defaultConfig = { clientId: 'clientId', clientSecret: 'clientSecret', 'domain': 'auth0-node-sdk.auth0.com' };
+  var defaultConfig = { 
+    clientId: 'clientId', 
+    clientSecret: 'clientSecret', 
+    domain: 'auth0-node-sdk.auth0.com',
+    audience: 'https://auth0-node-sdk.auth0.com/api/v2/' 
+  };
 
   it('should expose an instance of ManagementTokenProvider', function () {
     expect(new ManagementTokenProvider(defaultConfig))
@@ -20,68 +25,129 @@ describe('ManagementTokenProvider', function () {
       .to.throw(ArgumentError, 'Options must be an object');
   });
 
-  it('should raise an error when the domain is not set', function () {
-    var provider = ManagementTokenProvider.bind(null, { clientId: 'clientId', clientSecret: 'clientSecret' });
+  it('should raise an error when domain is not set', function () {
+    var config = assign({}, defaultConfig);
+    delete config.domain;
+    var provider = ManagementTokenProvider.bind(null, config);
 
     expect(provider)
       .to.throw(ArgumentError, 'Must provide a domain');
   });
 
-  it('should raise an error when the domain is not valid', function () {
-    var provider = ManagementTokenProvider.bind(null, { clientId: 'clientId', clientSecret: 'clientSecret', 'domain': '' });
+  it('should raise an error when domain is not valid', function () {
+    var config = assign({}, defaultConfig);
+    config.domain = '';
+    var provider = ManagementTokenProvider.bind(null, config);
 
     expect(provider)
       .to.throw(ArgumentError, 'Must provide a domain');
   });
 
-  it('should raise an error when the clientId is not set', function () {
-    var provider = ManagementTokenProvider.bind(null, { clientSecret: 'clientSecret', domain: 'domain' });
+  it('should raise an error when clientId is not set', function () {
+    var config = assign({}, defaultConfig);
+    delete config.clientId;
+    var provider = ManagementTokenProvider.bind(null, config);
 
     expect(provider)
-      .to.throw(ArgumentError, 'Must provide a Client Id');
+      .to.throw(ArgumentError, 'Must provide a clientId');
   });
 
-  it('should raise an error when the clientId is not valid', function () {
-    var provider = ManagementTokenProvider.bind(null, { clientId: '', clientSecret: 'clientSecret', 'domain': 'domain' });
+  it('should raise an error when clientId is not valid', function () {
+    var config = assign({}, defaultConfig);
+    config.clientId = '';
+    var provider = ManagementTokenProvider.bind(null, config);
 
     expect(provider)
-      .to.throw(ArgumentError, 'Must provide a Client Id');
+      .to.throw(ArgumentError, 'Must provide a clientId');
   });
 
-  it('should raise an error when the clientSecret is not set', function () {
-    var provider = ManagementTokenProvider.bind(null, { clientId: 'clientId' , domain: 'domain' });
+  it('should raise an error when clientSecret is not set', function () {
+    var config = assign({}, defaultConfig);
+    delete config.clientSecret;
+    var provider = ManagementTokenProvider.bind(null, config);
 
     expect(provider)
-      .to.throw(ArgumentError, 'Must provide a Client Secret');
+      .to.throw(ArgumentError, 'Must provide a clientSecret');
   });
 
-  it('should raise an error when the clientSecret is not valid', function () {
-    var provider = ManagementTokenProvider.bind(null, { clientId: 'clientId', clientSecret: '', 'domain': 'domain' });
+  it('should raise an error when clientSecret is not valid', function () {
+    var config = assign({}, defaultConfig);
+    config.clientSecret = '';
+    var provider = ManagementTokenProvider.bind(null, config);
 
     expect(provider)
-      .to.throw(ArgumentError, 'Must provide a Client Secret');
+      .to.throw(ArgumentError, 'Must provide a clientSecret');
   });
 
-  it('should raise an error when the useCache is not of type boolean', function () {
-    var provider = ManagementTokenProvider.bind(null, { clientId: 'clientId', clientSecret: 'clientSecret', 'domain': 'domain', 'useCache': 'false' });
+  it('should raise an error when enableCache is not of type boolean', function () {
+    var config = assign({}, defaultConfig);
+    config.enableCache = 'string';
+    var provider = ManagementTokenProvider.bind(null, config);
 
     expect(provider)
-      .to.throw(ArgumentError, 'The useCache must be a boolean');
+      .to.throw(ArgumentError, 'enableCache must be a boolean');
   });
 
-  it('should set useCache to true when not specified', function () {
-      var provider = new ManagementTokenProvider({ clientId: 'clientId', clientSecret: 'clientSecret', 'domain': 'domain' });
-      expect(provider.options.useCache).to.be.true;
+  it('should raise an error when scope is not of type string', function () {
+    var config = assign({}, defaultConfig);
+    config.scope = ['foo', 'bar'];
+    var provider = ManagementTokenProvider.bind(null, config);
+
+    expect(provider)
+      .to.throw(ArgumentError, 'scope must be a string');
   });
 
-  it('should set useCache to true when passed as true', function () {
-      var provider = new ManagementTokenProvider({ clientId: 'clientId', clientSecret: 'clientSecret', 'domain': 'domain', 'useCache': true });
-      expect(provider.options.useCache).to.be.true;
+  it('should set scope to read:users when passed as read:users', function () {
+    var config = assign({}, defaultConfig);
+    config.scope = 'read:users';
+    var provider = new ManagementTokenProvider(config);
+    expect(provider.options.scope).to.be.equal('read:users');
   });
 
-  it('should set useCache to false when passed as false', function () {
-      var provider = new ManagementTokenProvider({ clientId: 'clientId', clientSecret: 'clientSecret', 'domain': 'domain', 'useCache': false });
-      expect(provider.options.useCache).to.be.false;
+  it('should set enableCache to true when not specified', function () {
+      var config = assign({}, defaultConfig);
+      delete config.enableCache;
+      var provider = new ManagementTokenProvider(config);
+      expect(provider.options.enableCache).to.be.true;
+  });
+
+  it('should set enableCache to true when passed as true', function () {
+    var config = assign({}, defaultConfig);
+    config.enableCache = true;
+    var provider = new ManagementTokenProvider(config);
+    expect(provider.options.enableCache).to.be.true;
+  });
+
+  it('should set enableCache to false when passed as false', function () {
+    var config = assign({}, defaultConfig);
+    config.enableCache = false;
+    var provider = new ManagementTokenProvider(config);
+    expect(provider.options.enableCache).to.be.false;
+  });
+
+  it('should raise an error when the cacheTTLInSeconds is not of type number', function () {
+    var config = assign({}, defaultConfig);
+    config.cacheTTLInSeconds = 'string';
+    var provider = ManagementTokenProvider.bind(null, config);
+
+    expect(provider)
+      .to.throw(ArgumentError, 'cacheTTLInSeconds must be a number');
+  });
+
+  it('should raise an error when the cacheTTLInSeconds is not a greater than 0', function () {
+    var config = assign({}, defaultConfig);
+    config.cacheTTLInSeconds = -1;
+    var provider = ManagementTokenProvider.bind(null, config);
+
+    expect(provider)
+      .to.throw(ArgumentError, 'cacheTTLInSeconds must be a greater than 0');
+  });
+
+  it('should set cacheTTLInSeconds to 15 when passed as 15', function () {
+    var config = assign({}, defaultConfig);
+    config.cacheTTLInSeconds = 15;
+    var provider = new ManagementTokenProvider(config);
+    expect(provider.options.cacheTTLInSeconds).to.be.equal(15);
   });
 
   it('should handle network errors correctly', function (done) {
@@ -102,7 +168,6 @@ describe('ManagementTokenProvider', function () {
 
   it('should handle unauthorized errors correctly', function (done) {
     var client = new ManagementTokenProvider(defaultConfig);
-
     nock('https://' + defaultConfig.domain)
       .post('/oauth/token')
       .reply(401);
@@ -144,13 +209,11 @@ describe('ManagementTokenProvider', function () {
     config.domain = 'auth0-node-sdk-2.auth0.com'
     var client = new ManagementTokenProvider(config);
     
-      nock('https://' + config.domain)
+    nock('https://' + config.domain)
       .post('/oauth/token',function(body) {
-        
         expect(body.client_id).to.equal('clientId');
         expect(body.client_secret).to.equal('clientSecret');
         expect(body.grant_type).to.equal('client_credentials');
-        expect(body.audience).to.equal('https://auth0-node-sdk-2.auth0.com/api/v2/');
         return true;
       })
       .reply(function(uri, requestBody, cb) {
@@ -183,13 +246,19 @@ describe('ManagementTokenProvider', function () {
         expect(access_token).to.exist;
         expect(access_token).to.be.equal('access_token');
 
+        setTimeout(function() {
           client.getAccessToken()
-          .then(function(access_token){
-            expect(access_token).to.exist;
-            expect(access_token).to.be.equal('access_token');
-            done();
-            nock.cleanAll();
-          });
+            .then(function(access_token){
+              expect(access_token).to.exist;
+              expect(access_token).to.be.equal('access_token');
+              done();
+              nock.cleanAll();
+            }).catch(function(err){
+              expect.fail();
+              done();
+              nock.cleanAll();
+            });;
+        }, 40); // 40ms 
       });
   }); 
 
@@ -222,13 +291,18 @@ describe('ManagementTokenProvider', function () {
               expect(access_token).to.be.equal('new_access_token');
               done();
               nock.cleanAll();
-            });
+            }).catch(function(err){
+              expect.fail();
+              done();
+              nock.cleanAll();
+            });;
         }, 40); // 40ms 
       });
   });
 
   it('should return new access token on the second call when cache is disabled', function (done) {
-    var config = assign({ useCache: false }, defaultConfig);
+    var config = assign({}, defaultConfig);
+    config.enableCache = false;
     config.domain = 'auth0-node-sdk-3.auth0.com'
     var client = new ManagementTokenProvider(config);
 
@@ -249,32 +323,129 @@ describe('ManagementTokenProvider', function () {
         expect(access_token).to.exist;
         expect(access_token).to.be.equal('access_token');
 
+        setTimeout(function() {
           client.getAccessToken()
-          .then(function(access_token){
-            expect(access_token).to.exist;
-            expect(access_token).to.be.equal('new_access_token');
-            done();
-            nock.cleanAll();
-          }).catch(function(err){
-            expect.fail();
-            done();
-            nock.cleanAll();
-          });
+            .then(function(access_token){
+              expect(access_token).to.exist;
+              expect(access_token).to.be.equal('new_access_token');
+              done();
+              nock.cleanAll();
+            }).catch(function(err){
+              expect.fail();
+              done();
+              nock.cleanAll();
+            });
+        }, 40); // 40ms 
       });
   });
 
-  it('should pass the correct payload in the body of the oauth/token request', function (done) {
-    var config = assign({ scope: 'read:foo read:bar' }, defaultConfig);
-    var client = new ManagementTokenProvider(config); 
+  it('should return cached access token on the second call when cacheTTLInSeconds is not passed', function (done) {
+    var config = assign({}, defaultConfig);
+    config.domain = 'auth0-node-sdk-5.auth0.com';
+    config.cacheTTLInSeconds = 10 // 1sec / 40 = 25ms;
+    var client = new ManagementTokenProvider(config);
+
+    nock('https://' + config.domain)
+      .post('/oauth/token')
+      .reply(200, {
+        access_token: 'access_token'
+      })
+      .post('/oauth/token')
+      .reply(200, {
+        access_token: 'new_access_token'
+      })
+
+    client.getAccessToken()
+      .then(function(access_token){
+        expect(access_token).to.exist;
+        expect(access_token).to.be.equal('access_token');
+
+        setTimeout(function() {
+          client.getAccessToken()
+            .then(function(access_token){
+              expect(access_token).to.exist;
+              expect(access_token).to.be.equal('access_token');
+              done();
+              nock.cleanAll();
+            }).catch(function(err){
+              expect.fail();
+              done();
+              nock.cleanAll();
+            });
+        }, 40); // 40ms 
+      });
+  });
+
+  it('should return new access token on the second call when cacheTTLInSeconds is passed', function (done) {
+    var config = assign({}, defaultConfig);
+    config.domain = 'auth0-node-sdk-6.auth0.com'
+    config.cacheTTLInSeconds = 1 / 40 // 1sec / 40 = 25ms
+    var client = new ManagementTokenProvider(config);
+
+    nock('https://' + config.domain)
+      .post('/oauth/token')
+      .reply(200, {
+        access_token: 'access_token'
+      })
+      .post('/oauth/token')
+      .reply(200, {
+        access_token: 'new_access_token'
+      })
+
+    client.getAccessToken()
+      .then(function(access_token){
+        expect(access_token).to.exist;
+        expect(access_token).to.be.equal('access_token');
+
+        setTimeout(function() {
+          client.getAccessToken()
+            .then(function(access_token){
+              expect(access_token).to.exist;
+              expect(access_token).to.be.equal('new_access_token');
+              done();
+              nock.cleanAll();
+            }).catch(function(err){
+              expect.fail();
+              done();
+              nock.cleanAll();
+            });
+        }, 40); // 40ms 
+      });
+  });
+
+
+  it('should pass the correct payload in the body of the oauth/token request with cache enabled', function (done) {
+    var config = assign({}, defaultConfig);
+    var client = new ManagementTokenProvider(config);
     
     nock('https://' + config.domain)
       .post('/oauth/token', function(payload){
         expect(payload).to.exist; 
-        expect(payload.scope).to.be.equal('read:foo read:bar');
         expect(payload.client_id).to.be.equal('clientId');
         expect(payload.client_secret).to.be.equal('clientSecret');
         expect(payload.grant_type).to.be.equal('client_credentials');
-        expect(payload.audience).to.be.equal('https://auth0-node-sdk.auth0.com/api/v2/');
+        return true;
+      })
+      .reply(200);
+
+    client.getAccessToken()
+      .then(function(access_token){
+        done();
+        nock.cleanAll();
+      });
+  });
+
+  it('should pass the correct payload in the body of the oauth/token request with cache disabled', function (done) {
+    var config = assign({}, defaultConfig);
+    config.enableCache = false;
+    var client = new ManagementTokenProvider(config);
+    
+    nock('https://' + config.domain)
+      .post('/oauth/token', function(payload){
+        expect(payload).to.exist; 
+        expect(payload.client_id).to.be.equal('clientId');
+        expect(payload.client_secret).to.be.equal('clientSecret');
+        expect(payload.grant_type).to.be.equal('client_credentials');
         return true;
       })
       .reply(200);

--- a/yarn.lock
+++ b/yarn.lock
@@ -498,6 +498,13 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
+define-properties@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
+  dependencies:
+    foreach "^2.0.5"
+    object-keys "^1.0.8"
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -650,6 +657,10 @@ for-own@^0.1.4:
   dependencies:
     for-in "^1.0.1"
 
+foreach@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -707,6 +718,10 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     inherits "~2.0.0"
     mkdirp ">=0.5 0"
     rimraf "2"
+
+function-bind@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -1172,9 +1187,17 @@ loader-utils@^0.2.11, loader-utils@^0.2.5, loader-utils@~0.2.2, loader-utils@~0.
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
+lock@~0.1.2:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/lock/-/lock-0.1.4.tgz#fec7deaef17e7c3a0a55e1da042803e25d91745d"
+
 lodash@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.1.tgz#5b7723034dda4d262e5a46fb2c58d7cc22f71420"
+
+lodash@~4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.5.1.tgz#80e8a074ca5f3893a6b1c10b2a636492d710c316"
 
 lolex@1.3.2:
   version "1.3.2"
@@ -1197,6 +1220,22 @@ lower-case@^1.1.0, lower-case@^1.1.1, lower-case@^1.1.2:
 lru-cache@2:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
+
+lru-cache@~4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.0.2.tgz#1d17679c069cda5d040991a09dbc2c0db377e55e"
+  dependencies:
+    pseudomap "^1.0.1"
+    yallist "^2.0.0"
+
+lru-memoizer@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/lru-memoizer/-/lru-memoizer-1.11.1.tgz#0693f6100593914c02e192bf9b8d93884cbf50d3"
+  dependencies:
+    lock "~0.1.2"
+    lodash "~4.5.1"
+    lru-cache "~4.0.0"
+    very-fast-args "^1.1.0"
 
 marked@~0.3.6:
   version "0.3.6"
@@ -1441,6 +1480,18 @@ object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
+object-keys@^1.0.10, object-keys@^1.0.8:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+
+object.assign@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.0.4.tgz#b1c9cc044ef1b9fe63606fc141abbb32e14730cc"
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.0"
+    object-keys "^1.0.10"
+
 object.omit@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
@@ -1576,6 +1627,10 @@ propagate@0.3.x:
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
+
+pseudomap@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
 punycode@1.3.2:
   version "1.3.2"
@@ -2158,6 +2213,10 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
+very-fast-args@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/very-fast-args/-/very-fast-args-1.1.0.tgz#e16d1d1faf8a6e596a246421fd90a77963d0b396"
+
 vm-browserify@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
@@ -2238,6 +2297,10 @@ xml@^1.0.0:
 xtend@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+
+yallist@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
This PR adds the possibility to specify a token provider for the Management API. The `ManagementTokenProvider` fetches `access_token`'s via the Client Credentials Grant and caches the `access_token`s by default.

An instance of the `ManagementTokenProvider`, is passed via the `ManagementClient` options property `tokenProvider`.

The `ManagementTokenProvider` class will by default cache the `access_token` for the duration of the property `expires_in` returned in the response of the Client Credentials Grant.

Example;

~~~js
var ManagementClient = require('auth0').ManagementClient;
var ManagementTokenProvider = require('auth0').ManagementTokenProvider;
var auth0 = new ManagementClient({
  domain: '{YOUR_ACCOUNT}.auth0.com',
  tokenProvider: new ManagementTokenProvider({
    clientId: '{YOUR_NON_INTERACTIVE_CLIENT_ID}',
    clientSecret: '{YOUR_NON_INTERACTIVE_CLIENT_SECRET}',
    domain: '{YOUR_ACCOUNT}.auth0.com',
    scope: '{MANAGEMENT_API_SCOPES}',
    useCache: true //default
  })
});
~~~

A custom Token Provider class only needs to implement the method `getAccessToken` and return a Promise<string>.

~~~js
var provider ={
  getAccessToken: function () {
    return Promise.resolve('access_token');
  }
}
~~~