### PR TITLE
Use "files" package.json field instead of npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-examples
-test
-docs
-scripts
-.*
-*.md

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.10.0",
   "description": "SDK for Auth0 API v2",
   "main": "src/index.js",
+  "files": [
+    "src"
+  ],
   "scripts": {
     "test": "mocha -R spec $(find ./test -name *.tests.js)",
     "test:ci":


### PR DESCRIPTION
The npmignore file excludes some items, but is not exhaustive and a lot
of artifacts still get packaged up, leading to a package that currently
takes up to 4.4 MB on disk. You could keep adding entries to npmignore
but it's easy to miss things as the build process evolves.

With this change the on-disk size is down to a little over 200KB. This
includes `/src` plus `CHANGELOG`, `LICENSE`, `package.json`, and
`README` (https://docs.npmjs.com/files/package.json#files).

Fixes https://github.com/auth0/node-auth0/issues/271