### PR TITLE
Import users from JSON instead of file

### DIFF
--- a/src/management/JobsManager.js
+++ b/src/management/JobsManager.js
@@ -100,7 +100,8 @@ JobsManager.prototype.get = function(params, cb) {
 
 /**
  * Given a path to a file and a connection id, create a new job that imports the
- * users contained in the file and associate them with the given connection.
+ * users contained in the file or JSON string and associate them with the given 
+ * connection.
  *
  * @method   importUsers
  * @memberOf module:management.JobsManager.prototype
@@ -120,6 +121,7 @@ JobsManager.prototype.get = function(params, cb) {
  * @param   {Object}    data                Users import data.
  * @param   {String}    data.connectionId   Connection for the users insertion.
  * @param   {String}    data.users          Path to the users data file.
+ * @param   {String}    data.users_json     JSON data for the users.
  * @param   {Function}  [cb]                Callback function.
  *
  * @return  {Promise|undefined}
@@ -141,9 +143,9 @@ JobsManager.prototype.importUsers = function(data, cb) {
         headers: headers,
         formData: {
           users: {
-            value: fs.createReadStream(data.users),
+            value: data.users_json ? Buffer.from(data.users_json) : fs.createReadStream(data.users),
             options: {
-              filename: data.users
+              filename: data.users_json ? 'users.json' : data.users,
             }
           },
           connection_id: data.connection_id

--- a/test/data/users.json
+++ b/test/data/users.json
@@ -1,1 +1,26 @@
-[]
+[
+  {
+    "email": "jane.doe@contoso.com",
+    "email_verified": true,
+    "app_metadata": {
+      "roles": [
+        "admin"
+      ],
+      "plan": "premium"
+    },
+    "user_metadata": {
+      "theme": "light"
+    }
+  },
+  {
+    "email": "john.doe@contoso.com",
+    "email_verified": false,
+    "app_metadata": {
+      "roles": [],
+      "plan": "basic"
+    },
+    "user_metadata": {
+      "theme": "dark"
+    }
+  }
+]

--- a/test/management/jobs.tests.js
+++ b/test/management/jobs.tests.js
@@ -233,7 +233,9 @@ describe('JobsManager', function() {
             .to.contain('Content-Type: application/json');
 
           // Validate the content of the users JSON.
-          expect(parts.users.slice(-2)).to.equal('[]');
+          const users = JSON.parse(parts.users);
+          expect(users.length.to.equal(2));
+          expect(users[0].email.to.equal('jane.doe@contoso.com'));
 
           return true;
         })
@@ -262,58 +264,54 @@ describe('JobsManager', function() {
     });
   });
 
-  describe('#importUsers with JSON data', function () {
+  describe('#importUsers with JSON data', function() {
     var data = {
       users_json: fs.readFileSync(usersFilePath, 'utf8'),
       connection_id: 'con_test'
     };
 
-    beforeEach(function () {
+    beforeEach(function() {
       this.request = nock(API_URL)
         .post('/jobs/users-imports')
         .reply(200);
-    })
+    });
 
-    it('should correctly include user JSON', function (done) {
+    it('should correctly include user JSON', function(done) {
       nock.cleanAll();
       var boundary = null;
 
       var request = nock(API_URL)
-        .matchHeader('Content-Type', function (header) {
+        .matchHeader('Content-Type', function(header) {
           boundary = '--' + header.match(/boundary=([^\n]*)/)[1];
-        
+
           return true;
         })
-        .post('/jobs/users-imports', function (body) {
+        .post('/jobs/users-imports', function(body) {
           var parts = extractParts(body, boundary);
 
           // Validate the content type of the users JSON.
           expect(parts.users)
-            .to.exist
-            .to.be.a('string')
+            .to.exist.to.be.a('string')
             .to.contain('Content-Type: application/json');
 
           // Validate the content of the users JSON.
-          expect(parts.users.slice(-2))
-            .to.equal('[]');
+          const users = JSON.parse(parts.users);
+          expect(users.length.to.equal(2));
+          expect(users[0].email.to.equal('jane.doe@contoso.com'));
 
           return true;
         })
         .reply(200);
 
-      this
-        .jobs
-        .importUsers(data)
-        .then(function () {
-          expect(request.isDone())
-            .to.be.true;
+      this.jobs.importUsers(data).then(function() {
+        expect(request.isDone()).to.be.true;
 
-          done();
-        });
-    });  
+        done();
+      });
+    });
   });
 
-  describe('#verifyEmail', function () {
+  describe('#verifyEmail', function() {
     var data = {
       user_id: 'github|12345'
     };

--- a/test/management/jobs.tests.js
+++ b/test/management/jobs.tests.js
@@ -2,6 +2,7 @@ var path = require('path');
 var expect = require('chai').expect;
 var nock = require('nock');
 var extractParts = require('../utils').extractParts;
+var fs = require('fs');
 
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
@@ -141,9 +142,11 @@ describe('JobsManager', function() {
     });
   });
 
+  const usersFilePath = path.join(__dirname, '../data/users.json');
+
   describe('#importUsers', function() {
     var data = {
-      users: path.join(__dirname, '../data/users.json'),
+      users: usersFilePath,
       connection_id: 'con_test'
     };
 
@@ -261,7 +264,7 @@ describe('JobsManager', function() {
 
   describe('#importUsers with JSON data', function () {
     var data = {
-      users_json: '[]',
+      users_json: fs.readFileSync(usersFilePath, 'utf8'),
       connection_id: 'con_test'
     };
 

--- a/test/management/jobs.tests.js
+++ b/test/management/jobs.tests.js
@@ -233,7 +233,7 @@ describe('JobsManager', function() {
             .to.contain('Content-Type: application/json');
 
           // Validate the content of the users JSON.
-          const users = JSON.parse(parts.users);
+          const users = JSON.parse(parts.users.split('\r\n').slice(-1)[0]);
           expect(users.length.to.equal(2));
           expect(users[0].email.to.equal('jane.doe@contoso.com'));
 
@@ -295,7 +295,7 @@ describe('JobsManager', function() {
             .to.contain('Content-Type: application/json');
 
           // Validate the content of the users JSON.
-          const users = JSON.parse(parts.users);
+          const users = JSON.parse(parts.users.split('\r\n').slice(-1)[0]);
           expect(users.length.to.equal(2));
           expect(users[0].email.to.equal('jane.doe@contoso.com'));
 

--- a/test/management/jobs.tests.js
+++ b/test/management/jobs.tests.js
@@ -234,8 +234,8 @@ describe('JobsManager', function() {
 
           // Validate the content of the users JSON.
           const users = JSON.parse(parts.users.split('\r\n').slice(-1)[0]);
-          expect(users.length.to.equal(2));
-          expect(users[0].email.to.equal('jane.doe@contoso.com'));
+          expect(users.length).to.equal(2);
+          expect(users[0].email).to.equal('jane.doe@contoso.com');
 
           return true;
         })
@@ -296,8 +296,8 @@ describe('JobsManager', function() {
 
           // Validate the content of the users JSON.
           const users = JSON.parse(parts.users.split('\r\n').slice(-1)[0]);
-          expect(users.length.to.equal(2));
-          expect(users[0].email.to.equal('jane.doe@contoso.com'));
+          expect(users.length).to.equal(2);
+          expect(users[0].email).to.equal('jane.doe@contoso.com');
 
           return true;
         })


### PR DESCRIPTION
This PR adds a `users_json` parameter to `importUsers` that allows the calling app to provide a JSON string of users rather than a filename.