### PR TITLE
Add retry functionality for management api requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lru-memoizer": "^1.11.1",
     "object.assign": "^4.0.4",
     "request": "^2.83.0",
-    "rest-facade": "^1.5.0",
+    "rest-facade": "^1.10.0",
     "retry": "^0.10.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "lru-memoizer": "^1.11.1",
     "object.assign": "^4.0.4",
     "request": "^2.83.0",
-    "rest-facade": "^1.5.0"
+    "rest-facade": "^1.5.0",
+    "retry": "^0.10.1"
   },
   "devDependencies": {
     "chai": "^2.2.0",

--- a/src/RetryRestClient.js
+++ b/src/RetryRestClient.js
@@ -1,0 +1,159 @@
+
+var Promise = require('bluebird');
+var retry = require('retry');
+var ArgumentError = require('rest-facade').ArgumentError;
+var assign = Object.assign || require('object.assign');
+
+var DEFAULT_OPTIONS = { maxRetries: 10, enabled: true };
+
+/**
+ * @class RetryRestClient
+ * Wrapper Rest Client that adds Retry functionality when requests are failing due to rate limiting (status code 429).
+ * @constructor
+ * @memberOf module:management
+ * @param {Object}  restClient                   RestClient.
+ * @param {Object}  [options]                    Options for the RetryRestClient.
+ * @param {Object}  [options.enabled:true]       Enabled or Disable Retry Policy functionality.    
+ * @param {Number}  [options.maxRetries=10]      The maximum amount of times to retry the operation. Default is 10. 
+ */
+var RetryRestClient = function(restClient, options){
+  if (restClient === null || typeof restClient !== 'object') {
+    throw new ArgumentError('Must provide RestClient');
+  }
+
+  var params = assign({}, DEFAULT_OPTIONS, options);
+
+  if (typeof params.enabled !== 'boolean') {
+    throw new ArgumentError('Must provide enabled boolean value');
+  }
+
+  if (typeof params.maxRetries !== 'number' || params.maxRetries <= 0) {
+    throw new ArgumentError('Must provide maxRetries as a positive number');
+  }
+
+  this.restClient = restClient;
+  this.maxRetries = params.maxRetries;
+  this.enabled = params.enabled;
+}
+
+RetryRestClient.prototype.invoke = function(method, args){
+  var cb;
+  if(args && args[args.length -1] instanceof Function){
+    cb = args[args.length -1];
+    delete args[args.length -1];
+  }
+
+  var promise = this.handleRetry(method, args);
+
+  if (cb instanceof Function) {
+    promise
+      .then(cb.bind(null, null))
+      .catch(cb);
+    return;
+  }
+
+  return promise;
+}
+
+RetryRestClient.prototype.getAll = function ( /* [params], [callback] */ ) {
+  return this.invoke('getAll', arguments);  
+};
+
+RetryRestClient.prototype.get = function ( /* [params], [callback] */ ) {
+  return this.invoke('get', arguments); 
+}
+
+RetryRestClient.prototype.create = function ( /* [params], [callback] */ ) {
+  return this.invoke('create', arguments); 
+}
+
+RetryRestClient.prototype.patch = function ( /* [params], [callback] */ ) {
+  return this.invoke('patch', arguments); 
+}
+
+RetryRestClient.prototype.update = function ( /* [params], [callback] */ ) {
+  return this.invoke('update', arguments); 
+}
+
+RetryRestClient.prototype.delete = function ( /* [params], [callback] */ ) {
+  return this.invoke('delete', arguments); 
+}
+
+RetryRestClient.prototype.handleRetry = function(method, args){
+  if(!this.enabled){
+    return this.restClient[method].apply(this.restClient, args);
+  }
+
+  var retryOptions = {
+    retries: this.maxRetries,
+    factor: 1,
+    minTimeout: 1, // retry immediate, use custom logic to control this.
+    randomize: false
+  };
+
+  var self = this;
+  var promise = new Promise(function (resolve, reject) {
+    var operation = retry.operation(retryOptions);
+
+    operation.attempt(function(){
+      self.restClient[method].apply(self.restClient, args)
+        .then(function(body) { 
+          resolve(body);
+        })
+        .catch(function(err) {
+          self.invokeRetry(err, operation, reject);
+        });
+    });    
+  });
+
+  return promise;
+};
+
+RetryRestClient.prototype.invokeRetry = function(err, operation , reject){
+  var ratelimits = this.extractRatelimits(err);
+  if(ratelimits){
+    var delay = ratelimits.reset * 1000 - new Date().getTime();
+    if(delay > 0){
+      this.retryWithDelay(delay, operation, err, reject);
+    }else{
+      this.retryWithImmediate(operation, err, reject);
+    }   
+  }else{
+    reject(err);
+  }  
+}
+
+RetryRestClient.prototype.extractRatelimits = function(err){
+  if(err && err.statusCode === 429 && err.originalError && err.originalError.response){
+    var headers = err.originalError.response.header;
+    if(headers && headers['x-ratelimit-limit']){     
+      return {
+        limit: headers['x-ratelimit-limit'],
+        remaining: headers['x-ratelimit-remaining'],
+        reset: headers['x-ratelimit-reset']
+      }
+    }
+  }
+
+  return;
+}
+
+RetryRestClient.prototype.retryWithImmediate = function(operation, err, reject){
+  if(operation.retry(err)){
+    return;
+  }  
+  reject(err);
+}
+
+RetryRestClient.prototype.retryWithDelay = function(delay, operation, err, reject){
+  setTimeout(() => {
+    if(operation.retry(err)){
+      return;
+    }
+    reject(err);
+  }, delay);
+}
+
+
+
+module.exports = RetryRestClient;

--- a/src/RetryRestClient.js
+++ b/src/RetryRestClient.js
@@ -36,25 +36,6 @@ var RetryRestClient = function(restClient, options){
   this.enabled = params.enabled;
 }
 
-RetryRestClient.prototype.invoke = function(method, args){
-  var cb;
-  if(args && args[args.length -1] instanceof Function){
-    cb = args[args.length -1];
-    delete args[args.length -1];
-  }
-
-  var promise = this.handleRetry(method, args);
-
-  if (cb instanceof Function) {
-    promise
-      .then(cb.bind(null, null))
-      .catch(cb);
-    return;
-  }
-
-  return promise;
-}
-
 RetryRestClient.prototype.getAll = function ( /* [params], [callback] */ ) {
   return this.invoke('getAll', arguments);  
 };
@@ -77,6 +58,25 @@ RetryRestClient.prototype.update = function ( /* [params], [callback] */ ) {
 
 RetryRestClient.prototype.delete = function ( /* [params], [callback] */ ) {
   return this.invoke('delete', arguments); 
+}
+
+RetryRestClient.prototype.invoke = function(method, args){
+  var cb;
+  if(args && args[args.length -1] instanceof Function){
+    cb = args[args.length -1];
+    delete args[args.length -1];
+  }
+
+  var promise = this.handleRetry(method, args);
+
+  if (cb instanceof Function) {
+    promise
+      .then(cb.bind(null, null))
+      .catch(cb);
+    return;
+  }
+
+  return promise;
 }
 
 RetryRestClient.prototype.handleRetry = function(method, args){
@@ -103,7 +103,7 @@ RetryRestClient.prototype.handleRetry = function(method, args){
         .catch(function(err) {
           self.invokeRetry(err, operation, reject);
         });
-    });    
+    });
   });
 
   return promise;

--- a/src/management/BlacklistedTokensManager.js
+++ b/src/management/BlacklistedTokensManager.js
@@ -1,6 +1,7 @@
 var ArgumentError = require('rest-facade').ArgumentError;
 var utils = require('../utils');
 var Auth0RestClient = require('../Auth0RestClient');
+var RetryRestClient = require('../RetryRestClient');
 
 /**
  * @class BlacklistedTokensManager
@@ -12,6 +13,7 @@ var Auth0RestClient = require('../Auth0RestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
+ * @param {Object} [options.retry]    Retry Policy Config
  */
 var BlacklistedTokensManager = function (options) {
   if (options === null || typeof options !== 'object') {
@@ -43,7 +45,8 @@ var BlacklistedTokensManager = function (options) {
    *
    * @type {external:RestClient}
    */
-  this.resource = new Auth0RestClient(options.baseUrl + '/blacklists/tokens', clientOptions, options.tokenProvider);
+  var auth0RestClient = new Auth0RestClient(options.baseUrl + '/blacklists/tokens', clientOptions, options.tokenProvider);
+  this.resource = new RetryRestClient(auth0RestClient, options.retry);
 };
 
 

--- a/src/management/ClientGrantsManager.js
+++ b/src/management/ClientGrantsManager.js
@@ -1,7 +1,7 @@
 var ArgumentError = require('rest-facade').ArgumentError;
 var utils = require('../utils');
 var Auth0RestClient = require('../Auth0RestClient');
-
+var RetryRestClient = require('../RetryRestClient');
 /**
  * @class ClientGrantsManager
  * Auth0 Client Grants Manager.
@@ -14,6 +14,7 @@ var Auth0RestClient = require('../Auth0RestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
+ * @param {Object} [options.retry]    Retry Policy Config
  */
 var ClientGrantsManager = function (options) {
   if (options === null || typeof options !== 'object') {
@@ -41,11 +42,12 @@ var ClientGrantsManager = function (options) {
 
   /**
    * Provides an abstraction layer for consuming the
-   * {@link https://auth0.com/docs/api/v2#!/Client_Grants Auth0 Client Grantss endpoint}.
+   * {@link https://auth0.com/docs/api/v2#!/Client_Grants Auth0 Client Grants endpoint}.
    *
    * @type {external:RestClient}
    */
-  this.resource = new Auth0RestClient(options.baseUrl + '/client-grants/:id', clientOptions, options.tokenProvider);
+  var auth0RestClient = new Auth0RestClient(options.baseUrl + '/client-grants/:id', clientOptions, options.tokenProvider);
+  this.resource = new RetryRestClient(auth0RestClient, options.retry);
 };
 
 

--- a/src/management/ClientsManager.js
+++ b/src/management/ClientsManager.js
@@ -1,6 +1,7 @@
 var ArgumentError = require('rest-facade').ArgumentError;
 var utils = require('../utils');
 var Auth0RestClient = require('../Auth0RestClient');
+var RetryRestClient = require('../RetryRestClient');
 
 /**
  * @class ClientsManager
@@ -17,6 +18,7 @@ var Auth0RestClient = require('../Auth0RestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
+ * @param {Object} [options.retry]    Retry Policy Config
  */
 var ClientsManager = function (options) {
   if (options === null || typeof options !== 'object') {
@@ -48,7 +50,8 @@ var ClientsManager = function (options) {
    *
    * @type {external:RestClient}
    */
-  this.resource = new Auth0RestClient(options.baseUrl + '/clients/:client_id', clientOptions, options.tokenProvider);
+  var auth0RestClient = new Auth0RestClient(options.baseUrl + '/clients/:client_id', clientOptions, options.tokenProvider);
+  this.resource = new RetryRestClient(auth0RestClient, options.retry);
 };
 
 

--- a/src/management/ConnectionsManager.js
+++ b/src/management/ConnectionsManager.js
@@ -1,6 +1,7 @@
 var ArgumentError = require('rest-facade').ArgumentError;
 var utils = require('../utils');
 var Auth0RestClient = require('../Auth0RestClient');
+var RetryRestClient = require('../RetryRestClient');
 
 /**
  * @class ConnectionsManager
@@ -11,6 +12,7 @@ var Auth0RestClient = require('../Auth0RestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
+ * @param {Object} [options.retry]    Retry Policy Config
  */
 var ConnectionsManager = function (options) {
   if (options === null || typeof options !== 'object') {
@@ -30,7 +32,7 @@ var ConnectionsManager = function (options) {
    *
    * @type {Object}
    */
-  var apiOptions = {
+  var clientOptions = {
     headers: options.headers,
     query: { repeatParams: false }
   };
@@ -42,7 +44,8 @@ var ConnectionsManager = function (options) {
    *
    * @type {external:RestClient}
    */
-  this.resource = new Auth0RestClient(options.baseUrl + '/connections/:id ', apiOptions, options.tokenProvider);
+  var auth0RestClient = new Auth0RestClient(options.baseUrl + '/connections/:id ', clientOptions, options.tokenProvider);
+  this.resource = new RetryRestClient(auth0RestClient, options.retry);
 };
 
 

--- a/src/management/DeviceCredentialsManager.js
+++ b/src/management/DeviceCredentialsManager.js
@@ -1,6 +1,7 @@
 var ArgumentError = require('rest-facade').ArgumentError;
 var utils = require('../utils');
 var Auth0RestClient = require('../Auth0RestClient');
+var RetryRestClient = require('../RetryRestClient');
 
 /**
  * Simple facade for consuming a REST API endpoint.
@@ -18,6 +19,7 @@ var Auth0RestClient = require('../Auth0RestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
+ * @param {Object} [options.retry]    Retry Policy Config
  */
 var DeviceCredentialsManager = function (options) {
   if (options === null || typeof options !== 'object') {
@@ -50,7 +52,8 @@ var DeviceCredentialsManager = function (options) {
    *
    * @type {external:RestClient}
    */
-  this.resource = new Auth0RestClient(options.baseUrl + '/device-credentials/:id', clientOptions, options.tokenProvider);
+  var auth0RestClient = new Auth0RestClient(options.baseUrl + '/device-credentials/:id', clientOptions, options.tokenProvider);
+  this.resource = new RetryRestClient(auth0RestClient, options.retry);
 };
 
 

--- a/src/management/EmailProviderManager.js
+++ b/src/management/EmailProviderManager.js
@@ -1,6 +1,7 @@
 var ArgumentError = require('rest-facade').ArgumentError;
 var utils = require('../utils');
 var Auth0RestClient = require('../Auth0RestClient');
+var RetryRestClient = require('../RetryRestClient');
 
 /**
  * Simple facade for consuming a REST API endpoint.
@@ -18,6 +19,7 @@ var Auth0RestClient = require('../Auth0RestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
+ * @param {Object} [options.retry]    Retry Policy Config
  */
 var EmailProviderManager = function (options) {
   if (options === null || typeof options !== 'object') {
@@ -49,7 +51,8 @@ var EmailProviderManager = function (options) {
    *
    * @type {external:RestClient}
    */
-  this.resource = new Auth0RestClient(options.baseUrl + '/emails/provider', clientOptions, options.tokenProvider);
+  var auth0RestClient = new Auth0RestClient(options.baseUrl + '/emails/provider', clientOptions, options.tokenProvider);
+  this.resource = new RetryRestClient(auth0RestClient, options.retry);
 };
 
 

--- a/src/management/JobsManager.js
+++ b/src/management/JobsManager.js
@@ -5,6 +5,7 @@ var fs = require('fs');
 
 var ArgumentError = require('rest-facade').ArgumentError;
 var Auth0RestClient = require('../Auth0RestClient');
+var RetryRestClient = require('../RetryRestClient');
 
 /**
  * Simple facade for consuming a REST API endpoint.
@@ -22,6 +23,7 @@ var Auth0RestClient = require('../Auth0RestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
+ * @param {Object} [options.retry]    Retry Policy Config
  */
 var JobsManager = function (options){
   if (options === null || typeof options !== 'object') {
@@ -50,7 +52,8 @@ var JobsManager = function (options){
    *
    * @type {external:RestClient}
    */
-  this.jobs = new Auth0RestClient(options.baseUrl + '/jobs/:id', clientOptions, options.tokenProvider);
+  var auth0RestClient = new Auth0RestClient(options.baseUrl + '/jobs/:id', clientOptions, options.tokenProvider);
+  this.jobs = new RetryRestClient(auth0RestClient, options.retry);
 };
 
 

--- a/src/management/LogsManager.js
+++ b/src/management/LogsManager.js
@@ -1,6 +1,7 @@
 var ArgumentError = require('rest-facade').ArgumentError;
 var utils = require('../utils');
 var Auth0RestClient = require('../Auth0RestClient');
+var RetryRestClient = require('../RetryRestClient');
 
 /**
  * @class LogsManager
@@ -11,6 +12,7 @@ var Auth0RestClient = require('../Auth0RestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
+ * @param {Object} [options.retry]    Retry Policy Config
  */
 var LogsManager = function (options) {
   if (options === null || typeof options !== 'object') {
@@ -30,7 +32,7 @@ var LogsManager = function (options) {
    *
    * @type {Object}
    */
-  var apiOptions = {
+  var clientOptions = {
     headers: options.headers,
     query: { repeatParams: false }
   };
@@ -42,7 +44,8 @@ var LogsManager = function (options) {
    *
    * @type {external:RestClient}
    */
-  this.resource = new Auth0RestClient(options.baseUrl + '/logs/:id ', apiOptions, options.tokenProvider);
+  var auth0RestClient = new Auth0RestClient(options.baseUrl + '/logs/:id ', clientOptions, options.tokenProvider);
+  this.resource = new RetryRestClient(auth0RestClient, options.retry);
 };
 
 /**

--- a/src/management/ResourceServersManager.js
+++ b/src/management/ResourceServersManager.js
@@ -1,6 +1,7 @@
 var ArgumentError = require('rest-facade').ArgumentError;
 var utils = require('../utils');
 var Auth0RestClient = require('../Auth0RestClient');
+var RetryRestClient = require('../RetryRestClient');
 
 /**
  * @class ResourceServersManager
@@ -17,6 +18,7 @@ var Auth0RestClient = require('../Auth0RestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
+ * @param {Object} [options.retry]    Retry Policy Config
  */
 
 var ResourceServersManager = function (options) {
@@ -37,7 +39,7 @@ var ResourceServersManager = function (options) {
    *
    * @type {Object}
    */
-  var apiOptions = {
+  var clientOptions = {
     headers: options.headers,
     query: { repeatParams: false }
   };
@@ -48,7 +50,8 @@ var ResourceServersManager = function (options) {
    *
    * @type {external:RestClient}
    */
-  this.resource = new Auth0RestClient(options.baseUrl + '/resource-servers/:id', apiOptions, options.tokenProvider);
+  var auth0RestClient = new Auth0RestClient(options.baseUrl + '/resource-servers/:id', clientOptions, options.tokenProvider);
+  this.resource = new RetryRestClient(auth0RestClient, options.retry);
 };
 
 /**

--- a/src/management/RulesManager.js
+++ b/src/management/RulesManager.js
@@ -1,6 +1,7 @@
 var ArgumentError = require('rest-facade').ArgumentError;
 var utils = require('../utils');
 var Auth0RestClient = require('../Auth0RestClient');
+var RetryRestClient = require('../RetryRestClient');
 
 /**
  * Simple facade for consuming a REST API endpoint.
@@ -19,6 +20,7 @@ var Auth0RestClient = require('../Auth0RestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
+ * @param {Object} [options.retry]    Retry Policy Config
  */
 var RulesManager = function (options) {
   if (options === null || typeof options !== 'object') {
@@ -38,7 +40,7 @@ var RulesManager = function (options) {
    *
    * @type {Object}
    */
-  var apiOptions = {
+  var clientOptions = {
     headers: options.headers,
     query: { repeatParams: false }
   };
@@ -49,7 +51,8 @@ var RulesManager = function (options) {
    *
    * @type {external:RestClient}
    */
-  this.resource = new Auth0RestClient(options.baseUrl + '/rules/:id ', apiOptions, options.tokenProvider);
+  var auth0RestClient = new Auth0RestClient(options.baseUrl + '/rules/:id', clientOptions, options.tokenProvider);
+  this.resource = new RetryRestClient(auth0RestClient, options.retry);
 };
 
 

--- a/src/management/StatsManager.js
+++ b/src/management/StatsManager.js
@@ -1,5 +1,6 @@
 var ArgumentError = require('rest-facade').ArgumentError;
 var Auth0RestClient = require('../Auth0RestClient');
+var RetryRestClient = require('../RetryRestClient');
 
 /**
  * Simple facade for consuming a REST API endpoint.
@@ -17,6 +18,7 @@ var Auth0RestClient = require('../Auth0RestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
+ * @param {Object} [options.retry]    Retry Policy Config
  */
 var StatsManager = function (options){
   if (options === null || typeof options !== 'object') {
@@ -43,7 +45,8 @@ var StatsManager = function (options){
    *
    * @type {external:RestClient}
    */
-  this.stats = new Auth0RestClient(options.baseUrl + '/stats/:type', clientOptions, options.tokenProvider);
+  var auth0RestClient = new Auth0RestClient(options.baseUrl + '/stats/:type', clientOptions, options.tokenProvider);
+  this.stats = new RetryRestClient(auth0RestClient, options.retry);
 };
 
 

--- a/src/management/TenantManager.js
+++ b/src/management/TenantManager.js
@@ -1,6 +1,6 @@
 var ArgumentError = require('rest-facade').ArgumentError;
 var Auth0RestClient = require('../Auth0RestClient');
-
+var RetryRestClient = require('../RetryRestClient');
 
 /**
  * Simple facade for consuming a REST API endpoint.
@@ -18,6 +18,7 @@ var Auth0RestClient = require('../Auth0RestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
+ * @param {Object} [options.retry]    Retry Policy Config
  */
 var TenantManager = function (options){
   if (options === null || typeof options !== 'object') {
@@ -44,7 +45,8 @@ var TenantManager = function (options){
    *
    * @type {external:RestClient}
    */
-  this.tenant = new Auth0RestClient(options.baseUrl + '/tenants/settings', clientOptions,  options.tokenProvider);
+  var auth0RestClient = new Auth0RestClient(options.baseUrl + '/tenants/settings', clientOptions, options.tokenProvider);
+  this.tenant = new RetryRestClient(auth0RestClient, options.retry);
 };
 
 /**

--- a/src/management/TicketsManager.js
+++ b/src/management/TicketsManager.js
@@ -1,12 +1,17 @@
 var ArgumentError = require('rest-facade').ArgumentError;
 var Auth0RestClient = require('../Auth0RestClient');
-
+var RetryRestClient = require('../RetryRestClient');
 
 /**
  * @class
  * Abstracts interaction with the tickets endpoint.
  * @constructor
  * @memberOf module:management
+ * 
+ * @param {Object} options            The client options.
+ * @param {String} options.baseUrl    The URL of the API.
+ * @param {Object} [options.headers]  Headers to be included in all requests.
+ * @param {Object} [options.retry]    Retry Policy Config
  */
 var TicketsManager = function (options){
   if (options === null || typeof options !== 'object') {
@@ -33,7 +38,8 @@ var TicketsManager = function (options){
    *
    * @type {external:RestClient}
    */
-  this.ticket = new Auth0RestClient(options.baseUrl + '/tickets/:type', clientOptions, options.tokenProvider);
+  var auth0RestClient = new Auth0RestClient(options.baseUrl + '/tickets/:type', clientOptions, options.tokenProvider);
+  this.ticket = new RetryRestClient(auth0RestClient, options.retry);
 };
 
 

--- a/src/management/UsersManager.js
+++ b/src/management/UsersManager.js
@@ -1,5 +1,6 @@
 var ArgumentError = require('rest-facade').ArgumentError;
 var Auth0RestClient = require('../Auth0RestClient');
+var RetryRestClient = require('../RetryRestClient');
 
 /**
  * Simple facade for consuming a REST API endpoint.
@@ -17,6 +18,7 @@ var Auth0RestClient = require('../Auth0RestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
+ * @param {Object} [options.retry]    Retry Policy Config
  */
 var UsersManager = function (options){
   if (options === null || typeof options !== 'object') {
@@ -37,7 +39,8 @@ var UsersManager = function (options){
     query: { repeatParams: false }
   };
   
-  this.users = new Auth0RestClient(options.baseUrl + '/users/:id', clientOptions, options.tokenProvider);
+  var usersAuth0RestClient = new Auth0RestClient(options.baseUrl + '/users/:id', clientOptions, options.tokenProvider);
+  this.users = new RetryRestClient(usersAuth0RestClient, options.retry);
 
   /**
    * Provides an abstraction layer for consuming the
@@ -46,28 +49,32 @@ var UsersManager = function (options){
    *
    * @type {external:RestClient}
    */
-  this.multifactor = new Auth0RestClient(options.baseUrl + '/users/:id/multifactor/:provider', clientOptions, options.tokenProvider);
+  var multifactorAuth0RestClient = new Auth0RestClient(options.baseUrl + '/users/:id/multifactor/:provider', clientOptions, options.tokenProvider);
+  this.multifactor = new RetryRestClient(multifactorAuth0RestClient, options.retry);
 
   /**
    * Provides a simple abstraction layer for linking user accounts.
    *
    * @type {external:RestClient}
    */
-  this.identities = new Auth0RestClient(options.baseUrl + '/users/:id/identities/:provider/:user_id', clientOptions, options.tokenProvider);
+  var identitiesAuth0RestClient = new Auth0RestClient(options.baseUrl + '/users/:id/identities/:provider/:user_id', clientOptions, options.tokenProvider);
+  this.identities = new RetryRestClient(identitiesAuth0RestClient, options.retry);
 
   /**
    * Provides a simple abstraction layer for user logs
    *
    * @type {external:RestClient}
    */
-  this.userLogs = new Auth0RestClient(options.baseUrl + '/users/:id/logs', clientOptions, options.tokenProvider);
+  var userLogsAuth0RestClient = new Auth0RestClient(options.baseUrl + '/users/:id/logs', clientOptions, options.tokenProvider);
+  this.userLogs = new RetryRestClient(userLogsAuth0RestClient, options.retry);
 
   /**
    * Provides an abstraction layer for retrieving Guardian enrollments.
    *
    * @type {external:RestClient}
    */
-  this.enrollments = new Auth0RestClient(options.baseUrl + '/users/:id/enrollments', clientOptions, options.tokenProvider);
+  var enrollmentsAuth0RestClient = new Auth0RestClient(options.baseUrl + '/users/:id/enrollments', clientOptions, options.tokenProvider);
+  this.enrollments = new RetryRestClient(enrollmentsAuth0RestClient, options.retry);
 };
 
 

--- a/src/management/index.js
+++ b/src/management/index.js
@@ -78,8 +78,10 @@ var MANAGEMENT_API_AUD_FORMAT = 'https://%s/api/v2/';
  * @param   {String}  [options.clientSecret]                      Management API Non Interactive Client Secret.
  * @param   {String}  [options.audience]                          Management API Audience. By default is your domain's, e.g. the domain is `tenant.auth0.com` and the audience is `http://tenant.auth0.com/api/v2/`
  * @param   {String}  [options.scope]                             Management API Scopes.
- * @param   {String}  [options.tokenProvider.enableCache=true]    Enabled or Disable Cache.
+ * @param   {Boolean} [options.tokenProvider.enableCache=true]    Enabled or Disable Cache.
  * @param   {Number}  [options.tokenProvider.cacheTTLInSeconds]   By default the `expires_in` value will be used to determine the cached time of the token, this can be overridden.
+ * @param   {Boolean} [options.retry.enabled=true]                Enabled or Disable Retry Policy functionality.
+ * @param   {Number}  [options.retry.maxRetries=10]               Retry failed requests X times.
  *
  */
 var ManagementClient = function (options) {
@@ -121,7 +123,9 @@ var ManagementClient = function (options) {
     var telemetry = jsonToBase64(options.clientInfo || this.getClientInfo());
     managerOptions.headers['Auth0-Client'] = telemetry;
   }
-
+  
+  managerOptions.retry = options.retry;
+  
   /**
    * Simple abstraction for performing CRUD operations on the
    * clients endpoint.

--- a/test/retry-rest-client.tests.js
+++ b/test/retry-rest-client.tests.js
@@ -1,0 +1,297 @@
+var expect = require('chai').expect;
+var nock = require('nock');
+
+var Promise = require('bluebird');
+var ArgumentError = require('rest-facade').ArgumentError;
+var RestClient = require('rest-facade').Client;;
+var RetryRestClient = require('../src/RetryRestClient');
+
+var API_URL = 'https://tenant.auth0.com';
+
+describe('RetryRestClient', function () {
+  before(function () {
+    this.restClient = new RestClient(API_URL);
+  });
+
+  it('should raise an error when no RestClient is provided', function () {
+    expect(RetryRestClient)
+      .to.throw(ArgumentError, 'Must provide RestClient');
+  });
+
+  it('should raise an error when enabled is not of type boolean', function () {
+    var options = { enabled: {} };
+    var client = RetryRestClient.bind(null, {}, options);
+    expect(client)
+      .to.throw(ArgumentError, 'Must provide enabled boolean value');
+  });
+
+  it('should raise an error when maxRetries is negative', function () {
+    var options = { maxRetries: -1 };
+    var client = RetryRestClient.bind(null, {}, options);
+    expect(client)
+      .to.throw(ArgumentError, 'Must provide maxRetries as a positive number');
+  });
+
+  describe('instance', function () {
+    var client = new RetryRestClient(new RestClient(API_URL));
+    var methods = ['getAll', 'get', 'create', 'update', 'delete'];
+
+    methods.forEach(function (method) {
+      it('should have a ' + method + ' method', function () {
+        
+        expect(client[method])
+          .to.exist
+          .to.be.an.instanceOf(Function);
+      })
+    });
+  });
+
+  it('should pass data to callback when provided', function(done){
+    nock(API_URL)
+      .get('/')
+      .reply(200, { success: true });
+
+    var client = new RetryRestClient(this.restClient);
+    client.getAll(function(err, data){
+      expect(err).to.null;
+      expect(data.success).to.be.true;
+      done();
+    });
+  });
+
+  it('should return promise when no callback is provided', function(done){
+    nock(API_URL)
+      .get('/')
+      .reply(200, { success: true });
+
+    var client = new RetryRestClient(this.restClient);
+    client.getAll()
+      .then(function(data){
+        expect(data.success).to.be.true;
+        done();
+      });
+  });
+
+  it('should pass err to callback when provided', function(done){
+    nock(API_URL)
+      .get('/')
+      .reply(500);
+
+    var client = new RetryRestClient(this.restClient);
+    client.getAll(function(err){
+      expect(err).to.not.null;
+      expect(err.statusCode).to.be.equal(500);
+      done();
+    });
+  });
+
+  it('should return promise when no callback is provided', function(done){
+    nock(API_URL)
+      .get('/')
+      .reply(500);
+
+    var client = new RetryRestClient(this.restClient);
+    client.getAll()
+      .catch(function(err){
+        expect(err).to.not.null;
+        expect(err.statusCode).to.be.equal(500);
+        done();
+      });
+  });
+
+  it('should retry once when an error is returned', function(done){
+    var self = this;
+    var timesCalled = 0;
+    var restClientSpy = {
+      getAll: function(){
+        timesCalled += 1;
+        return self.restClient.getAll(arguments);
+      }
+    }
+
+    nock(API_URL)
+      .get('/')
+      .reply(429, { success: false }, {
+        "x-ratelimit-limit": "10",
+        "x-ratelimit-remaining": "0",
+        "x-ratelimit-reset": "1508253300",
+      })
+      .get('/')
+      .reply(200, { success: true });;
+
+    var client = new RetryRestClient(restClientSpy);
+    client.getAll()
+      .then(function(data) { 
+        expect(data.success).to.be.true;
+        expect(timesCalled).to.be.equal(2);
+        done();
+      });
+  });
+
+  it('should try 4 times when request fails 3 times', function(done){
+    var self = this;
+    var timesCalled = 0;
+    var restClientSpy = {
+      getAll: function(){
+        timesCalled += 1;
+        return self.restClient.getAll(arguments);
+      }
+    }
+
+    nock(API_URL)
+      .get('/')
+      .times(3)
+      .reply(429, { success: false }, {
+        "x-ratelimit-limit": "10",
+        "x-ratelimit-remaining": "0",
+        "x-ratelimit-reset": "1508253300",
+      })
+      .get('/')
+      .reply(200, { success: true });;
+
+    var client = new RetryRestClient(restClientSpy);
+    client.getAll()
+      .then(function(data) { 
+        expect(data.success).to.be.true;
+        expect(timesCalled).to.be.equal(4);
+        done();
+      });
+  });
+
+  it('should retry 2 times and fail when maxRetries is exceeded with no delay time', function(done){
+    var self = this;
+    var timesCalled = 0;
+    var restClientSpy = {
+      getAll: function(){
+        timesCalled += 1;
+        return self.restClient.getAll(arguments);
+      }
+    }
+
+    nock(API_URL)
+      .get('/')
+      .times(4)
+      .reply(429, { success: false }, {
+        "x-ratelimit-limit": "10",
+        "x-ratelimit-remaining": "0",
+        "x-ratelimit-reset": (new Date().getTime() - 10) / 1000 // past.
+      });
+
+    var client = new RetryRestClient(restClientSpy, { maxRetries: 3 });
+    client.getAll()
+      .catch(function(err) {
+        expect(err).to.not.null;
+        expect(timesCalled).to.be.equal(4); // Initial call + 3 retires.
+        done();
+      });
+  });
+
+  it('should retry 2 times and fail when maxRetries is exceeded with delay time', function(done){
+    var self = this;
+    var timesCalled = 0;
+    var restClientSpy = {
+      getAll: function(){
+        timesCalled += 1;
+        return self.restClient.getAll(arguments);
+      }
+    }
+
+    nock(API_URL)
+      .get('/')
+      .reply(429, { success: false }, {
+        "x-ratelimit-limit": "10",
+        "x-ratelimit-remaining": "0",
+        "x-ratelimit-reset": (new Date().getTime() + 50) / 1000 // epoch seconds + 50ms
+      })
+      .get('/')
+      .reply(429, { success: false }, {
+        "x-ratelimit-limit": "10",
+        "x-ratelimit-remaining": "0",
+        "x-ratelimit-reset": (new Date().getTime() + 100) / 1000 // epoch seconds + 100ms
+      });
+
+    var client = new RetryRestClient(restClientSpy, { maxRetries: 1 });
+    client.getAll()
+      .catch(function(err) {
+        expect(err).to.not.null;
+        expect(timesCalled).to.be.equal(2); // Initial call + 3 retires.
+        done();
+      });
+  });
+
+  it('should not retry when status code is not 429', function(done){
+    nock(API_URL)
+      .get('/')
+      .reply(500);
+
+    var client = new RetryRestClient(this.restClient);
+    client.getAll()
+      .catch(function(err) {
+        expect(err).to.not.null;
+        expect(err.statusCode).to.be.equal(500);
+        done();
+      });
+  });
+
+  it('should delay the retry using x-ratelimit-reset header value and succeed after retry', function(done){
+    var self = this;
+    var calledAt = [];
+    var restClientSpy = {
+      getAll: function(){
+        calledAt.push(new Date().getTime());
+        return self.restClient.getAll(arguments);
+      }
+    }
+
+    nock(API_URL)
+      .get('/')
+      .reply(429, { success: false }, {
+        "x-ratelimit-limit": "10",
+        "x-ratelimit-remaining": "0",
+        "x-ratelimit-reset": (new Date().getTime() + 50) / 1000 // epoch seconds + 50ms
+      })
+      .get('/')
+      .reply(200, { success: true });;
+
+      var client = new RetryRestClient(restClientSpy);
+
+    client.getAll()
+      .then(function(data) {
+        expect(data.success).to.be.true;
+        expect(calledAt.length).to.be.equal(2);
+        
+        var elapsedTime = calledAt[1] - calledAt[0];
+        expect(elapsedTime).to.be.above(49); // Time between the requests should at least be more than 49ms
+        done();
+      });
+  }); 
+
+
+  it('should not retry when retry functionality is disabled', function(done){
+    var self = this;
+    var timesCalled = 0;
+    var restClientSpy = {
+      getAll: function(){
+        timesCalled += 1;
+        return self.restClient.getAll(arguments);
+      }
+    }
+
+    nock(API_URL)
+      .get('/')
+      .reply(429, { success: false }, {
+        "x-ratelimit-limit": "10",
+        "x-ratelimit-remaining": "0",
+        "x-ratelimit-reset": "1508253300"
+      });
+
+    var client = new RetryRestClient(restClientSpy, { enabled: false });
+    client.getAll()
+      .catch(function(err) {
+        expect(err).to.not.null;
+        expect(err.statusCode).to.be.equal(429);
+        expect(timesCalled).to.be.equal(1);
+        done();
+      });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,19 @@ acorn@^3.0.0, acorn@^3.0.4, acorn@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
+agent-base@2, agent-base@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-2.1.1.tgz#d6de10d5af6132d5bd692427d46fc538539094c7"
+  dependencies:
+    extend "~3.0.0"
+    semver "~5.0.1"
+
+agent-base@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.1.1.tgz#92d8a4fc2524a3b09b3666a33b6c97960f23d6a4"
+  dependencies:
+    es6-promisify "^5.0.0"
+
 ajv@^4.9.1:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
@@ -119,6 +132,10 @@ assert@^1.1.1:
 assertion-error@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.0.tgz#c7f85438fdd466bc7ca16ab90c81513797a5d23b"
+
+ast-types@0.x.x:
+  version "0.9.14"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.14.tgz#d34ba5dffb9d15a44351fd2a9d82e4ab2838b5ba"
 
 async-each@^1.0.0:
   version "1.0.1"
@@ -244,6 +261,10 @@ buffer@^4.9.0:
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
+
+bytes@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
 
 camel-case@^1.1.1:
   version "1.2.2"
@@ -462,9 +483,19 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+data-uri-to-buffer@1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz#77163ea9c20d8641b4707e8f18abdf9a78f34835"
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
+
+debug@2, debug@^2.6.8:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  dependencies:
+    ms "2.0.0"
 
 debug@2.2.0, debug@^2.2.0:
   version "2.2.0"
@@ -498,12 +529,24 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
+deepmerge@^1.5.1:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"
+
 define-properties@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
   dependencies:
     foreach "^2.0.5"
     object-keys "^1.0.8"
+
+degenerator@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/degenerator/-/degenerator-1.0.4.tgz#fcf490a37ece266464d9cc431ab98c5819ced095"
+  dependencies:
+    ast-types "0.x.x"
+    escodegen "1.x.x"
+    esprima "3.x.x"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -512,6 +555,10 @@ delayed-stream@~1.0.0:
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
+
+depd@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
 
 diff@1.4.0:
   version "1.4.0"
@@ -551,6 +598,16 @@ errno@^0.1.3:
   dependencies:
     prr "~0.0.0"
 
+es6-promise@^4.0.3:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.1.1.tgz#8811e90915d9a0dba36274f0b242dbda78f9c92a"
+
+es6-promisify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  dependencies:
+    es6-promise "^4.0.3"
+
 escape-string-regexp@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz#4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1"
@@ -570,6 +627,17 @@ escodegen@1.8.x:
   optionalDependencies:
     source-map "~0.2.0"
 
+escodegen@1.x.x:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.9.0.tgz#9811a2f265dc1cd3894420ee3717064b632b8852"
+  dependencies:
+    esprima "^3.1.3"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.5.6"
+
 espree@~3.1.7:
   version "3.1.7"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.1.7.tgz#fd5deec76a97a5120a9cd3a7cb1177a0923b11d2"
@@ -581,9 +649,17 @@ esprima@2.7.x, esprima@^2.6.0, esprima@^2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
 
+esprima@3.x.x, esprima@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
+
 estraverse@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
+
+estraverse@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
 esutils@^2.0.2:
   version "2.0.2"
@@ -605,7 +681,7 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
+extend@3, extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
@@ -632,6 +708,10 @@ file-loader@^0.8.1:
   resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-0.8.5.tgz#9275d031fe780f27d47f5f4af02bd43713cc151b"
   dependencies:
     loader-utils "~0.2.5"
+
+file-uri-to-path@1:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
 
 filename-regex@^2.0.0:
   version "2.0.1"
@@ -719,6 +799,13 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
+ftp@~0.3.10:
+  version "0.3.10"
+  resolved "https://registry.yarnpkg.com/ftp/-/ftp-0.3.10.tgz#9197d861ad8142f3e63d5a83bfe4c59f7330885d"
+  dependencies:
+    readable-stream "1.1.x"
+    xregexp "2.0.0"
+
 function-bind@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -745,6 +832,17 @@ generate-object-property@^1.1.0:
   resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
   dependencies:
     is-property "^1.0.0"
+
+get-uri@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/get-uri/-/get-uri-2.0.1.tgz#dbdcacacd8c608a38316869368117697a1631c59"
+  dependencies:
+    data-uri-to-buffer "1"
+    debug "2"
+    extend "3"
+    file-uri-to-path "1"
+    ftp "~0.3.10"
+    readable-stream "2"
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -886,6 +984,23 @@ hoek@4.x.x:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
+http-errors@1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736"
+  dependencies:
+    depd "1.1.1"
+    inherits "2.0.3"
+    setprototypeof "1.0.3"
+    statuses ">= 1.3.1 < 2"
+
+http-proxy-agent@1, http-proxy-agent@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-1.0.0.tgz#cc1ce38e453bf984a0f7702d2dd59c73d081284a"
+  dependencies:
+    agent-base "2"
+    debug "2"
+    extend "3"
+
 http-signature@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
@@ -906,6 +1021,18 @@ https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
 
+https-proxy-agent@1, https-proxy-agent@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz#35f7da6c48ce4ddbfa264891ac593ee5ff8671e6"
+  dependencies:
+    agent-base "2"
+    debug "2"
+    extend "3"
+
+iconv-lite@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+
 ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
@@ -921,7 +1048,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.1:
+inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -936,6 +1063,10 @@ ini@~1.3.0:
 interpret@^0.6.4:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-0.6.6.tgz#fecd7a18e7ce5ca6abfb953e1f86213a49f1625b"
+
+ip@^1.1.4, ip@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
 
 is-binary-path@^1.0.0:
   version "1.0.1"
@@ -1029,6 +1160,10 @@ is-upper-case@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-upper-case/-/is-upper-case-1.1.2.tgz#8d0b1fa7e7933a1e58483600ec7d9661cbaf756f"
   dependencies:
     upper-case "^1.1.0"
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -1221,6 +1356,10 @@ lru-cache@2:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
 
+lru-cache@~2.6.5:
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.6.5.tgz#e56d6354148ede8d7707b58d143220fd08df0fd5"
+
 lru-cache@~4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.0.2.tgz#1d17679c069cda5d040991a09dbc2c0db377e55e"
@@ -1382,9 +1521,17 @@ ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
 
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
 nan@^2.3.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
+
+netmask@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/netmask/-/netmask-1.0.6.tgz#20297e89d86f6f6400f250d9f4f6b4c1945fcd35"
 
 nock@^3.1.1:
   version "3.6.0"
@@ -1542,6 +1689,29 @@ osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
+pac-proxy-agent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pac-proxy-agent/-/pac-proxy-agent-2.0.0.tgz#beb17cd2b06a20b379d57e1b2e2c29be0dfe5f9a"
+  dependencies:
+    agent-base "^2.1.1"
+    debug "^2.6.8"
+    get-uri "^2.0.0"
+    http-proxy-agent "^1.0.0"
+    https-proxy-agent "^1.0.0"
+    pac-resolver "^3.0.0"
+    raw-body "^2.2.0"
+    socks-proxy-agent "^3.0.0"
+
+pac-resolver@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pac-resolver/-/pac-resolver-3.0.0.tgz#6aea30787db0a891704deb7800a722a7615a6f26"
+  dependencies:
+    co "^4.6.0"
+    degenerator "^1.0.4"
+    ip "^1.1.5"
+    netmask "^1.0.6"
+    thunkify "^2.1.2"
+
 pako@~0.2.0:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
@@ -1624,6 +1794,19 @@ propagate@0.3.x:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-0.3.1.tgz#e3a84404a7ece820dd6bbea9f6d924e3135ae09c"
 
+proxy-agent@2:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-agent/-/proxy-agent-2.1.0.tgz#a3a2b3866debfeb79bb791f345dc9bc876e7ff86"
+  dependencies:
+    agent-base "2"
+    debug "2"
+    extend "3"
+    http-proxy-agent "1"
+    https-proxy-agent "1"
+    lru-cache "~2.6.5"
+    pac-proxy-agent "^2.0.0"
+    socks-proxy-agent "2"
+
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
@@ -1667,6 +1850,15 @@ randomatic@^1.1.3:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
+raw-body@^2.2.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.2.tgz#bcd60c77d3eb93cde0050295c3f379389bc88f89"
+  dependencies:
+    bytes "3.0.0"
+    http-errors "1.6.2"
+    iconv-lite "0.4.19"
+    unpipe "1.0.0"
+
 rc@^1.1.7:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.1.tgz#2e03e8e42ee450b8cb3dce65be1bf8974e1dfd95"
@@ -1675,6 +1867,27 @@ rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+readable-stream@1.1.x:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
+readable-stream@2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~1.0.6"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.0.3"
+    util-deprecate "~1.0.1"
 
 readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.6:
   version "2.2.11"
@@ -1805,13 +2018,19 @@ resolve@1.1.x:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-rest-facade@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/rest-facade/-/rest-facade-1.5.0.tgz#9d886eaf0256c7ecc902c17c9f7bf9072438dcee"
+rest-facade@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/rest-facade/-/rest-facade-1.10.0.tgz#527847f2900257813ccc99e5dec3c225c6fb9f34"
   dependencies:
     bluebird "^2.10.2"
     change-case "^2.3.0"
+    deepmerge "^1.5.1"
     superagent "^3.5.2"
+    superagent-proxy "^1.0.2"
+
+retry@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -1833,7 +2052,7 @@ safe-buffer@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.0.tgz#fe4c8460397f9eaaaa58e73be46273408a45e223"
 
-safe-buffer@^5.1.1:
+safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
@@ -1848,6 +2067,10 @@ samsam@1.1.2, samsam@~1.1:
 semver@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+
+semver@~5.0.1:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.0.3.tgz#77466de589cd5d3c95f138aa78bc569a3cb5d27a"
 
 sentence-case@^1.1.1, sentence-case@^1.1.2:
   version "1.1.3"
@@ -1866,6 +2089,10 @@ set-immediate-shim@^1.0.1:
 setimmediate@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+
+setprototypeof@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
 
 sha.js@2.2.6:
   version "2.2.6"
@@ -1888,6 +2115,10 @@ sinon@^1.17.1:
     samsam "1.1.2"
     util ">=0.10.3 <1"
 
+smart-buffer@^1.0.13:
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-1.1.15.tgz#7f114b5b65fab3e2a35aa775bb12f0d1c649bf16"
+
 snake-case@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-1.1.2.tgz#0c2f25e305158d9a18d3d977066187fef8a5a66a"
@@ -1905,6 +2136,28 @@ sntp@2.x.x:
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-2.0.2.tgz#5064110f0af85f7cfdb7d6b67a40028ce52b4b2b"
   dependencies:
     hoek "4.x.x"
+
+socks-proxy-agent@2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-2.1.1.tgz#86ebb07193258637870e13b7bd99f26c663df3d3"
+  dependencies:
+    agent-base "2"
+    extend "3"
+    socks "~1.1.5"
+
+socks-proxy-agent@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz#2eae7cf8e2a82d34565761539a7f9718c5617659"
+  dependencies:
+    agent-base "^4.1.0"
+    socks "^1.1.10"
+
+socks@^1.1.10, socks@~1.1.5:
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-1.1.10.tgz#5b8b7fc7c8f341c53ed056e929b7bf4de8ba7b5a"
+  dependencies:
+    ip "^1.1.4"
+    smart-buffer "^1.0.13"
 
 source-list-map@~0.1.7:
   version "0.1.8"
@@ -1932,6 +2185,10 @@ source-map@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
+source-map@~0.5.6:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -1949,6 +2206,10 @@ sshpk@^1.7.0:
     ecc-jsbn "~0.1.1"
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
+
+"statuses@>= 1.3.1 < 2":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
 
 stream-browserify@^2.0.1:
   version "2.0.1"
@@ -1985,7 +2246,7 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string_decoder@^0.10.25:
+string_decoder@^0.10.25, string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
@@ -1994,6 +2255,12 @@ string_decoder@~1.0.0:
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.2.tgz#b29e1f4e1125fa97a10382b8a533737b7491e179"
   dependencies:
     safe-buffer "~5.0.1"
+
+string_decoder@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
+  dependencies:
+    safe-buffer "~5.1.0"
 
 stringstream@~0.0.4, stringstream@~0.0.5:
   version "0.0.5"
@@ -2014,6 +2281,13 @@ style-loader@^0.8.3:
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.8.3.tgz#f4f92eb7db63768748f15065cd6700f5a1c85357"
   dependencies:
     loader-utils "^0.2.5"
+
+superagent-proxy@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/superagent-proxy/-/superagent-proxy-1.0.2.tgz#92d3660578f618ed43a82cf8cac799fe2938ba2d"
+  dependencies:
+    debug "2"
+    proxy-agent "2"
 
 superagent@^3.5.2:
   version "3.5.2"
@@ -2079,6 +2353,10 @@ tar@^2.2.1:
     block-stream "*"
     fstream "^1.0.2"
     inherits "2"
+
+thunkify@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/thunkify/-/thunkify-2.1.2.tgz#faa0e9d230c51acc95ca13a361ac05ca7e04553d"
 
 timers-browserify@^2.0.2:
   version "2.0.2"
@@ -2171,6 +2449,10 @@ underscore@1.6.0, underscore@~1.6.0:
 underscore@~1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
+
+unpipe@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
 
 upper-case-first@^1.1.0:
   version "1.1.2"
@@ -2293,6 +2575,10 @@ wrappy@1:
 xml@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+
+xregexp@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-2.0.0.tgz#52a63e56ca0b84a7f3a5f3d61872f126ad7a5943"
 
 xtend@^4.0.0:
   version "4.0.1"


### PR DESCRIPTION
This PR's provides a `RetryRestClient`, that retries failed request due to rate-limits again.

The requests are retried when the setting `retry.enabled` is set to `true` and will only retry requests when the status code is `429` and the response headers contains the specific rate limit header `x-ratelimit-limit`.

By default retry is enabled, changing this can be done as follows;

```
var managementClient = new ManagementClient({
  clientId: '',
  clientSecret: '',
  domain: 'xxx.auth0.com',
  retry: {
    enabled : true
  }
});
```
 