### PR TITLE
Added clientSecret option to passwordGrant

### DIFF
--- a/src/auth/OAuthAuthenticator.js
+++ b/src/auth/OAuthAuthenticator.js
@@ -151,8 +151,10 @@ OAuthAuthenticator.prototype.passwordGrant = function (userData, cb) {
   };
   var defaultFields = {
     client_id: this.clientId,
+    client_secret: this.clientSecret,
     grant_type: 'password'
   };
+  
   var data = extend(defaultFields, userData);
 
   if (!userData || typeof userData !== 'object') {


### PR DESCRIPTION
passwordGrant will fail if you've set your token endpoint up to 'Basic' or 'POST'. This is because the client secret is not sent along with the request. It seems like a trivial change to introduce the field to defaultFields so I'm throwing this out here for feedback.

Alternatively we could tell passwordGrant how the endpoint is set up and let it decide whether to bring the secret in or not.