### PR TITLE
Fix documentation for updating the email provider

### DIFF
--- a/src/management/EmailProviderManager.js
+++ b/src/management/EmailProviderManager.js
@@ -103,7 +103,7 @@ utils.wrapPropertyMethod(EmailProviderManager, 'get', 'resource.getAll');
  * @memberOf  module:management.EmailProviderManager.prototype
  *
  * @example
- * management.emailProvider.update(function (err, provider) {
+ * management.emailProvider.update(params, data, function (err, provider) {
  *   if (err) {
  *     // Handle error.
  *   }
@@ -112,6 +112,7 @@ utils.wrapPropertyMethod(EmailProviderManager, 'get', 'resource.getAll');
  *   console.log(provider);
  * });
  *
+ * @param   {Object}    params            Email provider parameters.
  * @param   {Object}    data              Updated email provider data.
  * @param   {Function}  [cb]              Callback function.
  *

--- a/src/management/index.js
+++ b/src/management/index.js
@@ -763,16 +763,19 @@ utils.wrapPropertyMethod(ManagementClient, 'deleteRule', 'rules.delete');
  * @memberOf  module:management.ManagementClient.prototype
  *
  * @example
- * management.deleteRule({ id: RULE_ID }, function (err) {
+ * var params = { id: RULE_ID };
+ * var data = { name: 'my-rule'};
+ * management.updateRule(params, data, function (err, rule) {
  *   if (err) {
  *     // Handle error.
  *   }
  *
- *   // Rule deleted.
+ *   console.log(rule.name); // 'my-rule'.
  * });
  *
  * @param   {Object}    params        Rule parameters.
  * @param   {String}    params.id     Rule ID.
+ * @param   {Object}    data          Updated rule data.
  * @param   {Function}  [cb]          Callback function.
  *
  * @return  {Promise|undefined}

--- a/src/management/index.js
+++ b/src/management/index.js
@@ -757,7 +757,7 @@ utils.wrapPropertyMethod(ManagementClient, 'deleteRule', 'rules.delete');
 
 
 /**
- * Delete an existing rule.
+ * Update an existing rule.
  *
  * @method    updateRule
  * @memberOf  module:management.ManagementClient.prototype
@@ -1266,7 +1266,7 @@ utils.wrapPropertyMethod(ManagementClient, 'deleteEmailProvider', 'emailProvider
  * @memberOf  module:management.ManagementClient.prototype
  *
  * @example
- * management.updateEmailProvider(data, function (err, provider) {
+ * management.updateEmailProvider(params, data, function (err, provider) {
  *   if (err) {
  *     // Handle error.
  *   }
@@ -1275,6 +1275,7 @@ utils.wrapPropertyMethod(ManagementClient, 'deleteEmailProvider', 'emailProvider
  *   console.log(provider);
  * });
  *
+ * @param   {Object}    params            Email provider parameters.
  * @param   {Object}    data              Updated email provider data.
  * @param   {Function}  [cb]              Callback function.
  *


### PR DESCRIPTION
It seems like the documentation for updating the email provider using the `ManagementClient` is not correct: it's missing the first `params` argument when calling the function.

The tests for the` emailProvider.update` do pass the first argument (currently is empty object, as the email provider configuration is tenant-wide): https://github.com/auth0/node-auth0/blob/f97527e190b21f0f7f3e8550cefaf43145a25661/test/management/email-provider.tests.js#L293
The other update functions, e.g. for clients and rules, including the email provider, use the rest-facade patch function, that requires the first `params` object, the `data` object and the callback function.

Call of the `updateEmailProvider(data, cb)` function with missing `params` object causes the arguments mismatch and leads to the `ArgumentError: The data must be an object`. Calling `updateEmailProvider({}, data, cb)` fixes the issue.

If this PR becomes accepted, it will be nice of you to take a look at and approve another PR https://github.com/DefinitelyTyped/DefinitelyTyped/pull/21487 that deals with typings for **node-auth0**, where we have the same problem with the first `params` argument being missed.

Let me know if you need more infos. Thanks for your time and hope to hear from you soon.