### PR TITLE
Migrate to ES6

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,14 +3,15 @@
   "version": "2.13.0",
   "description": "SDK for Auth0 API v2",
   "main": "src/index.js",
-  "files": ["src"],
+  "files": [
+    "src"
+  ],
   "engines": {
     "node": ">= 6"
   },
   "scripts": {
     "test": "mocha -R spec $(find ./test -name *.tests.js)",
-    "test:ci":
-      "istanbul cover _mocha --report lcovonly -R $(find ./test -name *.tests.js) -- -R mocha-multi --reporter-options spec=-,mocha-junit-reporter=-",
+    "test:ci": "istanbul cover _mocha --report lcovonly -R $(find ./test -name *.tests.js) -- -R mocha-multi --reporter-options spec=-,mocha-junit-reporter=-",
     "test:coverage": "codecov",
     "test:watch": "NODE_ENV=test mocha --timeout 5000 $(find ./test -name *.tests.js) --watch",
     "jsdoc:generate": "jsdoc --configure .jsdoc.json --verbose",
@@ -24,7 +25,10 @@
     "type": "git",
     "url": "https://github.com/auth0/node-auth0"
   },
-  "keywords": ["auth0", "api"],
+  "keywords": [
+    "auth0",
+    "api"
+  ],
   "author": "Auth0",
   "license": "MIT",
   "bugs": {
@@ -32,7 +36,7 @@
   },
   "homepage": "https://github.com/auth0/node-auth0",
   "dependencies": {
-    "bluebird": "^3.5.2",
+    "bluebird": "^2.10.2",
     "jsonwebtoken": "^8.3.0",
     "jwks-rsa": "^1.3.0",
     "lru-memoizer": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   },
   "homepage": "https://github.com/auth0/node-auth0",
   "dependencies": {
-    "bluebird": "^2.10.2",
     "jsonwebtoken": "^8.3.0",
     "jwks-rsa": "^1.3.0",
     "lru-memoizer": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">= 6"
   },
   "scripts": {
-    "test": "mocha -R spec $(find ./test -name *.tests.js)",
+    "test": "mocha -R spec $(find ./test -name *.tests.js) -w",
     "test:ci":
       "istanbul cover _mocha --report lcovonly -R $(find ./test -name *.tests.js) -- -R mocha-multi --reporter-options spec=-,mocha-junit-reporter=-",
     "test:coverage": "codecov",
@@ -32,6 +32,7 @@
   },
   "homepage": "https://github.com/auth0/node-auth0",
   "dependencies": {
+    "bluebird": "^3.5.2",
     "jsonwebtoken": "^8.3.0",
     "jwks-rsa": "^1.3.0",
     "lru-memoizer": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "jsonwebtoken": "^8.3.0",
     "jwks-rsa": "^1.3.0",
     "lru-memoizer": "^1.11.1",
-    "object.assign": "^4.0.4",
     "request": "^2.83.0",
     "rest-facade": "^1.10.1",
     "retry": "^0.10.1"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/auth0/node-auth0",
   "dependencies": {
-    "bluebird": "^2.10.2",
+    "es6-promisify": "^6.0.0",
     "jsonwebtoken": "^8.3.0",
     "jwks-rsa": "^1.3.0",
     "lru-memoizer": "^1.11.1",
@@ -45,6 +45,7 @@
     "retry": "^0.10.1"
   },
   "devDependencies": {
+    "bluebird": "^2.10.2",
     "chai": "^2.2.0",
     "codecov": "^2.2.0",
     "husky": "^0.14.3",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "SDK for Auth0 API v2",
   "main": "src/index.js",
   "files": ["src"],
+  "engines": {
+    "node": ">= 6"
+  },
   "scripts": {
     "test": "mocha -R spec $(find ./test -name *.tests.js)",
     "test:ci":

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">= 6"
   },
   "scripts": {
-    "test": "mocha -R spec $(find ./test -name *.tests.js) -w",
+    "test": "mocha -R spec $(find ./test -name *.tests.js)",
     "test:ci":
       "istanbul cover _mocha --report lcovonly -R $(find ./test -name *.tests.js) -- -R mocha-multi --reporter-options spec=-,mocha-junit-reporter=-",
     "test:coverage": "codecov",

--- a/src/Auth0RestClient.js
+++ b/src/Auth0RestClient.js
@@ -1,72 +1,72 @@
-var RestClient = require('rest-facade').Client;
-var Promise = require('bluebird');
-var ArgumentError = require('rest-facade').ArgumentError;
+const Promise = require('bluebird');
+const { ArgumentError, Client: RestClient } = require('rest-facade');
 
-var Auth0RestClient = function(resourceUrl, options, provider) {
-  if (resourceUrl === null || resourceUrl === undefined) {
-    throw new ArgumentError('Must provide a Resource Url');
+class Auth0RestClient {
+  constructor(resourceUrl, options, provider) {
+    if (resourceUrl === null || resourceUrl === undefined) {
+      throw new ArgumentError('Must provide a Resource Url');
+    }
+
+    if ('string' !== typeof resourceUrl || resourceUrl.length === 0) {
+      throw new ArgumentError('The provided Resource Url is invalid');
+    }
+
+    if (options === null || typeof options !== 'object') {
+      throw new ArgumentError('Must provide options');
+    }
+
+    this.options = options;
+    this.provider = provider;
+    this.restClient = new RestClient(resourceUrl, options);
   }
 
-  if ('string' !== typeof resourceUrl || resourceUrl.length === 0) {
-    throw new ArgumentError('The provided Resource Url is invalid');
-  }
-
-  if (options === null || typeof options !== 'object') {
-    throw new ArgumentError('Must provide options');
-  }
-
-  this.options = options;
-  this.provider = provider;
-  this.restClient = new RestClient(resourceUrl, options);
-
-  this.wrappedProvider = function(method, args) {
+  wrappedProvider(method, args) {
     if (!this.provider) {
       return this.restClient[method].apply(this.restClient, args);
     }
 
-    var callback;
+    let callback;
     if (args && args[args.length - 1] instanceof Function) {
       callback = args[args.length - 1];
     }
 
-    var self = this;
     return this.provider
       .getAccessToken()
-      .then(function(access_token) {
-        self.options.headers['Authorization'] = 'Bearer ' + access_token;
-        return self.restClient[method].apply(self.restClient, args);
+      .then(access_token => {
+        this.options.headers.Authorization = `Bearer ${access_token}`;
+        return this.restClient[method].apply(this.restClient, args);
       })
-      .catch(function(err) {
+      .catch(err => {
         if (callback) {
           return callback(err);
         }
         return Promise.reject(err);
       });
-  };
-};
+  }
 
-Auth0RestClient.prototype.getAll = function(/* [params], [callback] */) {
-  return this.wrappedProvider('getAll', arguments);
-};
+  getAll(...args /* [params], [callback] */) {
+    return this.wrappedProvider('getAll', args);
+  }
 
-Auth0RestClient.prototype.get = function(/* [params], [callback] */) {
-  return this.wrappedProvider('get', arguments);
-};
+  get(...args /* [params], [callback] */) {
+    return this.wrappedProvider('get', args);
+  }
 
-Auth0RestClient.prototype.create = function(/* [params], [callback] */) {
-  return this.wrappedProvider('create', arguments);
-};
+  create(...args /* [params], [callback] */) {
+    return this.wrappedProvider('create', args);
+  }
 
-Auth0RestClient.prototype.patch = function(/* [params], [callback] */) {
-  return this.wrappedProvider('patch', arguments);
-};
+  patch(...args /* [params], [callback] */) {
+    return this.wrappedProvider('patch', args);
+  }
 
-Auth0RestClient.prototype.update = function(/* [params], [callback] */) {
-  return this.wrappedProvider('update', arguments);
-};
+  update(...args /* [params], [callback] */) {
+    return this.wrappedProvider('update', args);
+  }
 
-Auth0RestClient.prototype.delete = function(/* [params], [callback] */) {
-  return this.wrappedProvider('delete', arguments);
-};
+  delete(...args /* [params], [callback] */) {
+    return this.wrappedProvider('delete', args);
+  }
+}
 
 module.exports = Auth0RestClient;

--- a/src/Auth0RestClient.js
+++ b/src/Auth0RestClient.js
@@ -1,4 +1,3 @@
-const Promise = require('bluebird');
 const { ArgumentError, Client: RestClient } = require('rest-facade');
 
 class Auth0RestClient {

--- a/src/RetryRestClient.js
+++ b/src/RetryRestClient.js
@@ -1,6 +1,5 @@
 const retry = require('retry');
 const { ArgumentError } = require('rest-facade');
-const { assign } = Object;
 
 const DEFAULT_OPTIONS = { maxRetries: 10, enabled: true };
 
@@ -20,7 +19,7 @@ class RetryRestClient {
       throw new ArgumentError('Must provide RestClient');
     }
 
-    const params = assign({}, DEFAULT_OPTIONS, options);
+    const params = Object.assign({}, DEFAULT_OPTIONS, options);
 
     if (typeof params.enabled !== 'boolean') {
       throw new ArgumentError('Must provide enabled boolean value');

--- a/src/RetryRestClient.js
+++ b/src/RetryRestClient.js
@@ -1,9 +1,9 @@
-var Promise = require('bluebird');
-var retry = require('retry');
-var ArgumentError = require('rest-facade').ArgumentError;
-var assign = Object.assign || require('object.assign');
+const Promise = require('bluebird');
+const retry = require('retry');
+const { ArgumentError } = require('rest-facade');
+const { assign } = Object;
 
-var DEFAULT_OPTIONS = { maxRetries: 10, enabled: true };
+const DEFAULT_OPTIONS = { maxRetries: 10, enabled: true };
 
 /**
  * @class RetryRestClient
@@ -15,142 +15,142 @@ var DEFAULT_OPTIONS = { maxRetries: 10, enabled: true };
  * @param {Object}  [options.enabled:true]       Enabled or Disable Retry Policy functionality.
  * @param {Number}  [options.maxRetries=10]      The maximum amount of times to retry the operation. Default is 10.
  */
-var RetryRestClient = function(restClient, options) {
-  if (restClient === null || typeof restClient !== 'object') {
-    throw new ArgumentError('Must provide RestClient');
+class RetryRestClient {
+  constructor(restClient, options) {
+    if (restClient === null || typeof restClient !== 'object') {
+      throw new ArgumentError('Must provide RestClient');
+    }
+
+    const params = assign({}, DEFAULT_OPTIONS, options);
+
+    if (typeof params.enabled !== 'boolean') {
+      throw new ArgumentError('Must provide enabled boolean value');
+    }
+
+    if (typeof params.maxRetries !== 'number' || params.maxRetries <= 0) {
+      throw new ArgumentError('Must provide maxRetries as a positive number');
+    }
+
+    this.restClient = restClient;
+    this.maxRetries = params.maxRetries;
+    this.enabled = params.enabled;
   }
 
-  var params = assign({}, DEFAULT_OPTIONS, options);
-
-  if (typeof params.enabled !== 'boolean') {
-    throw new ArgumentError('Must provide enabled boolean value');
+  getAll(...args /* [params], [callback] */) {
+    return this.invoke('getAll', args);
   }
 
-  if (typeof params.maxRetries !== 'number' || params.maxRetries <= 0) {
-    throw new ArgumentError('Must provide maxRetries as a positive number');
+  get(...args /* [params], [callback] */) {
+    return this.invoke('get', args);
   }
 
-  this.restClient = restClient;
-  this.maxRetries = params.maxRetries;
-  this.enabled = params.enabled;
-};
-
-RetryRestClient.prototype.getAll = function(/* [params], [callback] */) {
-  return this.invoke('getAll', arguments);
-};
-
-RetryRestClient.prototype.get = function(/* [params], [callback] */) {
-  return this.invoke('get', arguments);
-};
-
-RetryRestClient.prototype.create = function(/* [params], [callback] */) {
-  return this.invoke('create', arguments);
-};
-
-RetryRestClient.prototype.patch = function(/* [params], [callback] */) {
-  return this.invoke('patch', arguments);
-};
-
-RetryRestClient.prototype.update = function(/* [params], [callback] */) {
-  return this.invoke('update', arguments);
-};
-
-RetryRestClient.prototype.delete = function(/* [params], [callback] */) {
-  return this.invoke('delete', arguments);
-};
-
-RetryRestClient.prototype.invoke = function(method, args) {
-  var cb;
-  args = Array.prototype.slice.call(args); // convert array-like object to array.
-  if (args && args[args.length - 1] instanceof Function) {
-    cb = args[args.length - 1];
-    args.pop(); // Remove the callback
+  create(...args /* [params], [callback] */) {
+    return this.invoke('create', args);
   }
 
-  var promise = this.handleRetry(method, args);
-
-  if (cb instanceof Function) {
-    promise.then(cb.bind(null, null)).catch(cb);
-    return;
+  patch(...args /* [params], [callback] */) {
+    return this.invoke('patch', args);
   }
 
-  return promise;
-};
-
-RetryRestClient.prototype.handleRetry = function(method, args) {
-  if (!this.enabled) {
-    return this.restClient[method].apply(this.restClient, args);
+  update(...args /* [params], [callback] */) {
+    return this.invoke('update', args);
   }
 
-  var retryOptions = {
-    retries: this.maxRetries,
-    factor: 1,
-    minTimeout: 1, // retry immediate, use custom logic to control this.
-    randomize: false
-  };
+  delete(...args /* [params], [callback] */) {
+    return this.invoke('delete', args);
+  }
 
-  var self = this;
-  var promise = new Promise(function(resolve, reject) {
-    var operation = retry.operation(retryOptions);
+  invoke(method, args) {
+    let cb;
 
-    operation.attempt(function() {
-      self.restClient[method]
-        .apply(self.restClient, args)
-        .then(function(body) {
-          resolve(body);
-        })
-        .catch(function(err) {
-          self.invokeRetry(err, operation, reject);
-        });
+    if (args && args[args.length - 1] instanceof Function) {
+      cb = args[args.length - 1];
+      args.pop(); // Remove the callback
+    }
+
+    const promise = this.handleRetry(method, args);
+
+    if (cb instanceof Function) {
+      promise.then(cb.bind(null, null)).catch(cb);
+      return;
+    }
+
+    return promise;
+  }
+
+  handleRetry(method, args) {
+    if (!this.enabled) {
+      return this.restClient[method].apply(this.restClient, args);
+    }
+
+    const retryOptions = {
+      retries: this.maxRetries,
+      factor: 1,
+      minTimeout: 1, // retry immediate, use custom logic to control this.
+      randomize: false
+    };
+
+    const promise = new Promise((resolve, reject) => {
+      const operation = retry.operation(retryOptions);
+      operation.attempt(() => {
+        this.restClient[method]
+          .apply(this.restClient, args)
+          .then(body => {
+            resolve(body);
+          })
+          .catch(err => {
+            this.invokeRetry(err, operation, reject);
+          });
+      });
     });
-  });
 
-  return promise;
-};
+    return promise;
+  }
 
-RetryRestClient.prototype.invokeRetry = function(err, operation, reject) {
-  var ratelimits = this.extractRatelimits(err);
-  if (ratelimits) {
-    var delay = ratelimits.reset * 1000 - new Date().getTime();
-    if (delay > 0) {
-      this.retryWithDelay(delay, operation, err, reject);
+  invokeRetry(err, operation, reject) {
+    const ratelimits = this.extractRatelimits(err);
+    if (ratelimits) {
+      const delay = ratelimits.reset * 1000 - new Date().getTime();
+      if (delay > 0) {
+        this.retryWithDelay(delay, operation, err, reject);
+      } else {
+        this.retryWithImmediate(operation, err, reject);
+      }
     } else {
-      this.retryWithImmediate(operation, err, reject);
-    }
-  } else {
-    reject(err);
-  }
-};
-
-RetryRestClient.prototype.extractRatelimits = function(err) {
-  if (err && err.statusCode === 429 && err.originalError && err.originalError.response) {
-    var headers = err.originalError.response.header;
-    if (headers && headers['x-ratelimit-limit']) {
-      return {
-        limit: headers['x-ratelimit-limit'],
-        remaining: headers['x-ratelimit-remaining'],
-        reset: headers['x-ratelimit-reset']
-      };
+      reject(err);
     }
   }
 
-  return;
-};
+  extractRatelimits(err) {
+    if (err && err.statusCode === 429 && err.originalError && err.originalError.response) {
+      const headers = err.originalError.response.header;
+      if (headers && headers['x-ratelimit-limit']) {
+        return {
+          limit: headers['x-ratelimit-limit'],
+          remaining: headers['x-ratelimit-remaining'],
+          reset: headers['x-ratelimit-reset']
+        };
+      }
+    }
 
-RetryRestClient.prototype.retryWithImmediate = function(operation, err, reject) {
-  if (operation.retry(err)) {
     return;
   }
-  reject(err);
-};
 
-RetryRestClient.prototype.retryWithDelay = function(delay, operation, err, reject) {
-  setTimeout(() => {
+  retryWithImmediate(operation, err, reject) {
     if (operation.retry(err)) {
       return;
     }
     reject(err);
-  }, delay);
-};
+  }
+
+  retryWithDelay(delay, operation, err, reject) {
+    setTimeout(() => {
+      if (operation.retry(err)) {
+        return;
+      }
+      reject(err);
+    }, delay);
+  }
+}
 
 module.exports = RetryRestClient;

--- a/src/RetryRestClient.js
+++ b/src/RetryRestClient.js
@@ -1,4 +1,3 @@
-const Promise = require('bluebird');
 const retry = require('retry');
 const { ArgumentError } = require('rest-facade');
 const { assign } = Object;

--- a/src/auth/DatabaseAuthenticator.js
+++ b/src/auth/DatabaseAuthenticator.js
@@ -1,7 +1,4 @@
-var extend = require('util')._extend;
-
-var ArgumentError = require('rest-facade').ArgumentError;
-var RestClient = require('rest-facade').Client;
+const { ArgumentError, Client: RestClient } = require('rest-facade');
 
 /**
  * @class
@@ -15,280 +12,271 @@ var RestClient = require('rest-facade').Client;
  * @param  {String}              [options.clientId] Default client ID.
  * @param  {OAuthAuthenticator}  oauth              OAuthAuthenticator instance.
  */
-var DatabaseAuthenticator = function(options, oauth) {
-  if (!options) {
-    throw new ArgumentError('Missing authenticator options');
-  }
+class DatabaseAuthenticator {
+  constructor(options, oauth) {
+    if (!options) {
+      throw new ArgumentError('Missing authenticator options');
+    }
 
-  if (typeof options !== 'object') {
-    throw new ArgumentError('The authenticator options must be an object');
+    if (typeof options !== 'object') {
+      throw new ArgumentError('The authenticator options must be an object');
+    }
+
+    /**
+     * Options object for the Rest Client instance.
+     *
+     * @type {Object}z
+     */
+    const clientOptions = {
+      errorFormatter: { message: 'message', name: 'error' }
+    };
+
+    const { clientId, baseUrl } = options;
+
+    this.oauth = oauth;
+    this.dbConnections = new RestClient(`${baseUrl}/dbconnections/:type`, clientOptions);
+    this.clientId = clientId;
   }
 
   /**
-   * Options object for the Rest Client instace.
+   * Sign in using a database or active directory service.
+   * @method    signIn
+   * @memberOf  module:auth.DatabaseAuthenticator.prototype
    *
-   * @type {Object}
+   * @example <caption>
+   *   Given the user credentials and the connection specified, it will do the
+   *   authentication on the provider and return a JSON with the `access_token`
+   *   and `id_token`. Find more information about the structure of the data
+   *   object in the <a href="https://auth0.com/docs/auth-api#!#post--oauth-ro">
+   *   API docs</a>.
+   * </caption>
+   *
+   * const data = {
+   *   username: '{USERNAME}',
+   *   password: '{PASSWORD}',
+   *   connection: 'Username-Password-Authentication' // Optional field.
+   * };
+   *
+   * auth0.database.signIn(data, function (err, userData) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   *
+   *   console.log(userData);
+   * });
+   *
+   * @param   {Object}    data              User credentials object.
+   * @param   {String}    data.username     Username.
+   * @param   {String}    data.password     User password.
+   * @param   {String}    data.connection   Identity provider in use.
+   * @param   {Function}  [cb]              Method callback.
+   *
+   * @return  {Promise|undefined}
    */
-  var clientOptions = {
-    errorFormatter: { message: 'message', name: 'error' }
-  };
+  signIn(userData, cb) {
+    const data = Object.assign(
+      {
+        connection: 'Username-Password-Authentication'
+      },
+      userData
+    );
 
-  this.oauth = oauth;
-  this.dbConnections = new RestClient(options.baseUrl + '/dbconnections/:type', clientOptions);
-  this.clientId = options.clientId;
-};
+    if (!userData || typeof userData !== 'object') {
+      throw new ArgumentError('Missing user data object');
+    }
 
-/**
- * Sign in using a database or active directory service.
- * @method    signIn
- * @memberOf  module:auth.DatabaseAuthenticator.prototype
- *
- * @example <caption>
- *   Given the user credentials and the connection specified, it will do the
- *   authentication on the provider and return a JSON with the `access_token`
- *   and `id_token`. Find more information about the structure of the data
- *   object in the <a href="https://auth0.com/docs/auth-api#!#post--oauth-ro">
- *   API docs</a>.
- * </caption>
- *
- * var data = {
- *   username: '{USERNAME}',
- *   password: '{PASSWORD}',
- *   connection: 'Username-Password-Authentication' // Optional field.
- * };
- *
- * auth0.database.signIn(data, function (err, userData) {
- *   if (err) {
- *     // Handle error.
- *   }
- *
- *   console.log(userData);
- * });
- *
- * @param   {Object}    data              User credentials object.
- * @param   {String}    data.username     Username.
- * @param   {String}    data.password     User password.
- * @param   {String}    data.connection   Identity provider in use.
- * @param   {Function}  [cb]              Method callback.
- *
- * @return  {Promise|undefined}
- */
-DatabaseAuthenticator.prototype.signIn = function(userData, cb) {
-  var defaultFields = {
-    connection: 'Username-Password-Authentication'
-  };
-  var data = extend(defaultFields, userData);
+    if (typeof data.username !== 'string' || data.username.trim().length === 0) {
+      throw new ArgumentError('username field is required');
+    }
 
-  if (!userData || typeof userData !== 'object') {
-    throw new ArgumentError('Missing user data object');
+    if (typeof data.password !== 'string' || data.password.trim().length === 0) {
+      throw new ArgumentError('password field is required');
+    }
+
+    return this.oauth.signIn(data, cb);
   }
 
-  if (typeof data.username !== 'string' || data.username.trim().length === 0) {
-    throw new ArgumentError('username field is required');
+  /**
+   * Sign up using a database or active directory service.
+   * @method    signUp
+   * @memberOf  module:auth.DatabaseAuthenticator.prototype
+   *
+   * @example <caption>
+   *   Given the user credentials, the connection specified and (optionally) the
+   *   client ID, it will create a new user. Find more information in the
+   *   <a href="https://auth0.com/docs/auth-api#!#post--dbconnections-signup">
+   *   API Docs</a>.
+   * </caption>
+   *
+   * const data = {
+   *   email: '{EMAIL}',
+   *   password: '{PASSWORD}',
+   *   connection: 'Username-Password-Authentication' // Optional field.
+   * };
+   *
+   * auth0.database.signUp(data, function (err, userData) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   *
+   *   console.log(userData);
+   * });
+   *
+   * @param   {Object}    data              User credentials object.
+   * @param   {String}    data.email        User email address.
+   * @param   {String}    data.password     User password.
+   * @param   {String}    data.connection   Identity provider in use.
+   * @param   {Function}  [cb]              Method callback.
+   *
+   * @return  {Promise|undefined}
+   */
+  signUp(userData, cb) {
+    const params = { type: 'signup' };
+    const data = Object.assign({ client_id: this.clientId }, userData);
+
+    if (!userData || typeof userData !== 'object') {
+      throw new ArgumentError('Missing user data object');
+    }
+
+    if (typeof data.email !== 'string' || data.email.trim().length === 0) {
+      throw new ArgumentError('email field is required');
+    }
+
+    if (typeof data.password !== 'string' || data.password.trim().length === 0) {
+      throw new ArgumentError('password field is required');
+    }
+
+    if (typeof data.connection !== 'string' || data.connection.trim().length === 0) {
+      throw new ArgumentError('connection field is required');
+    }
+
+    if (cb && cb instanceof Function) {
+      return this.dbConnections.create(params, data, cb);
+    }
+
+    return this.dbConnections.create(params, data);
   }
 
-  if (typeof data.password !== 'string' || data.password.trim().length === 0) {
-    throw new ArgumentError('password field is required');
+  /**
+   * Change password using a database or active directory service.
+   *
+   * @method    changePassword
+   * @memberOf  module:auth.DatabaseAuthenticator.prototype
+   *
+   * @example <caption>
+   *   Given the user email, the connection specified and the new password to
+   *   use, Auth0 will send a forgot password email. Once the user clicks on the
+   *   confirm password change link, the new password specified in this POST will
+   *   be set to this user. Find more information in the
+   *   <a href="https://auth0.com/docs/auth-api#!#post--dbconnections-change_password>
+   *   API Docs</a>.
+   * </caption>
+   *
+   * const data = {
+   *   email: '{EMAIL}',
+   *   password: '{PASSWORD}',
+   *   connection: 'Username-Password-Authentication'
+   * };
+   *
+   * auth0.database.changePassword(data, function (err, message) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   *
+   *   console.log(message);
+   * });
+   *
+   * @param   {Object}    data              User credentials object.
+   * @param   {String}    data.email        User email address.
+   * @param   {String}    data.password     New password.
+   * @param   {String}    data.connection   Identity provider in use.
+   * @param   {Function}  [cb]              Method callback.
+   *
+   * @return  {Promise|undefined}
+   */
+  changePassword(userData, cb) {
+    const params = { type: 'change_password' };
+    const data = Object.assign({ client_id: this.clientId }, userData);
+
+    if (!userData || typeof userData !== 'object') {
+      throw new ArgumentError('Missing user data object');
+    }
+
+    if (typeof data.email !== 'string' || data.email.trim().length === 0) {
+      throw new ArgumentError('email field is required');
+    }
+
+    if (typeof data.password !== 'string' || data.password.trim().length === 0) {
+      throw new ArgumentError('password field is required');
+    }
+
+    if (typeof data.connection !== 'string' || data.connection.trim().length === 0) {
+      throw new ArgumentError('connection field is required');
+    }
+
+    if (cb && cb instanceof Function) {
+      return this.dbConnections.create(params, data, cb);
+    }
+
+    return this.dbConnections.create(params, data);
   }
 
-  return this.oauth.signIn(data, cb);
-};
+  /**
+   * Request a change password email using a database or active directory service.
+   *
+   * @method    requestChangePasswordEmail
+   * @memberOf  module:auth.DatabaseAuthenticator.prototype
+   *
+   * @example <caption>
+   *   Given the user email, the connection specified, Auth0 will send a change
+   *   password email. once the user clicks on the confirm password change link,
+   *   the new password specified in this POST will be set to this user. Find more
+   *   information in the <a href="https://auth0.com/docs/auth-api#!#post--dbconnections-change_password>
+   *   API Docs</a>.
+   * </caption>
+   *
+   * const data = {
+   *   email: '{EMAIL}',
+   *   connection: 'Username-Password-Authentication'
+   * };
+   *
+   * auth0.database.requestChangePasswordEmail(data, function (err, message) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   *
+   *   console.log(message);
+   * });
+   *
+   * @param   {Object}    data              User credentials object.
+   * @param   {String}    data.email        User email address.
+   * @param   {String}    data.connection   Identity provider in use.
+   * @param   {Function}  [cb]              Method callback.
+   *
+   * @return  {Promise|undefined}
+   */
+  requestChangePasswordEmail(userData, cb) {
+    const params = { type: 'change_password' };
+    const data = Object.assign({ client_id: this.clientId }, userData);
 
-/**
- * Sign up using a database or active directory service.
- * @method    signUp
- * @memberOf  module:auth.DatabaseAuthenticator.prototype
- *
- * @example <caption>
- *   Given the user credentials, the connection specified and (optionally) the
- *   client ID, it will create a new user. Find more information in the
- *   <a href="https://auth0.com/docs/auth-api#!#post--dbconnections-signup">
- *   API Docs</a>.
- * </caption>
- *
- * var data = {
- *   email: '{EMAIL}',
- *   password: '{PASSWORD}',
- *   connection: 'Username-Password-Authentication' // Optional field.
- * };
- *
- * auth0.database.signUp(data, function (err, userData) {
- *   if (err) {
- *     // Handle error.
- *   }
- *
- *   console.log(userData);
- * });
- *
- * @param   {Object}    data              User credentials object.
- * @param   {String}    data.email        User email address.
- * @param   {String}    data.password     User password.
- * @param   {Stinrg}    data.connection   Identity provider in use.
- * @param   {Function}  [cb]              Method callback.
- *
- * @return  {Promise|undefined}
- */
-DatabaseAuthenticator.prototype.signUp = function(userData, cb) {
-  var params = {
-    type: 'signup'
-  };
-  var defaultFields = {
-    client_id: this.clientId
-  };
-  var data = extend(defaultFields, userData);
+    if (!userData || typeof userData !== 'object') {
+      throw new ArgumentError('Missing user data object');
+    }
 
-  if (!userData || typeof userData !== 'object') {
-    throw new ArgumentError('Missing user data object');
+    if (typeof data.email !== 'string' || data.email.trim().length === 0) {
+      throw new ArgumentError('email field is required');
+    }
+
+    if (typeof data.connection !== 'string' || data.connection.trim().length === 0) {
+      throw new ArgumentError('connection field is required');
+    }
+
+    if (cb && cb instanceof Function) {
+      return this.dbConnections.create(params, data, cb);
+    }
+
+    return this.dbConnections.create(params, data);
   }
-
-  if (typeof data.email !== 'string' || data.email.trim().length === 0) {
-    throw new ArgumentError('email field is required');
-  }
-
-  if (typeof data.password !== 'string' || data.password.trim().length === 0) {
-    throw new ArgumentError('password field is required');
-  }
-
-  if (typeof data.connection !== 'string' || data.connection.trim().length === 0) {
-    throw new ArgumentError('connection field is required');
-  }
-
-  if (cb && cb instanceof Function) {
-    return this.dbConnections.create(params, data, cb);
-  }
-
-  return this.dbConnections.create(params, data);
-};
-
-/**
- * Change password using a database or active directory service.
- *
- * @method    changePassword
- * @memberOf  module:auth.DatabaseAuthenticator.prototype
- *
- * @example <caption>
- *   Given the user email, the connection specified and the new password to
- *   use, Auth0 will send a forgot password email. Once the user clicks on the
- *   confirm password change link, the new password specified in this POST will
- *   be set to this user. Find more information in the
- *   <a href="https://auth0.com/docs/auth-api#!#post--dbconnections-change_password>
- *   API Docs</a>.
- * </caption>
- *
- * var data = {
- *   email: '{EMAIL}',
- *   password: '{PASSWORD}',
- *   connection: 'Username-Password-Authentication'
- * };
- *
- * auth0.database.changePassword(data, function (err, message) {
- *   if (err) {
- *     // Handle error.
- *   }
- *
- *   console.log(message);
- * });
- *
- * @param   {Object}    data              User credentials object.
- * @param   {String}    data.email        User email address.
- * @param   {String}    data.password     New password.
- * @param   {String}    data.connection   Identity provider in use.
- * @param   {Function}  [cb]              Method callback.
- *
- * @return  {Promise|undefined}
- */
-DatabaseAuthenticator.prototype.changePassword = function(userData, cb) {
-  var params = {
-    type: 'change_password'
-  };
-  var defaultFields = {
-    client_id: this.clientId
-  };
-  var data = extend(defaultFields, userData);
-
-  if (!userData || typeof userData !== 'object') {
-    throw new ArgumentError('Missing user data object');
-  }
-
-  if (typeof data.email !== 'string' || data.email.trim().length === 0) {
-    throw new ArgumentError('email field is required');
-  }
-
-  if (typeof data.password !== 'string' || data.password.trim().length === 0) {
-    throw new ArgumentError('password field is required');
-  }
-
-  if (typeof data.connection !== 'string' || data.connection.trim().length === 0) {
-    throw new ArgumentError('connection field is required');
-  }
-
-  if (cb && cb instanceof Function) {
-    return this.dbConnections.create(params, data, cb);
-  }
-
-  return this.dbConnections.create(params, data);
-};
-
-/**
- * Request a change password email using a database or active directory service.
- *
- * @method    requestChangePasswordEmail
- * @memberOf  module:auth.DatabaseAuthenticator.prototype
- *
- * @example <caption>
- *   Given the user email, the connection specified, Auth0 will send a change
- *   password email. once the user clicks on the confirm password change link,
- *   the new password specified in this POST will be set to this user. Find more
- *   information in the <a href="https://auth0.com/docs/auth-api#!#post--dbconnections-change_password>
- *   API Docs</a>.
- * </caption>
- *
- * var data = {
- *   email: '{EMAIL}',
- *   connection: 'Username-Password-Authentication'
- * };
- *
- * auth0.database.requestChangePasswordEmail(data, function (err, message) {
- *   if (err) {
- *     // Handle error.
- *   }
- *
- *   console.log(message);
- * });
- *
- * @param   {Object}    data              User credentials object.
- * @param   {String}    data.email        User email address.
- * @param   {String}    data.connection   Identity provider in use.
- * @param   {Function}  [cb]              Method callback.
- *
- * @return  {Promise|undefined}
- */
-DatabaseAuthenticator.prototype.requestChangePasswordEmail = function(userData, cb) {
-  var params = {
-    type: 'change_password'
-  };
-  var defaultFields = {
-    client_id: this.clientId
-  };
-  var data = extend(defaultFields, userData);
-
-  if (!userData || typeof userData !== 'object') {
-    throw new ArgumentError('Missing user data object');
-  }
-
-  if (typeof data.email !== 'string' || data.email.trim().length === 0) {
-    throw new ArgumentError('email field is required');
-  }
-
-  if (typeof data.connection !== 'string' || data.connection.trim().length === 0) {
-    throw new ArgumentError('connection field is required');
-  }
-
-  if (cb && cb instanceof Function) {
-    return this.dbConnections.create(params, data, cb);
-  }
-
-  return this.dbConnections.create(params, data);
-};
+}
 
 module.exports = DatabaseAuthenticator;

--- a/src/auth/OAUthWithIDTokenValidation.js
+++ b/src/auth/OAUthWithIDTokenValidation.js
@@ -1,4 +1,3 @@
-const Promise = require('bluebird');
 const jwt = require('jsonwebtoken');
 const jwksClient = require('jwks-rsa');
 

--- a/src/auth/OAuthAuthenticator.js
+++ b/src/auth/OAuthAuthenticator.js
@@ -1,9 +1,5 @@
-var extend = require('util')._extend;
-
-var ArgumentError = require('rest-facade').ArgumentError;
-var RestClient = require('rest-facade').Client;
-
-var OAUthWithIDTokenValidation = require('./OAUthWithIDTokenValidation');
+const { ArgumentError, Client: RestClient } = require('rest-facade');
+const OAUthWithIDTokenValidation = require('./OAUthWithIDTokenValidation');
 
 /**
  * @class
@@ -18,302 +14,304 @@ var OAUthWithIDTokenValidation = require('./OAUthWithIDTokenValidation');
  * @param  {String}              [options.clientId]     Default client ID.
  * @param  {String}              [options.clientSecret] Default client Secret.
  */
-var OAuthAuthenticator = function(options) {
-  if (!options) {
-    throw new ArgumentError('Missing authenticator options');
-  }
+class OAuthAuthenticator {
+  constructor(options) {
+    if (!options) {
+      throw new ArgumentError('Missing authenticator options');
+    }
 
-  if (typeof options !== 'object') {
-    throw new ArgumentError('The authenticator options must be an object');
+    if (typeof options !== 'object') {
+      throw new ArgumentError('The authenticator options must be an object');
+    }
+
+    /**
+     * Options object for the Rest Client instance.
+     *
+     * @type {Object}
+     */
+    const clientOptions = {
+      errorFormatter: { message: 'message', name: 'error' }
+    };
+
+    const { clientId, clientSecret, baseUrl } = options;
+
+    this.oauth = new RestClient(`${baseUrl}/oauth/:type`, clientOptions);
+    this.oauthWithIDTokenValidation = new OAUthWithIDTokenValidation(this.oauth, options);
+    this.clientId = clientId;
+    this.clientSecret = clientSecret;
   }
 
   /**
-   * Options object for the Rest Client instace.
+   * Sign in using a username and password.
    *
-   * @type {Object}
+   * @method    signIn
+   * @memberOf  module:auth.OAuthAuthenticator.prototype
+   *
+   * @example <caption>
+   *   Given the user's credentials and the connection specified, it
+   *   will return a JSON with the access_token and id_token.
+   *   More information in the
+   *   <a href="https://auth0.com/docs/api/authentication#database-ad-ldap-active-">
+   *     API Docs
+   *   </a>.
+   * </caption>
+   *
+   * const data = {
+   *   client_id: '{CLIENT_ID}',  // Optional field.
+   *   username: '{USERNAME}',
+   *   password: '{PASSWORD}',
+   *   connection: '{CONNECTION_NAME}',
+   *   scope: 'openid'  // Optional field.
+   * };
+   *
+   * auth0.oauth.signIn(data, function (err, userData) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   *
+   *   console.log(userData);
+   * });
+   *
+   * @param   {Object}    userData              User credentials object.
+   * @param   {String}    userData.username     Username.
+   * @param   {String}    userData.password     User password.
+   * @param   {String}    userData.connection   The identity provider in use.
+   *
+   * @return  {Promise|undefined}
    */
-  var clientOptions = {
-    errorFormatter: { message: 'message', name: 'error' }
-  };
+  signIn(userData, cb) {
+    const params = { type: 'ro' };
+    const data = Object.assign(
+      {
+        client_id: this.clientId,
+        grant_type: 'password',
+        scope: 'openid'
+      },
+      userData
+    );
 
-  this.oauth = new RestClient(options.baseUrl + '/oauth/:type', clientOptions);
-  this.oauthWithIDTokenValidation = new OAUthWithIDTokenValidation(this.oauth, options);
-  this.clientId = options.clientId;
-  this.clientSecret = options.clientSecret;
-};
+    if (!userData || typeof userData !== 'object') {
+      throw new ArgumentError('Missing user data object');
+    }
 
-/**
- * Sign in using a username and password.
- *
- * @method    signIn
- * @memberOf  module:auth.OAuthAuthenticator.prototype
- *
- * @example <caption>
- *   Given the user's credentials and the connection specified, it
- *   will return a JSON with the access_token and id_token.
- *   More information in the
- *   <a href="https://auth0.com/docs/api/authentication#database-ad-ldap-active-">
- *     API Docs
- *   </a>.
- * </caption>
- *
- * var data = {
- *   client_id: '{CLIENT_ID}',  // Optional field.
- *   username: '{USERNAME}',
- *   password: '{PASSWORD}',
- *   connection: '{CONNECTION_NAME}',
- *   scope: 'openid'  // Optional field.
- * };
- *
- * auth0.oauth.signIn(data, function (err, userData) {
- *   if (err) {
- *     // Handle error.
- *   }
- *
- *   console.log(userData);
- * });
- *
- * @param   {Object}    userData              User credentials object.
- * @param   {String}    userData.username     Username.
- * @param   {String}    userData.password     User password.
- * @param   {String}    userData.connection   The identity provider in use.
- *
- * @return  {Promise|undefined}
- */
-OAuthAuthenticator.prototype.signIn = function(userData, cb) {
-  var params = {
-    type: 'ro'
-  };
-  var defaultFields = {
-    client_id: this.clientId,
-    grant_type: 'password',
-    scope: 'openid'
-  };
-  var data = extend(defaultFields, userData);
+    if (typeof data.connection !== 'string' || data.connection.split().length === 0) {
+      throw new ArgumentError('connection field is required');
+    }
 
-  if (!userData || typeof userData !== 'object') {
-    throw new ArgumentError('Missing user data object');
+    if (cb && cb instanceof Function) {
+      return this.oauthWithIDTokenValidation.create(params, data, cb);
+    }
+
+    return this.oauthWithIDTokenValidation.create(params, data);
   }
 
-  if (typeof data.connection !== 'string' || data.connection.split().length === 0) {
-    throw new ArgumentError('connection field is required');
+  /**
+   * Sign in using a username and password
+   *
+   * @method    passwordGrant
+   * @memberOf  module:auth.OAuthAuthenticator.prototype
+   *
+   * @example <caption>
+   *   Given the user's credentials perform the OAuth password grant
+   *   or Password Realm grant if a realm is provided,
+   *   it will return a JSON with the access_token and id_token.
+   *   More information in the
+   *   <a href="https://auth0.com/docs/api/authentication#resource-owner-password">
+   *     API Docs
+   *   </a>.
+   * </caption>
+   *
+   * const data = {
+   *   client_id: '{CLIENT_ID}',  // Optional field.
+   *   username: '{USERNAME}',
+   *   password: '{PASSWORD}',
+   *   realm: '{CONNECTION_NAME}', // Optional field.
+   *   scope: 'openid'  // Optional field.
+   * };
+   *
+   * auth0.oauth.passwordGrant(data, function (err, userData) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   *
+   *   console.log(userData);
+   * });
+   *
+   * @param   {Object}    userData              User credentials object.
+   * @param   {String}    userData.username     Username.
+   * @param   {String}    userData.password     User password.
+   * @param   {String}    [userData.realm]      Name of the realm to use to authenticate or the connection name
+   *
+   * @return  {Promise|undefined}
+   */
+  passwordGrant(userData, cb) {
+    const params = { type: 'token' };
+    const data = Object.assign(
+      {
+        client_id: this.clientId,
+        client_secret: this.clientSecret,
+        grant_type: 'password'
+      },
+      userData
+    );
+
+    if (!userData || typeof userData !== 'object') {
+      throw new ArgumentError('Missing user data object');
+    }
+
+    if (typeof data.username !== 'string' || data.username.split().length === 0) {
+      throw new ArgumentError('username field is required');
+    }
+
+    if (typeof data.password !== 'string' || data.password.split().length === 0) {
+      throw new ArgumentError('password field is required');
+    }
+
+    if (typeof data.realm === 'string' && data.realm.split().length !== 0) {
+      data.grant_type = 'http://auth0.com/oauth/grant-type/password-realm';
+    }
+
+    if (cb && cb instanceof Function) {
+      return this.oauthWithIDTokenValidation.create(params, data, cb);
+    }
+
+    return this.oauthWithIDTokenValidation.create(params, data);
   }
 
-  if (cb && cb instanceof Function) {
-    return this.oauthWithIDTokenValidation.create(params, data, cb);
+  /**
+   * Sign in using a social provider access token.
+   *
+   * @method    socialSignIn
+   * @memberOf  module:auth.OAuthAuthenticator.prototype
+   *
+   * @param   {Object}    data                User credentials object.
+   * @param   {String}    data.access_token   User access token.
+   * @param   {String}    data.connection     Identity provider.
+   *
+   * @return  {Promise|undefined}
+   */
+  socialSignIn(data, cb) {
+    const params = { type: 'access_token' };
+
+    if (typeof data !== 'object') {
+      throw new ArgumentError('Missing user credential objects');
+    }
+
+    if (typeof data.access_token !== 'string' || data.access_token.trim().length === 0) {
+      throw new ArgumentError('access_token field is required');
+    }
+
+    if (typeof data.connection !== 'string' || data.connection.trim().length === 0) {
+      throw new ArgumentError('connection field is required');
+    }
+
+    if (cb && cb instanceof Function) {
+      return this.oauth.create(params, data, cb);
+    }
+
+    return this.oauth.create(params, data);
   }
 
-  return this.oauthWithIDTokenValidation.create(params, data);
-};
+  clientCredentialsGrant(options, cb) {
+    const params = { type: 'token' };
+    const { clientId: client_id, clientSecret: client_secret } = this;
 
-/**
- * Sign in using a username and password
- *
- * @method    passwordGrant
- * @memberOf  module:auth.OAuthAuthenticator.prototype
- *
- * @example <caption>
- *   Given the user's credentials perform the OAuth password grant
- *   or Password Realm grant if a realm is provided,
- *   it will return a JSON with the access_token and id_token.
- *   More information in the
- *   <a href="https://auth0.com/docs/api/authentication#resource-owner-password">
- *     API Docs
- *   </a>.
- * </caption>
- *
- * var data = {
- *   client_id: '{CLIENT_ID}',  // Optional field.
- *   username: '{USERNAME}',
- *   password: '{PASSWORD}',
- *   realm: '{CONNECTION_NAME}', // Optional field.
- *   scope: 'openid'  // Optional field.
- * };
- *
- * auth0.oauth.passwordGrant(data, function (err, userData) {
- *   if (err) {
- *     // Handle error.
- *   }
- *
- *   console.log(userData);
- * });
- *
- * @param   {Object}    userData              User credentials object.
- * @param   {String}    userData.username     Username.
- * @param   {String}    userData.password     User password.
- * @param   {String}    [userData.realm]      Name of the realm to use to authenticate or the connection name
- *
- * @return  {Promise|undefined}
- */
-OAuthAuthenticator.prototype.passwordGrant = function(userData, cb) {
-  var params = {
-    type: 'token'
-  };
-  var defaultFields = {
-    client_id: this.clientId,
-    client_secret: this.clientSecret,
-    grant_type: 'password'
-  };
-  var data = extend(defaultFields, userData);
+    const data = Object.assign(
+      {
+        grant_type: 'client_credentials',
+        client_id,
+        client_secret
+      },
+      options
+    );
 
-  if (!userData || typeof userData !== 'object') {
-    throw new ArgumentError('Missing user data object');
+    if (!options || typeof options !== 'object') {
+      throw new ArgumentError('Missing options object');
+    }
+
+    if (!data.client_id || data.client_id.trim().length === 0) {
+      throw new ArgumentError('client_id field is required');
+    }
+
+    if (!data.client_secret || data.client_secret.trim().length === 0) {
+      throw new ArgumentError('client_secret field is required');
+    }
+
+    if (cb && cb instanceof Function) {
+      return this.oauth.create(params, data, cb);
+    }
+
+    return this.oauth.create(params, data);
   }
 
-  if (typeof data.username !== 'string' || data.username.split().length === 0) {
-    throw new ArgumentError('username field is required');
+  /**
+   * Sign in using an authorization code
+   *
+   * @method    authorizationCodeGrant
+   * @memberOf  module:auth.OAuthAuthenticator.prototype
+   *
+   * @example <caption>
+   *   Given the code returned in the URL params after the redirect
+   *   from successful authentication, exchange the code for auth0
+   *   credentials. It will return JSON with the access_token and id_token.
+   *   More information in the
+   *   <a href="https://auth0.com/docs/api/authentication#authorization-code-grant">
+   *     API Docs
+   *   </a>.
+   * </caption>
+   *
+   * const data = {
+   *   code: '{CODE}',
+   *   redirect_uri: '{REDIRECT_URI}',
+   *   client_id: '{CLIENT_ID}',  // Optional field.
+   *   client_secret: '{CLIENT_SECRET}',  // Optional field.
+   * };
+   *
+   * auth0.oauth.authorizationCodeGrant(data, function (err, userData) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   *
+   *   console.log(userData);
+   * });
+   *
+   * @param   {Object}    data                  Authorization code payload
+   * @param   {String}    userData.code         Code in URL returned after authentication
+   * @param   {String}    userData.redirect_uri The URL to which Auth0 will redirect the browser after authorization has been granted by the user.
+   *
+   * @return  {Promise|undefined}
+   */
+  authorizationCodeGrant(options, cb) {
+    const params = { type: 'token' };
+    const { clientId: client_id, clientSecret: client_secret } = this;
+
+    const data = Object.assign(
+      {
+        grant_type: 'authorization_code',
+        client_id,
+        client_secret
+      },
+      options
+    );
+
+    if (!options || typeof options !== 'object') {
+      throw new ArgumentError('Missing options object');
+    }
+
+    if (!data.code || data.code.trim().length === 0) {
+      throw new ArgumentError('code field is required');
+    }
+
+    if (!data.redirect_uri || data.redirect_uri.trim().length === 0) {
+      throw new ArgumentError('redirect_uri field is required');
+    }
+
+    if (cb && cb instanceof Function) {
+      return this.oauthWithIDTokenValidation.create(params, data, cb);
+    }
+
+    return this.oauthWithIDTokenValidation.create(params, data);
   }
-
-  if (typeof data.password !== 'string' || data.password.split().length === 0) {
-    throw new ArgumentError('password field is required');
-  }
-
-  if (typeof data.realm === 'string' && data.realm.split().length !== 0) {
-    data.grant_type = 'http://auth0.com/oauth/grant-type/password-realm';
-  }
-
-  if (cb && cb instanceof Function) {
-    return this.oauthWithIDTokenValidation.create(params, data, cb);
-  }
-
-  return this.oauthWithIDTokenValidation.create(params, data);
-};
-
-/**
- * Sign in using a social provider access token.
- *
- * @method    socialSignIn
- * @memberOf  module:auth.OAuthAuthenticator.prototype
- *
- * @param   {Object}    data                User credentials object.
- * @param   {String}    data.access_token   User access token.
- * @param   {String}    data.connection     Identity provider.
- *
- * @return  {Promise|undefined}
- */
-OAuthAuthenticator.prototype.socialSignIn = function(data, cb) {
-  var params = {
-    type: 'access_token'
-  };
-
-  if (typeof data !== 'object') {
-    throw new ArgumentError('Missing user credential objects');
-  }
-
-  if (typeof data.access_token !== 'string' || data.access_token.trim().length === 0) {
-    throw new ArgumentError('access_token field is required');
-  }
-
-  if (typeof data.connection !== 'string' || data.connection.trim().length === 0) {
-    throw new ArgumentError('connection field is required');
-  }
-
-  if (cb && cb instanceof Function) {
-    return this.oauth.create(params, data, cb);
-  }
-
-  return this.oauth.create(params, data);
-};
-
-OAuthAuthenticator.prototype.clientCredentialsGrant = function(options, cb) {
-  var params = {
-    type: 'token'
-  };
-
-  var defaultFields = {
-    grant_type: 'client_credentials',
-    client_id: this.clientId,
-    client_secret: this.clientSecret
-  };
-
-  var data = extend(defaultFields, options);
-
-  if (!options || typeof options !== 'object') {
-    throw new ArgumentError('Missing options object');
-  }
-
-  if (!data.client_id || data.client_id.trim().length === 0) {
-    throw new ArgumentError('client_id field is required');
-  }
-
-  if (!data.client_secret || data.client_secret.trim().length === 0) {
-    throw new ArgumentError('client_secret field is required');
-  }
-
-  if (cb && cb instanceof Function) {
-    return this.oauth.create(params, data, cb);
-  }
-
-  return this.oauth.create(params, data);
-};
-
-/**
- * Sign in using an authorization code
- *
- * @method    authorizationCodeGrant
- * @memberOf  module:auth.OAuthAuthenticator.prototype
- *
- * @example <caption>
- *   Given the code returned in the URL params after the redirect
- *   from successful authentication, exchange the code for auth0
- *   credentials. It will return JSON with the access_token and id_token.
- *   More information in the
- *   <a href="https://auth0.com/docs/api/authentication#authorization-code-grant">
- *     API Docs
- *   </a>.
- * </caption>
- *
- * var data = {
- *   code: '{CODE}',
- *   redirect_uri: '{REDIRECT_URI}',
- *   client_id: '{CLIENT_ID}',  // Optional field.
- *   client_secret: '{CLIENT_SECRET}',  // Optional field.
- * };
- *
- * auth0.oauth.authorizationCodeGrant(data, function (err, userData) {
- *   if (err) {
- *     // Handle error.
- *   }
- *
- *   console.log(userData);
- * });
- *
- * @param   {Object}    data                  Authorization code payload
- * @param   {String}    userData.code         Code in URL returned after authentication
- * @param   {String}    userData.redirect_uri The URL to which Auth0 will redirect the browser after authorization has been granted by the user.
- *
- * @return  {Promise|undefined}
- */
-OAuthAuthenticator.prototype.authorizationCodeGrant = function(options, cb) {
-  var params = {
-    type: 'token'
-  };
-
-  var defaultFields = {
-    grant_type: 'authorization_code',
-    client_id: this.clientId,
-    client_secret: this.clientSecret
-  };
-
-  var data = extend(defaultFields, options);
-
-  if (!options || typeof options !== 'object') {
-    throw new ArgumentError('Missing options object');
-  }
-
-  if (!data.code || data.code.trim().length === 0) {
-    throw new ArgumentError('code field is required');
-  }
-
-  if (!data.redirect_uri || data.redirect_uri.trim().length === 0) {
-    throw new ArgumentError('redirect_uri field is required');
-  }
-
-  if (cb && cb instanceof Function) {
-    return this.oauthWithIDTokenValidation.create(params, data, cb);
-  }
-
-  return this.oauthWithIDTokenValidation.create(params, data);
-};
+}
 
 module.exports = OAuthAuthenticator;

--- a/src/auth/PasswordlessAuthenticator.js
+++ b/src/auth/PasswordlessAuthenticator.js
@@ -1,7 +1,4 @@
-var extend = require('util')._extend;
-
-var ArgumentError = require('rest-facade').ArgumentError;
-var RestClient = require('rest-facade').Client;
+const { ArgumentError, Client: RestClient } = require('rest-facade');
 
 /**
  * @class
@@ -14,222 +11,217 @@ var RestClient = require('rest-facade').Client;
  * @param  {String}              [options.clientId] Default client ID.
  * @param  {OAuthAuthenticator}  oauth              OAuthAuthenticator instance.
  */
-var PasswordlessAuthenticator = function(options, oauth) {
-  if (!options) {
-    throw new ArgumentError('Missing authenticator options');
-  }
+class PasswordlessAuthenticator {
+  constructor(options, oauth) {
+    if (!options) {
+      throw new ArgumentError('Missing authenticator options');
+    }
 
-  if (typeof options !== 'object') {
-    throw new ArgumentError('The authenticator options must be an object');
+    if (typeof options !== 'object') {
+      throw new ArgumentError('The authenticator options must be an object');
+    }
+
+    /**
+     * Options object for the Rest Client instance.
+     *
+     * @type {Object}
+     */
+    const clientOptions = {
+      errorFormatter: { message: 'message', name: 'error' }
+    };
+
+    const { baseUrl, clientId } = options;
+
+    this.oauth = oauth;
+    this.passwordless = new RestClient(`${baseUrl}/passwordless/start`, clientOptions);
+    this.clientId = clientId;
   }
 
   /**
-   * Options object for the Rest Client instace.
+   * Sign in with the given user credentials.
    *
-   * @type {Object}
+   * @method    signIn
+   * @memberOf  module:auth.PasswordlessAuthenticator.prototype
+   * @example <caption>
+   *   Given the user credentials (`phone_number` and `code`), it will do the
+   *   authentication on the provider and return a JSON with the `access_token`
+   *   and `id_token`.
+   * </caption>
+   *
+   * const data = {
+   *   username: '{PHONE_NUMBER}',
+   *   password: '{VERIFICATION_CODE}'
+   * };
+   *
+   * auth0.passwordless.signIn(data, function (err) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   * });
+   *
+   * @example <caption>
+   *   The user data object has the following structure.
+   * </caption>
+   *
+   * {
+   *   id_token: String,
+   *   access_token: String,
+   *   token_type: String
+   * }
+   *
+   * @param   {Object}    userData              User credentials object.
+   * @param   {String}    userData.username     Username.
+   * @param   {String}    userData.password     Password.
+   * @param   {String}    [userData.connection=sms]  Connection string: "sms" or "email".
+   * @param   {String}    [userData.client_id]  Client ID.
+   * @param   {Function}  [cb]                  Method callback.
+   *
+   * @return  {Promise|undefined}
    */
-  var clientOptions = {
-    errorFormatter: { message: 'message', name: 'error' }
-  };
+  signIn(userData, cb) {
+    const data = Object.assign({ client_id: this.clientId }, userData);
 
-  this.oauth = oauth;
-  this.passwordless = new RestClient(options.baseUrl + '/passwordless/start', clientOptions);
-  this.clientId = options.clientId;
-};
+    // Don't let the user override the connection nor the grant type.
+    if (!data.connection || (data.connection !== 'email' && data.connection !== 'sms')) {
+      data.connection = 'sms';
+    }
+    data.grant_type = 'password';
 
-/**
- * Sign in with the given user credentials.
- *
- * @method    signIn
- * @memberOf  module:auth.PasswordlessAuthenticator.prototype
- * @example <caption>
- *   Given the user credentials (`phone_number` and `code`), it will do the
- *   authentication on the provider and return a JSON with the `access_token`
- *   and `id_token`.
- * </caption>
- *
- * var data = {
- *   username: '{PHONE_NUMBER}',
- *   password: '{VERIFICATION_CODE}'
- * };
- *
- * auth0.passwordless.signIn(data, function (err) {
- *   if (err) {
- *     // Handle error.
- *   }
- * });
- *
- * @example <caption>
- *   The user data object has the following structure.
- * </caption>
- *
- * {
- *   id_token: String,
- *   access_token: String,
- *   token_type: String
- * }
- *
- * @param   {Object}    userData              User credentials object.
- * @param   {String}    userData.username     Username.
- * @param   {String}    userData.password     Password.
- * @param   {String}    [userData.connection=sms]  Connection string: "sms" or "email".
- * @param   {String}    [userData.client_id]  Client ID.
- * @param   {Function}  [cb]                  Method callback.
- *
- * @return  {Promise|undefined}
- */
-PasswordlessAuthenticator.prototype.signIn = function(userData, cb) {
-  var defaultFields = {
-    client_id: this.clientId
-  };
-  var data = extend(defaultFields, userData);
+    if (!userData || typeof userData !== 'object') {
+      throw new ArgumentError('Missing user data object');
+    }
 
-  // Don't let the user override the connection nor the grant type.
-  if (!data.connection || (data.connection !== 'email' && data.connection !== 'sms')) {
+    if (typeof data.username !== 'string' || data.username.trim().length === 0) {
+      throw new ArgumentError('username field (phone number) is required');
+    }
+
+    if (typeof data.password !== 'string' || data.password.trim().length === 0) {
+      throw new ArgumentError('password field (verification code) is required');
+    }
+
+    return this.oauth.signIn(data, cb);
+  }
+
+  /**
+   * Start passwordless flow sending an email.
+   *
+   * @method    sendEmail
+   * @memberOf  module:auth.PasswordlessAuthenticator.prototype
+   * @example <caption>
+   *   Given the user `email` address, it will send an email with:
+   *
+   *   <ul>
+   *     <li>A link (default, `send:"link"`). You can then authenticate with this
+   *       user opening the link and he will be automatically logged in to the
+   *       application. Optionally, you can append/override parameters to the link
+   *       (like `scope`, `redirect_uri`, `protocol`, `response_type`, etc.) using
+   *       `authParams` object.
+   *     </li>
+   *     <li>
+   *       A verification code (`send:"code"`). You can then authenticate with
+   *       this user using the `/oauth/ro` endpoint specifying `email` as
+   *       `username` and `code` as `password`.
+   *     </li>
+   *   </ul>
+   *
+   *   Find more information in the
+   *   <a href="https://auth0.com/docs/auth-api#!#post--with_email">API Docs</a>
+   * </caption>
+   *
+   * const data = {
+   *   email: '{EMAIL}',
+   *   send: 'link',
+   *   authParams: {} // Optional auth params.
+   * };
+   *
+   * auth0.passwordless.sendEmail(data, function (err) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   * });
+   *
+   * @param   {Object}    userData                User account data.
+   * @param   {String}    userData.email          User email address.
+   * @param   {String}    userData.send           The type of email to be sent.
+   * @param   {Function}  [cb]                    Method callback.
+   *
+   * @return  {Promise|undefined}
+   */
+  sendEmail(userData, cb) {
+    const data = Object.assign({ client_id: this.clientId }, userData);
+
+    // Don't let the user override the connection nor the grant type.
+    data.connection = 'email';
+
+    if (!userData || typeof userData !== 'object') {
+      throw new ArgumentError('Missing user data object');
+    }
+
+    if (typeof data.email !== 'string' || data.email.trim().length === 0) {
+      throw new ArgumentError('email field is required');
+    }
+
+    if (typeof data.send !== 'string' || data.send.trim().length === 0) {
+      throw new ArgumentError('send field is required');
+    }
+
+    if (cb && cb instanceof Function) {
+      return this.passwordless.create(data, cb);
+    }
+
+    return this.passwordless.create(data);
+  }
+
+  /**
+   * Start passwordless flow sending an SMS.
+   *
+   * @method    sendSMS
+   * @memberOf  module:auth.PasswordlessAuthenticator.prototype
+   *
+   * @example <caption>
+   *   Given the user `phone_number`, it will send a SMS message with a
+   *   verification code. You can then authenticate with this user using the
+   *   `/oauth/ro` endpoint specifying `phone_number` as `username` and `code` as
+   *   `password`:
+   * </caption>
+   *
+   * const data = {
+   *   phone_number: '{PHONE}'
+   * };
+   *
+   * auth0.passwordless.sendSMS(data, function (err) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   * });
+   *
+   * @param   {Object}    userData                User account data.
+   * @param   {String}    userData.phone_number   User phone number.
+   * @param   {String}    [userData.client_id]    Client ID.
+   * @param   {Function}  [cb]                    Method callback.
+   *
+   * @return  {Promise|undefined}
+   */
+  sendSMS(userData, cb) {
+    const data = Object.assign({ client_id: this.clientId }, userData);
+
+    // Don't let the user override the connection nor the grant type.
     data.connection = 'sms';
+
+    if (!userData || typeof userData !== 'object') {
+      throw new ArgumentError('Missing user data object');
+    }
+
+    if (typeof data.phone_number !== 'string' || data.phone_number.trim().length === 0) {
+      throw new ArgumentError('phone_number field is required');
+    }
+
+    if (cb && cb instanceof Function) {
+      return this.passwordless.create(data, cb);
+    }
+
+    return this.passwordless.create(data);
   }
-  data.grant_type = 'password';
-
-  if (!userData || typeof userData !== 'object') {
-    throw new ArgumentError('Missing user data object');
-  }
-
-  if (typeof data.username !== 'string' || data.username.trim().length === 0) {
-    throw new ArgumentError('username field (phone number) is required');
-  }
-
-  if (typeof data.password !== 'string' || data.password.trim().length === 0) {
-    throw new ArgumentError('password field (verification code) is required');
-  }
-
-  return this.oauth.signIn(data, cb);
-};
-
-/**
- * Start passwordless flow sending an email.
- *
- * @method    sendEmail
- * @memberOf  module:auth.PasswordlessAuthenticator.prototype
- * @example <caption>
- *   Given the user `email` address, it will send an email with:
- *
- *   <ul>
- *     <li>A link (default, `send:"link"`). You can then authenticate with this
- *       user opening the link and he will be automatically logged in to the
- *       application. Optionally, you can append/override parameters to the link
- *       (like `scope`, `redirect_uri`, `protocol`, `response_type`, etc.) using
- *       `authParams` object.
- *     </li>
- *     <li>
- *       A verification code (`send:"code"`). You can then authenticate with
- *       this user using the `/oauth/ro` endpoint specifying `email` as
- *       `username` and `code` as `password`.
- *     </li>
- *   </ul>
- *
- *   Find more information in the
- *   <a href="https://auth0.com/docs/auth-api#!#post--with_email">API Docs</a>
- * </caption>
- *
- * var data = {
- *   email: '{EMAIL}',
- *   send: 'link',
- *   authParams: {} // Optional auth params.
- * };
- *
- * auth0.passwordless.sendEmail(data, function (err) {
- *   if (err) {
- *     // Handle error.
- *   }
- * });
- *
- * @param   {Object}    userData                User account data.
- * @param   {String}    userData.email          User email address.
- * @param   {String}    userData.send           The type of email to be sent.
- * @param   {Function}  [cb]                    Method callback.
- *
- * @return  {Promise|undefined}
- */
-PasswordlessAuthenticator.prototype.sendEmail = function(userData, cb) {
-  var defaultFields = {
-    client_id: this.clientId
-  };
-  var data = extend(defaultFields, userData);
-
-  // Don't let the user override the connection nor the grant type.
-  data.connection = 'email';
-
-  if (!userData || typeof userData !== 'object') {
-    throw new ArgumentError('Missing user data object');
-  }
-
-  if (typeof data.email !== 'string' || data.email.trim().length === 0) {
-    throw new ArgumentError('email field is required');
-  }
-
-  if (typeof data.send !== 'string' || data.send.trim().length === 0) {
-    throw new ArgumentError('send field is required');
-  }
-
-  if (cb && cb instanceof Function) {
-    return this.passwordless.create(data, cb);
-  }
-
-  return this.passwordless.create(data);
-};
-
-/**
- * Start passwordless flow sending an SMS.
- *
- * @method    sendSMS
- * @memberOf  module:auth.PasswordlessAuthenticator.prototype
- *
- * @example <caption>
- *   Given the user `phone_number`, it will send a SMS message with a
- *   verification code. You can then authenticate with this user using the
- *   `/oauth/ro` endpoint specifying `phone_number` as `username` and `code` as
- *   `password`:
- * </caption>
- *
- * var data = {
- *   phone_number: '{PHONE}'
- * };
- *
- * auth0.passwordless.sendSMS(data, function (err) {
- *   if (err) {
- *     // Handle error.
- *   }
- * });
- *
- * @param   {Object}    userData                User account data.
- * @param   {String}    userData.phone_number   User phone number.
- * @param   {String}    [userData.client_id]    Client ID.
- * @param   {Function}  [cb]                    Method callback.
- *
- * @return  {Promise|undefined}
- */
-PasswordlessAuthenticator.prototype.sendSMS = function(userData, cb) {
-  var defaultFields = {
-    client_id: this.clientId
-  };
-  var data = extend(defaultFields, userData);
-
-  // Don't let the user override the connection nor the grant type.
-  data.connection = 'sms';
-
-  if (!userData || typeof userData !== 'object') {
-    throw new ArgumentError('Missing user data object');
-  }
-
-  if (typeof data.phone_number !== 'string' || data.phone_number.trim().length === 0) {
-    throw new ArgumentError('phone_number field is required');
-  }
-
-  if (cb && cb instanceof Function) {
-    return this.passwordless.create(data, cb);
-  }
-
-  return this.passwordless.create(data);
-};
+}
 
 module.exports = PasswordlessAuthenticator;

--- a/src/auth/TokensManager.js
+++ b/src/auth/TokensManager.js
@@ -1,7 +1,5 @@
-var extend = require('util')._extend;
-var getRequestPromise = require('../utils').getRequestPromise;
-
-var ArgumentError = require('rest-facade').ArgumentError;
+const { ArgumentError } = require('rest-facade');
+const { getRequestPromise } = require('../utils');
 
 /**
  * @class
@@ -14,162 +12,168 @@ var ArgumentError = require('rest-facade').ArgumentError;
  * @param  {String}   [options.headers]     Default request headers.
  * @param  {String}   [options.clientId]    Default client ID.
  */
-var TokensManager = function(options) {
-  if (typeof options !== 'object') {
-    throw new ArgumentError('Missing tokens manager options');
+class TokensManager {
+  constructor(options) {
+    if (typeof options !== 'object') {
+      throw new ArgumentError('Missing tokens manager options');
+    }
+
+    if (typeof options.baseUrl !== 'string') {
+      throw new ArgumentError('baseUrl field is required');
+    }
+
+    const { baseUrl, headers = {}, clientId = '' } = options;
+
+    this.baseUrl = baseUrl;
+    this.headers = headers;
+    this.clientId = clientId;
   }
 
-  if (typeof options.baseUrl !== 'string') {
-    throw new ArgumentError('baseUrl field is required');
+  /**
+   * Given an ID token get the user profile linked to it.
+   *
+   * @method
+   * @memberOf module:auth.TokensManager.prototype
+   *
+   * @example <caption>
+   *   Validates a JSON Web Token (signature and expiration) and returns the user
+   *   information associated with the user id (sub property) of the token. Find
+   *   more information in the
+   *   <a href="https://auth0.com/docs/auth-api#!#post--tokeninfo">API Docs</a>.
+   * </caption>
+   *
+   * auth0.tokens.getInfo(token, function (err, tokenInfo) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   *
+   *   console.log(tokenInfo);
+   * });
+   *
+   * @param   {String}    idToken     User ID token.
+   * @param   {Function}  [cb]        Method callback.
+   *
+   * @return  {Promise|undefined}
+   */
+  getInfo(idToken, cb) {
+    const headers = Object.assign({}, this.headers);
+
+    if (idToken === null || idToken === undefined) {
+      throw new ArgumentError('An ID token is required');
+    }
+
+    if (typeof idToken !== 'string' || idToken.trim().length === 0) {
+      throw new ArgumentError('The ID token is not valid');
+    }
+
+    // Perform the request.
+    const promise = getRequestPromise({
+      method: 'POST',
+      url: `${this.baseUrl}/tokeninfo`,
+      data: { id_token: idToken },
+      headers
+    });
+
+    // Use callback if given.
+    if (cb instanceof Function) {
+      promise.then(cb.bind(null, null)).catch(cb);
+      return;
+    }
+
+    return promise;
   }
 
-  this.baseUrl = options.baseUrl;
-  this.headers = options.headers || {};
-  this.clientId = options.clientId || '';
-};
+  /**
+   * Exchange the token of the logged in user with a token that is valid to call
+   * the API (signed with the API secret).
+   *
+   * @method
+   * @memberOf module:auth.TokensManager.prototype
+   *
+   * @example <caption>
+   *   Given an existing token, this endpoint will generate a new token signed
+   *   with the target client secret. This is used to flow the identity of the
+   *   user from the application to an API or across different APIs that are
+   *   protected with different secrets. Find more information in the
+   *   <a href="https://auth0.com/docs/auth-api#!#post--delegation">API Docs</a>.
+   * </caption>
+   *
+   * const data = {
+   *   id_token: '{ID_TOKEN}',
+   *   api_type: 'app',
+   *   target: '{TARGET}',
+   *   grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer'
+   * };
+   *
+   * auth0.tokens.getDelegationToken(data, function (err, token) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   *
+   *   console.log(token);
+   * });
+   *
+   * @param   {Object}    data                Token data object.
+   * @param   {String}    data.id_token       User ID token.
+   * @param   {String}    data.refresh_token  User refresh token.
+   * @param   {String}    data.target         Target client ID.
+   * @param   {String}    data.api_type       The API to be used (aws, auth0, etc).
+   * @param   {String}    data.grant_type     Grant type (password, jwt, etc).
+   * @param   {Function}  [cb]                Callback function.
+   *
+   * @return  {Promise|undefined}
+   */
+  getDelegationToken(data, cb) {
+    const body = Object.assign({ client_id: this.clientId }, data);
+    const { headers } = this;
 
-/**
- * Given an ID token get the user profile linked to it.
- *
- * @method
- * @memberOf module:auth.TokensManager.prototype
- *
- * @example <caption>
- *   Validates a JSON Web Token (signature and expiration) and returns the user
- *   information associated with the user id (sub property) of the token. Find
- *   more information in the
- *   <a href="https://auth0.com/docs/auth-api#!#post--tokeninfo">API Docs</a>.
- * </caption>
- *
- * auth0.tokens.getInfo(token, function (err, tokenInfo) {
- *   if (err) {
- *     // Handle error.
- *   }
- *
- *   console.log(tokenInfo);
- * });
- *
- * @param   {String}    idToken     User ID token.
- * @param   {Function}  [cb]        Method callback.
- *
- * @return  {Promise|undefined}
- */
-TokensManager.prototype.getInfo = function(idToken, cb) {
-  var headers = extend({}, this.headers);
+    if (!data) {
+      throw new ArgumentError('Missing token data object');
+    }
 
-  if (idToken === null || idToken === undefined) {
-    throw new ArgumentError('An ID token is required');
+    const hasIdToken = typeof data.id_token === 'string' && data.id_token.trim().length !== 0;
+
+    const hasRefreshToken =
+      typeof data.refresh_token === 'string' && data.refresh_token.trim().length !== 0;
+
+    if (!hasIdToken && !hasRefreshToken) {
+      throw new ArgumentError('one of id_token or refresh_token is required');
+    }
+
+    if (hasIdToken && hasRefreshToken) {
+      throw new ArgumentError(
+        'id_token and refresh_token fields cannot be specified simulatenously'
+      );
+    }
+
+    if (typeof data.target !== 'string' || data.target.trim().length === 0) {
+      throw new ArgumentError('target field is required');
+    }
+
+    if (typeof data.api_type !== 'string' || data.api_type.trim().length === 0) {
+      throw new ArgumentError('api_type field is required');
+    }
+
+    if (typeof data.grant_type !== 'string' || data.grant_type.trim().length === 0) {
+      throw new ArgumentError('grant_type field is required');
+    }
+
+    // Perform the request.
+    const promise = getRequestPromise({
+      method: 'POST',
+      url: `${this.baseUrl}/delegation`,
+      data: body,
+      headers
+    });
+
+    // Use callback if given.
+    if (cb instanceof Function) {
+      promise.then(cb.bind(null, null)).catch(cb);
+      return;
+    }
+
+    return promise;
   }
-
-  if (typeof idToken !== 'string' || idToken.trim().length === 0) {
-    throw new ArgumentError('The ID token is not valid');
-  }
-
-  // Perform the request.
-  var promise = getRequestPromise({
-    method: 'POST',
-    url: this.baseUrl + '/tokeninfo',
-    data: { id_token: idToken },
-    headers: headers
-  });
-
-  // Use callback if given.
-  if (cb instanceof Function) {
-    promise.then(cb.bind(null, null)).catch(cb);
-    return;
-  }
-
-  return promise;
-};
-
-/**
- * Exchange the token of the logged in user with a token that is valid to call
- * the API (signed with the API secret).
- *
- * @method
- * @memberOf module:auth.TokensManager.prototype
- *
- * @example <caption>
- *   Given an existing token, this endpoint will generate a new token signed
- *   with the target client secret. This is used to flow the identity of the
- *   user from the application to an API or across different APIs that are
- *   protected with different secrets. Find more information in the
- *   <a href="https://auth0.com/docs/auth-api#!#post--delegation">API Docs</a>.
- * </caption>
- *
- * var data = {
- *   id_token: '{ID_TOKEN}',
- *   api_type: 'app',
- *   target: '{TARGET}',
- *   grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer'
- * };
- *
- * auth0.tokens.getDelegationToken(data, function (err, token) {
- *   if (err) {
- *     // Handle error.
- *   }
- *
- *   console.log(token);
- * });
- *
- * @param   {Object}    data                Token data object.
- * @param   {String}    data.id_token       User ID token.
- * @param   {String}    data.refresh_token  User refresh token.
- * @param   {String}    data.target         Target client ID.
- * @param   {String}    data.api_type       The API to be used (aws, auth0, etc).
- * @param   {String}    data.grant_type     Grant type (password, jwt, etc).
- * @param   {Function}  [cb]                Callback function.
- *
- * @return  {Promise|undefined}
- */
-TokensManager.prototype.getDelegationToken = function(data, cb) {
-  var body = extend({ client_id: this.clientId }, data);
-  var headers = this.headers;
-
-  if (!data) {
-    throw new ArgumentError('Missing token data object');
-  }
-
-  var hasIdToken = typeof data.id_token === 'string' && data.id_token.trim().length !== 0;
-
-  var hasRefreshToken =
-    typeof data.refresh_token === 'string' && data.refresh_token.trim().length !== 0;
-
-  if (!hasIdToken && !hasRefreshToken) {
-    throw new ArgumentError('one of id_token or refresh_token is required');
-  }
-
-  if (hasIdToken && hasRefreshToken) {
-    throw new ArgumentError('id_token and refresh_token fields cannot be specified simulatenously');
-  }
-
-  if (typeof data.target !== 'string' || data.target.trim().length === 0) {
-    throw new ArgumentError('target field is required');
-  }
-
-  if (typeof data.api_type !== 'string' || data.api_type.trim().length === 0) {
-    throw new ArgumentError('api_type field is required');
-  }
-
-  if (typeof data.grant_type !== 'string' || data.grant_type.trim().length === 0) {
-    throw new ArgumentError('grant_type field is required');
-  }
-
-  // Perform the request.
-  var promise = getRequestPromise({
-    method: 'POST',
-    url: this.baseUrl + '/delegation',
-    data: body,
-    headers: headers
-  });
-
-  // Use callback if given.
-  if (cb instanceof Function) {
-    promise.then(cb.bind(null, null)).catch(cb);
-    return;
-  }
-
-  return promise;
-};
+}
 
 module.exports = TokensManager;

--- a/src/auth/TokensManager.js
+++ b/src/auth/TokensManager.js
@@ -142,7 +142,7 @@ class TokensManager {
 
     if (hasIdToken && hasRefreshToken) {
       throw new ArgumentError(
-        'id_token and refresh_token fields cannot be specified simulatenously'
+        'id_token and refresh_token fields cannot be specified simultaneously'
       );
     }
 

--- a/src/auth/UsersManager.js
+++ b/src/auth/UsersManager.js
@@ -1,7 +1,5 @@
-var extend = require('util')._extend;
-var getRequestPromise = require('../utils').getRequestPromise;
-
-var ArgumentError = require('rest-facade').ArgumentError;
+const { ArgumentError } = require('rest-facade');
+const { getRequestPromise } = require('../utils');
 
 /**
  * @class
@@ -14,160 +12,172 @@ var ArgumentError = require('rest-facade').ArgumentError;
  * @param  {String}   [options.headers]     Default request headers.
  * @param  {String}   [options.clientId]    Default client ID.
  */
-var UsersManager = function(options) {
-  if (typeof options !== 'object') {
-    throw new ArgumentError('Missing users manager options');
+class UsersManager {
+  constructor(options) {
+    if (typeof options !== 'object') {
+      throw new ArgumentError('Missing users manager options');
+    }
+
+    if (typeof options.baseUrl !== 'string') {
+      throw new ArgumentError('baseUrl field is required');
+    }
+
+    const { baseUrl, headers, clientId } = options;
+
+    this.baseUrl = baseUrl;
+    this.headers = headers;
+    this.clientId = clientId;
   }
 
-  if (typeof options.baseUrl !== 'string') {
-    throw new ArgumentError('baseUrl field is required');
+  /**
+   * Given an access token get the user profile linked to it.
+   *
+   * @method    getInfo
+   * @memberOf  module:auth.UsersManager.prototype
+   *
+   * @example <caption>
+   *   Get the user information based on the Auth0 access token (obtained during
+   *   login). Find more information in the
+   *   <a href="https://auth0.com/docs/auth-api#!#get--userinfo">API Docs</a>.
+   * </caption>
+   *
+   * auth0.users.getInfo(accessToken, function (err, userInfo) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   *
+   *   console.log(userInfo);
+   * });
+   *
+   * @param   {String}    accessToken   User access token.
+   * @param   {Function}  [cb]          Callback function.
+   *
+   * @return  {Promise|undefined}
+   */
+  getInfo(accessToken, cb) {
+    const url = `${this.baseUrl}/userinfo`;
+    const headers = Object.assign({}, this.headers);
+
+    if (accessToken === null || accessToken === undefined) {
+      throw new ArgumentError('An access token is required');
+    }
+
+    if (typeof accessToken !== 'string' || accessToken.trim().length === 0) {
+      throw new ArgumentError('Invalid access token');
+    }
+
+    // Send the user access token in the Authorization header.
+    headers.Authorization = `Bearer ${accessToken}`;
+
+    // Perform the request.
+    const promise = getRequestPromise({
+      method: 'GET',
+      url,
+      headers,
+      data: {}
+    });
+
+    // Use callback if given.
+    if (cb instanceof Function) {
+      promise.then(cb.bind(null, null)).catch(cb);
+      return;
+    }
+
+    return promise;
   }
 
-  this.baseUrl = options.baseUrl;
-  this.headers = options.headers;
-  this.clientId = options.clientId;
-};
+  /**
+   * Impersonate the user with the given user ID.
+   *
+   * @method    impersonate
+   * @memberOf  module:auth.UsersManager.prototype
+   *
+   * @example <caption>
+   *   Gets a link that can be used once to log in as a specific user. Useful for
+   *   troubleshooting. Find more information in the
+   *   [API Docs](https://auth0.com/docs/auth-api#!#post--users--user_id--impersonate).
+   * </caption>
+   *
+   * const settings = {
+   *   impersonator_id: '{IMPERSONATOR_ID}',
+   *   protocol: 'oauth2',
+   *   additionalParameters: {}  // Optional additional params.
+   * };
+   *
+   * auth0.users.impersonate(userId, settings, function (err, link) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   *
+   *   console.log(link);
+   * });
+   *
+   * @param   {String}    userId                    User ID token.
+   * @param   {Object}    settings                  Impersonation settings.
+   * @param   {String}    settings.impersonator_id  Impersonator user ID.
+   * @param   {String}    settings.protocol         The authentication protocol.
+   * @param   {String}    settings.token            API v1 token obtained for impersonation
+   * @param   {String}    [settings.clientId]       Client id used for impersonation. Uses the one supplied in the constructor by default.
+   * @param   {Function}  [cb]                     Callback function.
+   *
+   * @return  {Promise|undefined}
+   */
+  impersonate(userId, settings, cb) {
+    const url = `${this.baseUrl}/users/${userId}/impersonate`;
 
-/**
- * Given an access token get the user profile linked to it.
- *
- * @method    getInfo
- * @memberOf  module:auth.UsersManager.prototype
- *
- * @example <caption>
- *   Get the user information based on the Auth0 access token (obtained during
- *   login). Find more information in the
- *   <a href="https://auth0.com/docs/auth-api#!#get--userinfo">API Docs</a>.
- * </caption>
- *
- * auth0.users.getInfo(accessToken, function (err, userInfo) {
- *   if (err) {
- *     // Handle error.
- *   }
- *
- *   console.log(userInfo);
- * });
- *
- * @param   {String}    accessToken   User access token.
- * @param   {Function}  [cb]          Callback function.
- *
- * @return  {Promise|undefined}
- */
-UsersManager.prototype.getInfo = function(accessToken, cb) {
-  var url = this.baseUrl + '/userinfo';
-  var headers = extend({}, this.headers);
+    if (userId === null || userId === undefined) {
+      throw new ArgumentError('You must specify a user ID');
+    }
 
-  if (accessToken === null || accessToken === undefined) {
-    throw new ArgumentError('An access token is required');
+    if (typeof userId !== 'string' || userId.trim().length === 0) {
+      throw new ArgumentError('The user ID is not valid');
+    }
+
+    if (typeof settings !== 'object') {
+      throw new ArgumentError('Missing impersonation settings object');
+    }
+
+    if (
+      typeof settings.impersonator_id !== 'string' ||
+      settings.impersonator_id.trim().length === 0
+    ) {
+      throw new ArgumentError('impersonator_id field is required');
+    }
+
+    if (typeof settings.protocol !== 'string' || settings.protocol.trim().length === 0) {
+      throw new ArgumentError('protocol field is required');
+    }
+
+    if (typeof settings.token !== 'string' || settings.token.trim().length === 0) {
+      throw new ArgumentError('token field is required');
+    }
+
+    const { clientId = this.clientId } = settings;
+    const data = Object.assign({ client_id: clientId }, settings);
+
+    const headers = Object.assign(
+      {
+        Authorization: `Bearer ${settings.token}`
+      },
+      this.headers
+    );
+
+    // Perform the request.
+    const promise = getRequestPromise({
+      method: 'POST',
+      headers: headers,
+      data: data,
+      url: url
+    });
+
+    // Use callback if given.
+    if (cb instanceof Function) {
+      promise.then(cb.bind(null, null)).catch(cb);
+      return;
+    }
+
+    return promise;
   }
-
-  if (typeof accessToken !== 'string' || accessToken.trim().length === 0) {
-    throw new ArgumentError('Invalid access token');
-  }
-
-  // Send the user access token in the Authorization header.
-  headers['Authorization'] = 'Bearer ' + accessToken;
-
-  // Perform the request.
-  var promise = getRequestPromise({
-    method: 'GET',
-    url: url,
-    headers: headers,
-    data: {}
-  });
-
-  // Use callback if given.
-  if (cb instanceof Function) {
-    promise.then(cb.bind(null, null)).catch(cb);
-    return;
-  }
-
-  return promise;
-};
-
-/**
- * Impersonate the user with the given user ID.
- *
- * @method    impersonate
- * @memberOf  module:auth.UsersManager.prototype
- *
- * @example <caption>
- *   Gets a link that can be used once to log in as a specific user. Useful for
- *   troubleshooting. Find more information in the
- *   [API Docs](https://auth0.com/docs/auth-api#!#post--users--user_id--impersonate).
- * </caption>
- *
- * var settings = {
- *   impersonator_id: '{IMPERSONATOR_ID}',
- *   protocol: 'oauth2',
- *   additionalParameters: {}  // Optional aditional params.
- * };
- *
- * auth0.users.impersonate(userId, settings, function (err, link) {
- *   if (err) {
- *     // Handle error.
- *   }
- *
- *   console.log(link);
- * });
- *
- * @param   {String}    userId                    User ID token.
- * @param   {Object}    settings                  Impersonation settings.
- * @param   {String}    settings.impersonator_id  Impersonator user ID.
- * @param   {String}    settings.protocol         The authentication protocol.
- * @param   {String}    settings.token            API v1 token obtained for impersonation
- * @param   {String}    [settings.clientId]       Client id used for impersonation. Uses the one supplied in the constructor by default.
- * @param   {Function}  [cb]]                     Callback function.
- *
- * @return  {Promise|undefined}
- */
-UsersManager.prototype.impersonate = function(userId, settings, cb) {
-  var url = this.baseUrl + '/users/' + userId + '/impersonate';
-
-  if (userId === null || userId === undefined) {
-    throw new ArgumentError('You must specify a user ID');
-  }
-
-  if (typeof userId !== 'string' || userId.trim().length === 0) {
-    throw new ArgumentError('The user ID is not valid');
-  }
-
-  if (typeof settings !== 'object') {
-    throw new ArgumentError('Missing impersonation settings object');
-  }
-
-  if (
-    typeof settings.impersonator_id !== 'string' ||
-    settings.impersonator_id.trim().length === 0
-  ) {
-    throw new ArgumentError('impersonator_id field is required');
-  }
-
-  if (typeof settings.protocol !== 'string' || settings.protocol.trim().length === 0) {
-    throw new ArgumentError('protocol field is required');
-  }
-
-  if (typeof settings.token !== 'string' || settings.token.trim().length === 0) {
-    throw new ArgumentError('token field is required');
-  }
-
-  var data = extend({ client_id: settings.clientId || this.clientId }, settings);
-  var headers = extend({ Authorization: `Bearer ${settings.token}` }, this.headers);
-  // Perform the request.
-  var promise = getRequestPromise({
-    method: 'POST',
-    headers: headers,
-    data: data,
-    url: url
-  });
-
-  // Use callback if given.
-  if (cb instanceof Function) {
-    promise.then(cb.bind(null, null)).catch(cb);
-    return;
-  }
-
-  return promise;
-};
+}
 
 module.exports = UsersManager;

--- a/src/management/BlacklistedTokensManager.js
+++ b/src/management/BlacklistedTokensManager.js
@@ -32,7 +32,7 @@ class BlacklistedTokensManager {
     const { headers, retry, baseUrl, tokenProvider } = options;
 
     /**
-     * Options object for the Rest Client instace.
+     * Options object for the Rest Client instance.
      *
      * @type {Object}
      */

--- a/src/management/BlacklistedTokensManager.js
+++ b/src/management/BlacklistedTokensManager.js
@@ -1,7 +1,7 @@
-var ArgumentError = require('rest-facade').ArgumentError;
-var utils = require('../utils');
-var Auth0RestClient = require('../Auth0RestClient');
-var RetryRestClient = require('../RetryRestClient');
+const { ArgumentError } = require('rest-facade');
+const { wrapPropertyMethod } = require('../utils');
+const Auth0RestClient = require('../Auth0RestClient');
+const RetryRestClient = require('../RetryRestClient');
 
 /**
  * @class BlacklistedTokensManager
@@ -15,43 +15,47 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} [options.headers]  Headers to be included in all requests.
  * @param {Object} [options.retry]    Retry Policy Config
  */
-var BlacklistedTokensManager = function(options) {
-  if (options === null || typeof options !== 'object') {
-    throw new ArgumentError('Must provide client options');
+class BlacklistedTokensManager {
+  constructor(options) {
+    if (options === null || typeof options !== 'object') {
+      throw new ArgumentError('Must provide client options');
+    }
+
+    if (options.baseUrl === null || options.baseUrl === undefined) {
+      throw new ArgumentError('Must provide a base URL for the API');
+    }
+
+    if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
+      throw new ArgumentError('The provided base URL is invalid');
+    }
+
+    const { headers, retry, baseUrl, tokenProvider } = options;
+
+    /**
+     * Options object for the Rest Client instace.
+     *
+     * @type {Object}
+     */
+    const clientOptions = {
+      errorFormatter: { message: 'message', name: 'error' },
+      headers,
+      query: { repeatParams: false }
+    };
+
+    /**
+     * Provides an abstraction layer for consuming the
+     * [Auth0 Blacklisted Tokens endpoint]{@link https://auth0.com/docs/api/v2#!/Clients}.
+     *
+     * @type {external:RestClient}
+     */
+    const auth0RestClient = new Auth0RestClient(
+      `${baseUrl}/blacklists/tokens`,
+      clientOptions,
+      tokenProvider
+    );
+    this.resource = new RetryRestClient(auth0RestClient, retry);
   }
-
-  if (options.baseUrl === null || options.baseUrl === undefined) {
-    throw new ArgumentError('Must provide a base URL for the API');
-  }
-
-  if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
-    throw new ArgumentError('The provided base URL is invalid');
-  }
-
-  /**
-   * Options object for the Rest Client instace.
-   *
-   * @type {Object}
-   */
-  var clientOptions = {
-    errorFormatter: { message: 'message', name: 'error' },
-    headers: options.headers,
-    query: { repeatParams: false }
-  };
-
-  /**
-   * Provides an abstraction layer for consuming the
-   * [Auth0 Blacklisted Tokens endpoint]{@link https://auth0.com/docs/api/v2#!/Clients}.
-   *
-   * @type {external:RestClient}
-   */
-  var auth0RestClient = new Auth0RestClient(
-    options.baseUrl + '/blacklists/tokens',
-    clientOptions,
-    options.tokenProvider
-  );
-  this.resource = new RetryRestClient(auth0RestClient, options.retry);
-};
+}
 
 /**
  * Blacklist a new token.
@@ -60,7 +64,7 @@ var BlacklistedTokensManager = function(options) {
  * @memberOf  module:management.BlacklistedTokensManager.prototype
  *
  * @example
- * var token = {
+ * const token = {
  *  aud: 'aud',
  *  jti: 'jti'
  * };
@@ -80,7 +84,7 @@ var BlacklistedTokensManager = function(options) {
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(BlacklistedTokensManager, 'add', 'resource.create');
+wrapPropertyMethod(BlacklistedTokensManager, 'add', 'resource.create');
 
 /**
  * Get all blacklisted tokens.
@@ -97,6 +101,6 @@ utils.wrapPropertyMethod(BlacklistedTokensManager, 'add', 'resource.create');
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(BlacklistedTokensManager, 'getAll', 'resource.getAll');
+wrapPropertyMethod(BlacklistedTokensManager, 'getAll', 'resource.getAll');
 
 module.exports = BlacklistedTokensManager;

--- a/src/management/ClientGrantsManager.js
+++ b/src/management/ClientGrantsManager.js
@@ -1,5 +1,5 @@
 const ArgumentError = require('rest-facade').ArgumentError;
-const utils = require('../utils');
+const { wrapPropertyMethod } = require('../utils');
 const Auth0RestClient = require('../Auth0RestClient');
 const RetryRestClient = require('../RetryRestClient');
 /**
@@ -78,7 +78,7 @@ class ClientGrantsManager {
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(ClientGrantsManager, 'create', 'resource.create');
+wrapPropertyMethod(ClientGrantsManager, 'create', 'resource.create');
 
 /**
  * Get all Auth0 Client Grants.
@@ -110,7 +110,7 @@ utils.wrapPropertyMethod(ClientGrantsManager, 'create', 'resource.create');
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(ClientGrantsManager, 'getAll', 'resource.getAll');
+wrapPropertyMethod(ClientGrantsManager, 'getAll', 'resource.getAll');
 
 /**
  * Update an Auth0 client grant.
@@ -141,7 +141,7 @@ utils.wrapPropertyMethod(ClientGrantsManager, 'getAll', 'resource.getAll');
  *
  * @return    {Promise|undefined}
  */
-utils.wrapPropertyMethod(ClientGrantsManager, 'update', 'resource.patch');
+wrapPropertyMethod(ClientGrantsManager, 'update', 'resource.patch');
 
 /**
  * Delete an Auth0 client grant.
@@ -164,6 +164,6 @@ utils.wrapPropertyMethod(ClientGrantsManager, 'update', 'resource.patch');
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(ClientGrantsManager, 'delete', 'resource.delete');
+wrapPropertyMethod(ClientGrantsManager, 'delete', 'resource.delete');
 
 module.exports = ClientGrantsManager;

--- a/src/management/ClientGrantsManager.js
+++ b/src/management/ClientGrantsManager.js
@@ -1,7 +1,7 @@
-var ArgumentError = require('rest-facade').ArgumentError;
-var utils = require('../utils');
-var Auth0RestClient = require('../Auth0RestClient');
-var RetryRestClient = require('../RetryRestClient');
+const ArgumentError = require('rest-facade').ArgumentError;
+const utils = require('../utils');
+const Auth0RestClient = require('../Auth0RestClient');
+const RetryRestClient = require('../RetryRestClient');
 /**
  * @class ClientGrantsManager
  * Auth0 Client Grants Manager.
@@ -16,43 +16,47 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} [options.headers]  Headers to be included in all requests.
  * @param {Object} [options.retry]    Retry Policy Config
  */
-var ClientGrantsManager = function(options) {
-  if (options === null || typeof options !== 'object') {
-    throw new ArgumentError('Must provide client options');
+class ClientGrantsManager {
+  constructor(options) {
+    if (options === null || typeof options !== 'object') {
+      throw new ArgumentError('Must provide client options');
+    }
+
+    if (options.baseUrl === null || options.baseUrl === undefined) {
+      throw new ArgumentError('Must provide a base URL for the API');
+    }
+
+    if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
+      throw new ArgumentError('The provided base URL is invalid');
+    }
+
+    const { headers, baseUrl, tokenProvider, retry } = options;
+
+    /**
+     * Options object for the Rest Client instance.
+     *
+     * @type {Object}
+     */
+    const clientOptions = {
+      errorFormatter: { message: 'message', name: 'error' },
+      headers,
+      query: { repeatParams: false }
+    };
+
+    /**
+     * Provides an abstraction layer for consuming the
+     * {@link https://auth0.com/docs/api/v2#!/Client_Grants Auth0 Client Grants endpoint}.
+     *
+     * @type {external:RestClient}
+     */
+    const auth0RestClient = new Auth0RestClient(
+      `${baseUrl}/client-grants/:id`,
+      clientOptions,
+      tokenProvider
+    );
+    this.resource = new RetryRestClient(auth0RestClient, retry);
   }
-
-  if (options.baseUrl === null || options.baseUrl === undefined) {
-    throw new ArgumentError('Must provide a base URL for the API');
-  }
-
-  if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
-    throw new ArgumentError('The provided base URL is invalid');
-  }
-
-  /**
-   * Options object for the Rest Client instance.
-   *
-   * @type {Object}
-   */
-  var clientOptions = {
-    errorFormatter: { message: 'message', name: 'error' },
-    headers: options.headers,
-    query: { repeatParams: false }
-  };
-
-  /**
-   * Provides an abstraction layer for consuming the
-   * {@link https://auth0.com/docs/api/v2#!/Client_Grants Auth0 Client Grants endpoint}.
-   *
-   * @type {external:RestClient}
-   */
-  var auth0RestClient = new Auth0RestClient(
-    options.baseUrl + '/client-grants/:id',
-    clientOptions,
-    options.tokenProvider
-  );
-  this.resource = new RetryRestClient(auth0RestClient, options.retry);
-};
+}
 
 /**
  * Create an Auth0 client grant.
@@ -89,7 +93,7 @@ utils.wrapPropertyMethod(ClientGrantsManager, 'create', 'resource.create');
  * </caption>
  *
  * // Pagination settings.
- * var params = {
+ * const params = {
  *   per_page: 10,
  *   page: 0
  * };
@@ -115,12 +119,12 @@ utils.wrapPropertyMethod(ClientGrantsManager, 'getAll', 'resource.getAll');
  * @memberOf  module:management.ClientGrantsManager.prototype
  *
  * @example
- * var data = {
+ * const data = {
  *   client_id: CLIENT_ID,
  *   audience: AUDIENCE,
  *   scope: []
  * };
- * var params = { id: CLIENT_GRANT_ID };
+ * const params = { id: CLIENT_GRANT_ID };
  *
  * management.clientGrants.update(params, data, function (err, grant) {
  *   if (err) {

--- a/src/management/ClientGrantsManager.js
+++ b/src/management/ClientGrantsManager.js
@@ -1,4 +1,4 @@
-const ArgumentError = require('rest-facade').ArgumentError;
+const { ArgumentError } = require('rest-facade');
 const { wrapPropertyMethod } = require('../utils');
 const Auth0RestClient = require('../Auth0RestClient');
 const RetryRestClient = require('../RetryRestClient');

--- a/src/management/ClientsManager.js
+++ b/src/management/ClientsManager.js
@@ -1,7 +1,7 @@
-var ArgumentError = require('rest-facade').ArgumentError;
-var utils = require('../utils');
-var Auth0RestClient = require('../Auth0RestClient');
-var RetryRestClient = require('../RetryRestClient');
+const { ArgumentError } = require('rest-facade');
+const { wrapPropertyMethod } = require('../utils');
+const Auth0RestClient = require('../Auth0RestClient');
+const RetryRestClient = require('../RetryRestClient');
 
 /**
  * @class ClientsManager
@@ -20,43 +20,47 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} [options.headers]  Headers to be included in all requests.
  * @param {Object} [options.retry]    Retry Policy Config
  */
-var ClientsManager = function(options) {
-  if (options === null || typeof options !== 'object') {
-    throw new ArgumentError('Must provide client options');
+class ClientsManager {
+  constructor(options) {
+    if (options === null || typeof options !== 'object') {
+      throw new ArgumentError('Must provide client options');
+    }
+
+    if (options.baseUrl === null || options.baseUrl === undefined) {
+      throw new ArgumentError('Must provide a base URL for the API');
+    }
+
+    if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
+      throw new ArgumentError('The provided base URL is invalid');
+    }
+
+    const { headers, baseUrl, tokenProvider, retry } = options;
+
+    /**
+     * Options object for the Rest Client instance.
+     *
+     * @type {Object}
+     */
+    const clientOptions = {
+      errorFormatter: { message: 'message', name: 'error' },
+      headers,
+      query: { repeatParams: false }
+    };
+
+    /**
+     * Provides an abstraction layer for consuming the
+     * {@link https://auth0.com/docs/api/v2#!/Clients Auth0 Clients endpoint}.
+     *
+     * @type {external:RestClient}
+     */
+    const auth0RestClient = new Auth0RestClient(
+      `${baseUrl}/clients/:client_id`,
+      clientOptions,
+      tokenProvider
+    );
+    this.resource = new RetryRestClient(auth0RestClient, retry);
   }
-
-  if (options.baseUrl === null || options.baseUrl === undefined) {
-    throw new ArgumentError('Must provide a base URL for the API');
-  }
-
-  if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
-    throw new ArgumentError('The provided base URL is invalid');
-  }
-
-  /**
-   * Options object for the Rest Client instance.
-   *
-   * @type {Object}
-   */
-  var clientOptions = {
-    errorFormatter: { message: 'message', name: 'error' },
-    headers: options.headers,
-    query: { repeatParams: false }
-  };
-
-  /**
-   * Provides an abstraction layer for consuming the
-   * {@link https://auth0.com/docs/api/v2#!/Clients Auth0 Clients endpoint}.
-   *
-   * @type {external:RestClient}
-   */
-  var auth0RestClient = new Auth0RestClient(
-    options.baseUrl + '/clients/:client_id',
-    clientOptions,
-    options.tokenProvider
-  );
-  this.resource = new RetryRestClient(auth0RestClient, options.retry);
-};
+}
 
 /**
  * Create an Auth0 client.
@@ -78,7 +82,7 @@ var ClientsManager = function(options) {
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(ClientsManager, 'create', 'resource.create');
+wrapPropertyMethod(ClientsManager, 'create', 'resource.create');
 
 /**
  * Get all Auth0 clients.
@@ -93,7 +97,7 @@ utils.wrapPropertyMethod(ClientsManager, 'create', 'resource.create');
  * </caption>
  *
  * // Pagination settings.
- * var params = {
+ * const params = {
  *   per_page: 10,
  *   page: 0
  * };
@@ -109,7 +113,7 @@ utils.wrapPropertyMethod(ClientsManager, 'create', 'resource.create');
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(ClientsManager, 'getAll', 'resource.getAll');
+wrapPropertyMethod(ClientsManager, 'getAll', 'resource.getAll');
 
 /**
  * Get an Auth0 client.
@@ -132,7 +136,7 @@ utils.wrapPropertyMethod(ClientsManager, 'getAll', 'resource.getAll');
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(ClientsManager, 'get', 'resource.get');
+wrapPropertyMethod(ClientsManager, 'get', 'resource.get');
 
 /**
  * Update an Auth0 client.
@@ -141,8 +145,8 @@ utils.wrapPropertyMethod(ClientsManager, 'get', 'resource.get');
  * @memberOf  module:management.ClientsManager.prototype
  *
  * @example
- * var data = { name: 'newClientName' };
- * var params = { client_id: CLIENT_ID };
+ * const data = { name: 'newClientName' };
+ * const params = { client_id: CLIENT_ID };
  *
  * management.clients.update(params, data, function (err, client) {
  *   if (err) {
@@ -159,7 +163,7 @@ utils.wrapPropertyMethod(ClientsManager, 'get', 'resource.get');
  *
  * @return    {Promise|undefined}
  */
-utils.wrapPropertyMethod(ClientsManager, 'update', 'resource.patch');
+wrapPropertyMethod(ClientsManager, 'update', 'resource.patch');
 
 /**
  * Delete an Auth0 client.
@@ -182,6 +186,6 @@ utils.wrapPropertyMethod(ClientsManager, 'update', 'resource.patch');
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(ClientsManager, 'delete', 'resource.delete');
+wrapPropertyMethod(ClientsManager, 'delete', 'resource.delete');
 
 module.exports = ClientsManager;

--- a/src/management/ConnectionsManager.js
+++ b/src/management/ConnectionsManager.js
@@ -1,7 +1,7 @@
-var ArgumentError = require('rest-facade').ArgumentError;
-var utils = require('../utils');
-var Auth0RestClient = require('../Auth0RestClient');
-var RetryRestClient = require('../RetryRestClient');
+const { ArgumentError } = require('rest-facade');
+const { wrapPropertyMethod } = require('../utils');
+const Auth0RestClient = require('../Auth0RestClient');
+const RetryRestClient = require('../RetryRestClient');
 
 /**
  * @class ConnectionsManager
@@ -14,43 +14,47 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} [options.headers]  Headers to be included in all requests.
  * @param {Object} [options.retry]    Retry Policy Config
  */
-var ConnectionsManager = function(options) {
-  if (options === null || typeof options !== 'object') {
-    throw new ArgumentError('Must provide client options');
+class ConnectionsManager {
+  constructor(options) {
+    if (options === null || typeof options !== 'object') {
+      throw new ArgumentError('Must provide client options');
+    }
+
+    if (options.baseUrl === null || options.baseUrl === undefined) {
+      throw new ArgumentError('Must provide a base URL for the API');
+    }
+
+    if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
+      throw new ArgumentError('The provided base URL is invalid');
+    }
+
+    const { headers, baseUrl, tokenProvider, retry } = options;
+
+    /**
+     * Options object for the Rest Client instance.
+     *
+     * @type {Object}
+     */
+    const clientOptions = {
+      headers,
+      query: { repeatParams: false }
+    };
+
+    /**
+     * Provides an abstraction layer for performing CRUD operations on
+     * {@link https://auth0.com/docs/api/v2#!/ConnectionsManagers Auth0
+     *  Connections}.
+     *
+     * @type {external:RestClient}
+     */
+    const auth0RestClient = new Auth0RestClient(
+      `${baseUrl}/connections/:id`,
+      clientOptions,
+      tokenProvider
+    );
+    this.resource = new RetryRestClient(auth0RestClient, retry);
   }
-
-  if (options.baseUrl === null || options.baseUrl === undefined) {
-    throw new ArgumentError('Must provide a base URL for the API');
-  }
-
-  if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
-    throw new ArgumentError('The provided base URL is invalid');
-  }
-
-  /**
-   * Options object for the Rest Client instance.
-   *
-   * @type {Object}
-   */
-  var clientOptions = {
-    headers: options.headers,
-    query: { repeatParams: false }
-  };
-
-  /**
-   * Provides an abstraction layer for performing CRUD operations on
-   * {@link https://auth0.com/docs/api/v2#!/ConnectionsManagers Auth0
-   *  Connections}.
-   *
-   * @type {external:RestClient}
-   */
-  var auth0RestClient = new Auth0RestClient(
-    options.baseUrl + '/connections/:id ',
-    clientOptions,
-    options.tokenProvider
-  );
-  this.resource = new RetryRestClient(auth0RestClient, options.retry);
-};
+}
 
 /**
  * Create a new connection.
@@ -64,7 +68,7 @@ var ConnectionsManager = function(options) {
  *     // Handle error.
  *   }
  *
- *   // Conection created.
+ *   // Connection created.
  * });
  *
  * @param   {Object}    data     Connection data object.
@@ -72,7 +76,7 @@ var ConnectionsManager = function(options) {
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(ConnectionsManager, 'create', 'resource.create');
+wrapPropertyMethod(ConnectionsManager, 'create', 'resource.create');
 
 /**
  * Get all connections.
@@ -87,7 +91,7 @@ utils.wrapPropertyMethod(ConnectionsManager, 'create', 'resource.create');
  * </caption>
  *
  * // Pagination settings.
- * var params = {
+ * const params = {
  *   per_page: 10,
  *   page: 0
  * };
@@ -103,7 +107,7 @@ utils.wrapPropertyMethod(ConnectionsManager, 'create', 'resource.create');
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(ConnectionsManager, 'getAll', 'resource.getAll');
+wrapPropertyMethod(ConnectionsManager, 'getAll', 'resource.getAll');
 
 /**
  * Get an Auth0 connection.
@@ -126,7 +130,7 @@ utils.wrapPropertyMethod(ConnectionsManager, 'getAll', 'resource.getAll');
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(ConnectionsManager, 'get', 'resource.get');
+wrapPropertyMethod(ConnectionsManager, 'get', 'resource.get');
 
 /**
  * Update an existing connection.
@@ -135,8 +139,8 @@ utils.wrapPropertyMethod(ConnectionsManager, 'get', 'resource.get');
  * @memberOf  module:management.ConnectionsManager.prototype
  *
  * @example
- * var data = { name: 'newConnectionName' };
- * var params = { id: CONNECTION_ID };
+ * const data = { name: 'newConnectionName' };
+ * const params = { id: CONNECTION_ID };
  *
  * management.connections.update(params, data, function (err, connection) {
  *   if (err) {
@@ -146,14 +150,14 @@ utils.wrapPropertyMethod(ConnectionsManager, 'get', 'resource.get');
  *   console.log(connection.name);  // 'newConnectionName'
  * });
  *
- * @param   {Object}    params        Conneciton parameters.
+ * @param   {Object}    params        Connection parameters.
  * @param   {String}    params.id     Connection ID.
  * @param   {Object}    data          Updated connection data.
  * @param   {Function}  [cb]          Callback function.
  *
  * @return    {Promise|undefined}
  */
-utils.wrapPropertyMethod(ConnectionsManager, 'update', 'resource.patch');
+wrapPropertyMethod(ConnectionsManager, 'update', 'resource.patch');
 
 /**
  * Delete an existing connection.
@@ -167,7 +171,7 @@ utils.wrapPropertyMethod(ConnectionsManager, 'update', 'resource.patch');
  *     // Handle error.
  *   }
  *
- *   // Conection deleted.
+ *   // Connection deleted.
  * });
  *
  * @param   {Object}    params          Connection parameters.
@@ -176,6 +180,6 @@ utils.wrapPropertyMethod(ConnectionsManager, 'update', 'resource.patch');
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(ConnectionsManager, 'delete', 'resource.delete');
+wrapPropertyMethod(ConnectionsManager, 'delete', 'resource.delete');
 
 module.exports = ConnectionsManager;

--- a/src/management/EmailTemplatesManager.js
+++ b/src/management/EmailTemplatesManager.js
@@ -1,7 +1,7 @@
-var ArgumentError = require('rest-facade').ArgumentError;
-var utils = require('../utils');
-var Auth0RestClient = require('../Auth0RestClient');
-var RetryRestClient = require('../RetryRestClient');
+const { ArgumentError } = require('rest-facade');
+const { wrapPropertyMethod } = require('../utils');
+const Auth0RestClient = require('../Auth0RestClient');
+const RetryRestClient = require('../RetryRestClient');
 
 /**
  * Simple facade for consuming a REST API endpoint.
@@ -21,39 +21,42 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} [options.headers]  Headers to be included in all requests.
  * @param {Object} [options.retry]    Retry Policy Config
  */
-var EmailTemplatesManager = function(options) {
-  if (!options || 'object' !== typeof options) {
-    throw new ArgumentError('Must provide manager options');
+class EmailTemplatesManager {
+  constructor(options) {
+    if (!options || 'object' !== typeof options) {
+      throw new ArgumentError('Must provide manager options');
+    }
+
+    if (!options.baseUrl || 'string' !== typeof options.baseUrl) {
+      throw new ArgumentError('Must provide a valid string as base URL for the API');
+    }
+
+    const { headers, baseUrl, tokenProvider, retry } = options;
+
+    /**
+     * Options object for the Rest Client instance.
+     *
+     * @type {Object}
+     */
+    const clientOptions = {
+      headers,
+      query: { repeatParams: false }
+    };
+
+    /**
+     * Provides an abstraction layer for performing CRUD operations on
+     * {@link https://auth0.com/docs/api/management/v2#!/Email_Templates/get_email_templates_by_templateName Auth0's Email Templates}.
+     *
+     * @type {external:RestClient}
+     */
+    const auth0RestClient = new Auth0RestClient(
+      `${baseUrl}/email-templates/:name`,
+      clientOptions,
+      tokenProvider
+    );
+    this.resource = new RetryRestClient(auth0RestClient, retry);
   }
-
-  if (!options.baseUrl || 'string' !== typeof options.baseUrl) {
-    throw new ArgumentError('Must provide a valid string as base URL for the API');
-  }
-
-  /**
-   * Options object for the Rest Client instance.
-   *
-   * @type {Object}
-   */
-  var clientOptions = {
-    headers: options.headers,
-    query: { repeatParams: false }
-  };
-
-  /**
-   * Provides an abstraction layer for performing CRUD operations on
-   * {@link https://auth0.com/docs/api/management/v2#!/Email_Templates/get_email_templates_by_templateName Auth0's Email Templates}.
-   *
-   * @type {external:RestClient}
-   */
-  var auth0RestClient = new Auth0RestClient(
-    options.baseUrl + '/email-templates/:name',
-    clientOptions,
-    options.tokenProvider
-  );
-  this.resource = new RetryRestClient(auth0RestClient, options.retry);
-};
-
+}
 /**
  * Create a new Email Template.
  *
@@ -74,7 +77,7 @@ var EmailTemplatesManager = function(options) {
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(EmailTemplatesManager, 'create', 'resource.create');
+wrapPropertyMethod(EmailTemplatesManager, 'create', 'resource.create');
 
 /**
  * Get an Auth0 Email Template.
@@ -97,7 +100,7 @@ utils.wrapPropertyMethod(EmailTemplatesManager, 'create', 'resource.create');
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(EmailTemplatesManager, 'get', 'resource.get');
+wrapPropertyMethod(EmailTemplatesManager, 'get', 'resource.get');
 
 /**
  * Update an existing Email Template.
@@ -106,8 +109,8 @@ utils.wrapPropertyMethod(EmailTemplatesManager, 'get', 'resource.get');
  * @memberOf  module:management.EmailTemplatesManager.prototype
  *
  * @example
- * var data = { from: 'new@email.com' };
- * var params = { name: EMAIL_TEMPLATE_NAME };
+ * const data = { from: 'new@email.com' };
+ * const params = { name: EMAIL_TEMPLATE_NAME };
  *
  * management.emailTemplates.update(params, data, function (err, emailTemplate) {
  *   if (err) {
@@ -124,6 +127,6 @@ utils.wrapPropertyMethod(EmailTemplatesManager, 'get', 'resource.get');
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(EmailTemplatesManager, 'update', 'resource.patch');
+wrapPropertyMethod(EmailTemplatesManager, 'update', 'resource.patch');
 
 module.exports = EmailTemplatesManager;

--- a/src/management/GuardianManager.js
+++ b/src/management/GuardianManager.js
@@ -1,6 +1,6 @@
-var ArgumentError = require('rest-facade').ArgumentError;
-var Auth0RestClient = require('../Auth0RestClient');
-var RetryRestClient = require('../RetryRestClient');
+const { ArgumentError } = require('rest-facade');
+const Auth0RestClient = require('../Auth0RestClient');
+const RetryRestClient = require('../RetryRestClient');
 
 /**
  * Simple facade for consuming a REST API endpoint.
@@ -19,78 +19,82 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} [options.headers]  Headers to be included in all requests.
  * @param {Object} [options.retry]    Retry Policy Config
  */
-var GuardianManager = function(options) {
-  if (options === null || typeof options !== 'object') {
-    throw new ArgumentError('Must provide manager options');
-  }
+class GuardianManager {
+  constructor(options) {
+    if (options === null || typeof options !== 'object') {
+      throw new ArgumentError('Must provide manager options');
+    }
 
-  if (options.baseUrl === null || options.baseUrl === undefined) {
-    throw new ArgumentError('Must provide a base URL for the API');
-  }
+    if (options.baseUrl === null || options.baseUrl === undefined) {
+      throw new ArgumentError('Must provide a base URL for the API');
+    }
 
-  if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
-    throw new ArgumentError('The provided base URL is invalid');
-  }
+    if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
+      throw new ArgumentError('The provided base URL is invalid');
+    }
 
-  var clientOptions = {
-    errorFormatter: { message: 'message', name: 'error' },
-    headers: options.headers,
-    query: { repeatParams: false }
-  };
+    const { headers, baseUrl, tokenProvider, retry } = options;
+
+    const clientOptions = {
+      errorFormatter: { message: 'message', name: 'error' },
+      headers,
+      query: { repeatParams: false }
+    };
+
+    /**
+     * Provides an abstraction layer for retrieving Guardian enrollments.
+     *
+     * @type {external:RestClient}
+     */
+    const guardianEnrollmentsAuth0RestClient = new Auth0RestClient(
+      `${baseUrl}/guardian/enrollments/:id`,
+      clientOptions,
+      tokenProvider
+    );
+    this.enrollments = new RetryRestClient(guardianEnrollmentsAuth0RestClient, retry);
+  }
 
   /**
-   * Provides an abstraction layer for retrieving Guardian enrollments.
+   * Get a single Guardian enrollment.
    *
-   * @type {external:RestClient}
+   * @method    getGuardianEnrollment
+   * @memberOf  module:management.GuardianManager.prototype
+   *
+   * @example
+   * management.users.getGuardianEnrollment({ id: ENROLLMENT_ID }, function (err, enrollment) {
+   *   console.log(enrollment);
+   * });
+   *
+   * @param   {Object}    data      The user data object.
+   * @param   {String}    data.id   The user id.
+   * @param   {Function}  [cb]      Callback function.
+   *
+   * @return  {Promise|undefined}
    */
-  var guardianEnrollmentsAuth0RestClient = new Auth0RestClient(
-    options.baseUrl + '/guardian/enrollments/:id',
-    clientOptions,
-    options.tokenProvider
-  );
-  this.enrollments = new RetryRestClient(guardianEnrollmentsAuth0RestClient, options.retry);
-};
+  getGuardianEnrollment(params, cb) {
+    return this.enrollments.get(params, cb);
+  }
 
-/**
- * Get a single Guardian enrollment.
- *
- * @method    getGuardianEnrollment
- * @memberOf  module:management.GuardianManager.prototype
- *
- * @example
- * management.users.getGuardianEnrollment({ id: ENROLLMENT_ID }, function (err, enrollment) {
- *   console.log(enrollment);
- * });
- *
- * @param   {Object}    data      The user data object.
- * @param   {String}    data.id   The user id.
- * @param   {Function}  [cb]      Callback function.
- *
- * @return  {Promise|undefined}
- */
-GuardianManager.prototype.getGuardianEnrollment = function(params, cb) {
-  return this.enrollments.get(params, cb);
-};
-
-/**
- * Delete a Guardian enrollment.
- *
- * @method    deleteGuardianEnrollment
- * @memberOf  module:management.GuardianManager.prototype
- *
- * @example
- * management.users.deleteGuardianEnrollment({ id: ENROLLMENT_ID }, function (err, enrollments) {
- *   console.log(enrollments);
- * });
- *
- * @param   {Object}    data      The user data object.
- * @param   {String}    data.id   The user id.
- * @param   {Function}  [cb]      Callback function.
- *
- * @return  {Promise|undefined}
- */
-GuardianManager.prototype.deleteGuardianEnrollment = function(params, cb) {
-  return this.enrollments.delete(params, cb);
-};
+  /**
+   * Delete a Guardian enrollment.
+   *
+   * @method    deleteGuardianEnrollment
+   * @memberOf  module:management.GuardianManager.prototype
+   *
+   * @example
+   * management.users.deleteGuardianEnrollment({ id: ENROLLMENT_ID }, function (err, enrollments) {
+   *   console.log(enrollments);
+   * });
+   *
+   * @param   {Object}    data      The user data object.
+   * @param   {String}    data.id   The user id.
+   * @param   {Function}  [cb]      Callback function.
+   *
+   * @return  {Promise|undefined}
+   */
+  deleteGuardianEnrollment(params, cb) {
+    return this.enrollments.delete(params, cb);
+  }
+}
 
 module.exports = GuardianManager;

--- a/src/management/JobsManager.js
+++ b/src/management/JobsManager.js
@@ -128,9 +128,9 @@ class JobsManager {
    * @return  {Promise|undefined}
    */
   importUsers(data, cb) {
-    const { headers, baseUrl, tokenProvider } = this.options;
+    const { baseUrl, tokenProvider } = this.options;
     const { users_json, users, connection_id } = data;
-    const headers = Object.assign({}, headers);
+    const headers = Object.assign({}, this.options.headers);
 
     headers['Content-Type'] = 'multipart/form-data';
 

--- a/src/management/JobsManager.js
+++ b/src/management/JobsManager.js
@@ -1,11 +1,10 @@
-var request = require('request');
-var extend = require('util')._extend;
-var Promise = require('bluebird');
-var fs = require('fs');
+const Promise = require('bluebird');
+const request = require('request');
+const { createReadStream } = require('fs');
 
-var ArgumentError = require('rest-facade').ArgumentError;
-var Auth0RestClient = require('../Auth0RestClient');
-var RetryRestClient = require('../RetryRestClient');
+const { ArgumentError } = require('rest-facade');
+const Auth0RestClient = require('../Auth0RestClient');
+const RetryRestClient = require('../RetryRestClient');
 
 /**
  * Simple facade for consuming a REST API endpoint.
@@ -24,202 +23,205 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} [options.headers]  Headers to be included in all requests.
  * @param {Object} [options.retry]    Retry Policy Config
  */
-var JobsManager = function(options) {
-  if (options === null || typeof options !== 'object') {
-    throw new ArgumentError('Must provide client options');
+class JobsManager {
+  constructor(options) {
+    if (options === null || typeof options !== 'object') {
+      throw new ArgumentError('Must provide client options');
+    }
+
+    if (options.baseUrl === null || options.baseUrl === undefined) {
+      throw new ArgumentError('Must provide a base URL for the API');
+    }
+
+    if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
+      throw new ArgumentError('The provided base URL is invalid');
+    }
+
+    const { headers, baseUrl, tokenProvider, retry } = options;
+
+    const clientOptions = {
+      errorFormatter: { message: 'message', name: 'error' },
+      headers,
+      query: { repeatParams: false }
+    };
+
+    this.options = options;
+
+    /**
+     * Provides an abstraction layer for consuming the
+     * {@link https://auth0.com/docs/api/v2#!/Jobs Jobs endpoint}.
+     *
+     * @type {external:RestClient}
+     */
+    const auth0RestClient = new Auth0RestClient(
+      `${baseUrl}/jobs/:id`,
+      clientOptions,
+      tokenProvider
+    );
+    this.jobs = new RetryRestClient(auth0RestClient, retry);
   }
-
-  if (options.baseUrl === null || options.baseUrl === undefined) {
-    throw new ArgumentError('Must provide a base URL for the API');
-  }
-
-  if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
-    throw new ArgumentError('The provided base URL is invalid');
-  }
-
-  var clientOptions = {
-    errorFormatter: { message: 'message', name: 'error' },
-    headers: options.headers,
-    query: { repeatParams: false }
-  };
-
-  this.options = options;
 
   /**
-   * Provides an abstraction layer for consuming the
-   * {@link https://auth0.com/docs/api/v2#!/Jobs Jobs endpoint}.
+   * Get a job by its ID.
    *
-   * @type {external:RestClient}
+   * @method   get
+   * @memberOf module:management.JobsManager.prototype
+   *
+   * @example
+   * const params = {
+   *   id: '{JOB_ID}'
+   * };
+   *
+   * management.jobs.get(params, function (err, job) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   *
+   *   // Retrieved job.
+   *   console.log(job);
+   * });
+   *
+   * @param   {Object}    params        Job parameters.
+   * @param   {String}    params.id     Job ID.
+   * @param   {Function}  [cb]          Callback function.
+   *
+   * @return  {Promise|undefined}
    */
-  var auth0RestClient = new Auth0RestClient(
-    options.baseUrl + '/jobs/:id',
-    clientOptions,
-    options.tokenProvider
-  );
-  this.jobs = new RetryRestClient(auth0RestClient, options.retry);
-};
+  get(params, cb) {
+    if (!params.id || typeof params.id !== 'string') {
+      throw new ArgumentError('The id parameter must be a valid job id');
+    }
 
-/**
- * Get a job by its ID.
- *
- * @method   get
- * @memberOf module:management.JobsManager.prototype
- *
- * @example
- * var params = {
- *   id: '{JOB_ID}'
- * };
- *
- * management.jobs.get(params, function (err, job) {
- *   if (err) {
- *     // Handle error.
- *   }
- *
- *   // Retrieved job.
- *   console.log(job);
- * });
- *
- * @param   {Object}    params        Job parameters.
- * @param   {String}    params.id     Job ID.
- * @param   {Function}  [cb]          Callback function.
- *
- * @return  {Promise|undefined}
- */
-JobsManager.prototype.get = function(params, cb) {
-  if (!params.id || typeof params.id !== 'string') {
-    throw new ArgumentError('The id parameter must be a valid job id');
+    if (cb && cb instanceof Function) {
+      return this.jobs.get(params, cb);
+    }
+
+    // Return a promise.
+    return this.jobs.get(params);
   }
 
-  if (cb && cb instanceof Function) {
-    return this.jobs.get(params, cb);
-  }
+  /**
+   * Given a path to a file and a connection id, create a new job that imports the
+   * users contained in the file or JSON string and associate them with the given
+   * connection.
+   *
+   * @method   importUsers
+   * @memberOf module:management.JobsManager.prototype
+   *
+   * @example
+   * const params = {
+   *   connection_id: '{CONNECTION_ID}',
+   *   users: '{PATH_TO_USERS_FILE}'
+   * };
+   *
+   * management.jobs.get(params, function (err) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   * });
+   *
+   * @param   {Object}    data                Users import data.
+   * @param   {String}    data.connectionId   Connection for the users insertion.
+   * @param   {String}    data.users          Path to the users data file.
+   * @param   {String}    data.users_json     JSON data for the users.
+   * @param   {Function}  [cb]                Callback function.
+   *
+   * @return  {Promise|undefined}
+   */
+  importUsers(data, cb) {
+    const { headers, baseUrl, tokenProvider } = this.options;
+    const { users_json, users, connection_id } = data;
+    const headers = Object.assign({}, headers);
 
-  // Return a promise.
-  return this.jobs.get(params);
-};
+    headers['Content-Type'] = 'multipart/form-data';
 
-/**
- * Given a path to a file and a connection id, create a new job that imports the
- * users contained in the file or JSON string and associate them with the given
- * connection.
- *
- * @method   importUsers
- * @memberOf module:management.JobsManager.prototype
- *
- * @example
- * var params = {
- *   connection_id: '{CONNECTION_ID}',
- *   users: '{PATH_TO_USERS_FILE}'
- * };
- *
- * management.jobs.get(params, function (err) {
- *   if (err) {
- *     // Handle error.
- *   }
- * });
- *
- * @param   {Object}    data                Users import data.
- * @param   {String}    data.connectionId   Connection for the users insertion.
- * @param   {String}    data.users          Path to the users data file.
- * @param   {String}    data.users_json     JSON data for the users.
- * @param   {Function}  [cb]                Callback function.
- *
- * @return  {Promise|undefined}
- */
-JobsManager.prototype.importUsers = function(data, cb) {
-  var options = this.options;
-  var headers = extend({}, options.headers);
+    const url = `${baseUrl}/jobs/users-imports`;
+    const method = 'POST';
 
-  headers['Content-Type'] = 'multipart/form-data';
-
-  var url = options.baseUrl + '/jobs/users-imports';
-  var method = 'POST';
-
-  var promise = options.tokenProvider.getAccessToken().then(function(access_token) {
-    return new Promise(function(resolve, reject) {
-      request(
-        {
-          url: url,
-          method: method,
-          headers: extend({ Authorization: `Bearer ${access_token}` }, headers),
-          formData: {
-            users: {
-              value: data.users_json
-                ? Buffer.from(data.users_json)
-                : fs.createReadStream(data.users),
-              options: {
-                filename: data.users_json ? 'users.json' : data.users
-              }
-            },
-            connection_id: data.connection_id
+    const promise = tokenProvider.getAccessToken().then(access_token => {
+      return new Promise((resolve, reject) => {
+        request(
+          {
+            url,
+            method,
+            headers: Object.assign({ Authorization: `Bearer ${access_token}` }, headers),
+            formData: {
+              users: {
+                value: users_json ? Buffer.from(users_json) : createReadStream(users),
+                options: {
+                  filename: users_json ? 'users.json' : users
+                }
+              },
+              connection_id
+            }
+          },
+          (err, res) => {
+            if (err) {
+              reject(err);
+              return;
+            }
+            // `superagent` uses the error parameter in callback on http errors.
+            // the following code is intended to keep that behaviour (https://github.com/visionmedia/superagent/blob/master/lib/node/response.js#L170)
+            const type = (res.statusCode / 100) | 0;
+            const isErrorResponse = 4 === type || 5 === type;
+            if (isErrorResponse) {
+              const error = new Error(`cannot ${method} ${url} (${res.statusCode})`);
+              error.status = res.statusCode;
+              error.method = method;
+              error.text = res.text;
+              reject(error);
+            }
+            resolve(res);
           }
-        },
-        function(err, res) {
-          if (err) {
-            reject(err);
-            return;
-          }
-          // `superagent` uses the error parameter in callback on http errors.
-          // the following code is intended to keep that behaviour (https://github.com/visionmedia/superagent/blob/master/lib/node/response.js#L170)
-          var type = (res.statusCode / 100) | 0;
-          var isErrorResponse = 4 === type || 5 === type;
-          if (isErrorResponse) {
-            var error = new Error('cannot ' + method + ' ' + url + ' (' + res.statusCode + ')');
-            error.status = res.statusCode;
-            error.method = method;
-            error.text = res.text;
-            reject(error);
-          }
-          resolve(res);
-        }
-      );
+        );
+      });
     });
-  });
 
-  // Don't return a promise if a callback was given.
-  if (cb && cb instanceof Function) {
-    promise.then(cb.bind(null, null)).catch(cb);
+    // Don't return a promise if a callback was given.
+    if (cb && cb instanceof Function) {
+      promise.then(cb.bind(null, null)).catch(cb);
 
-    return;
+      return;
+    }
+
+    return promise;
   }
 
-  return promise;
-};
+  /**
+   * Send a verification email to a user.
+   *
+   * @method    verifyEmail
+   * @memberOf module:management.JobsManager.prototype
+   *
+   * @example
+   * const params = {
+   * 	user_id: '{USER_ID}'
+   * };
+   *
+   * management.jobs.verifyEmail(function (err) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   * });
+   *
+   * @param   {Object}    data          User data object.
+   * @param   {String}    data.user_id  ID of the user to be verified.
+   * @param   {Function}  [cb]          Callback function.
+   *
+   * @return  {Promise|undefined}
+   */
+  verifyEmail(data, cb) {
+    if (!data.user_id || typeof data.user_id !== 'string') {
+      throw new ArgumentError('Must specify a user ID');
+    }
 
-/**
- * Send a verification email to a user.
- *
- * @method    verifyEmail
- * @memberOf module:management.JobsManager.prototype
- *
- * @example
- * var params = {
- * 	user_id: '{USER_ID}'
- * };
- *
- * management.jobs.verifyEmail(function (err) {
- *   if (err) {
- *     // Handle error.
- *   }
- * });
- *
- * @param   {Object}    data          User data object.
- * @param   {String}    data.user_id  ID of the user to be verified.
- * @param   {Function}  [cb]          Callback function.
- *
- * @return  {Promise|undefined}
- */
-JobsManager.prototype.verifyEmail = function(data, cb) {
-  if (!data.user_id || typeof data.user_id !== 'string') {
-    throw new ArgumentError('Must specify a user ID');
+    if (cb && cb instanceof Function) {
+      return this.jobs.create({ id: 'verification-email' }, data, cb);
+    }
+
+    // Return a promise.
+    return this.jobs.create({ id: 'verification-email' }, data);
   }
-
-  if (cb && cb instanceof Function) {
-    return this.jobs.create({ id: 'verification-email' }, data, cb);
-  }
-
-  // Return a promise.
-  return this.jobs.create({ id: 'verification-email' }, data);
-};
+}
 
 module.exports = JobsManager;

--- a/src/management/JobsManager.js
+++ b/src/management/JobsManager.js
@@ -1,4 +1,3 @@
-const Promise = require('bluebird');
 const request = require('request');
 const { createReadStream } = require('fs');
 

--- a/src/management/LogsManager.js
+++ b/src/management/LogsManager.js
@@ -1,7 +1,7 @@
-var ArgumentError = require('rest-facade').ArgumentError;
-var utils = require('../utils');
-var Auth0RestClient = require('../Auth0RestClient');
-var RetryRestClient = require('../RetryRestClient');
+const { ArgumentError } = require('rest-facade');
+const { wrapPropertyMethod } = require('../utils');
+const Auth0RestClient = require('../Auth0RestClient');
+const RetryRestClient = require('../RetryRestClient');
 
 /**
  * @class LogsManager
@@ -14,43 +14,47 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} [options.headers]  Headers to be included in all requests.
  * @param {Object} [options.retry]    Retry Policy Config
  */
-var LogsManager = function(options) {
-  if (options === null || typeof options !== 'object') {
-    throw new ArgumentError('Must provide client options');
+class LogsManager {
+  constructor(options) {
+    if (options === null || typeof options !== 'object') {
+      throw new ArgumentError('Must provide client options');
+    }
+
+    if (options.baseUrl === null || options.baseUrl === undefined) {
+      throw new ArgumentError('Must provide a base URL for the API');
+    }
+
+    if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
+      throw new ArgumentError('The provided base URL is invalid');
+    }
+
+    const { headers, baseUrl, tokenProvider, retry } = options;
+
+    /**
+     * Options object for the Rest Client instance.
+     *
+     * @type {Object}
+     */
+    const clientOptions = {
+      headers,
+      query: { repeatParams: false }
+    };
+
+    /**
+     * Provides an abstraction layer for performing CRUD operations on
+     * {@link https://auth0.com/docs/api/v2#!/LogsManagers Auth0
+     *  Logs}.
+     *
+     * @type {external:RestClient}
+     */
+    const auth0RestClient = new Auth0RestClient(
+      `${baseUrl}/logs/:id`,
+      clientOptions,
+      tokenProvider
+    );
+    this.resource = new RetryRestClient(auth0RestClient, retry);
   }
-
-  if (options.baseUrl === null || options.baseUrl === undefined) {
-    throw new ArgumentError('Must provide a base URL for the API');
-  }
-
-  if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
-    throw new ArgumentError('The provided base URL is invalid');
-  }
-
-  /**
-   * Options object for the Rest Client instance.
-   *
-   * @type {Object}
-   */
-  var clientOptions = {
-    headers: options.headers,
-    query: { repeatParams: false }
-  };
-
-  /**
-   * Provides an abstraction layer for performing CRUD operations on
-   * {@link https://auth0.com/docs/api/v2#!/LogsManagers Auth0
-   *  Logs}.
-   *
-   * @type {external:RestClient}
-   */
-  var auth0RestClient = new Auth0RestClient(
-    options.baseUrl + '/logs/:id ',
-    clientOptions,
-    options.tokenProvider
-  );
-  this.resource = new RetryRestClient(auth0RestClient, options.retry);
-};
+}
 
 /**
  * Get all logs.
@@ -65,7 +69,7 @@ var LogsManager = function(options) {
  * </caption>
  *
  * // Pagination settings.
- * var params = {
+ * const params = {
  *   per_page: 10,
  *   page: 2
  * };
@@ -86,7 +90,7 @@ var LogsManager = function(options) {
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(LogsManager, 'getAll', 'resource.getAll');
+wrapPropertyMethod(LogsManager, 'getAll', 'resource.getAll');
 
 /**
  * Get an Auth0 log.
@@ -109,6 +113,6 @@ utils.wrapPropertyMethod(LogsManager, 'getAll', 'resource.getAll');
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(LogsManager, 'get', 'resource.get');
+wrapPropertyMethod(LogsManager, 'get', 'resource.get');
 
 module.exports = LogsManager;

--- a/src/management/ManagementTokenProvider.js
+++ b/src/management/ManagementTokenProvider.js
@@ -98,7 +98,7 @@ class ManagementTokenProvider {
   }
 }
 
-ManagementTokenProvider.prototype._getCachedAccessToken = promisify(
+ManagementTokenProvider.prototype.getCachedAccessToken = promisify(
   memoizer({
     load(options, callback) {
       const { domain, scope, audience } = options;

--- a/src/management/ManagementTokenProvider.js
+++ b/src/management/ManagementTokenProvider.js
@@ -1,4 +1,4 @@
-const Promise = require('bluebird');
+const { promisify } = require('util');
 const { ArgumentError } = require('rest-facade');
 const memoizer = require('lru-memoizer');
 const AuthenticationClient = require('../auth');
@@ -97,7 +97,7 @@ class ManagementTokenProvider {
   }
 }
 
-ManagementTokenProvider.prototype._getCachedAccessToken = Promise.promisify(
+ManagementTokenProvider.prototype._getCachedAccessToken = promisify(
   memoizer({
     load(options, callback) {
       const { domain, scope, audience } = options;

--- a/src/management/ManagementTokenProvider.js
+++ b/src/management/ManagementTokenProvider.js
@@ -1,4 +1,5 @@
-const { promisify } = require('util');
+// @todo: remove bluebird when node v6 becomes EoL
+const { promisify } = require('bluebird');
 const { ArgumentError } = require('rest-facade');
 const memoizer = require('lru-memoizer');
 const AuthenticationClient = require('../auth');

--- a/src/management/ManagementTokenProvider.js
+++ b/src/management/ManagementTokenProvider.js
@@ -1,5 +1,5 @@
 // @todo: remove bluebird when node v6 becomes EoL
-const { promisify } = require('bluebird');
+const { promisify } = require('es6-promisify');
 const { ArgumentError } = require('rest-facade');
 const memoizer = require('lru-memoizer');
 const AuthenticationClient = require('../auth');

--- a/src/management/ResourceServersManager.js
+++ b/src/management/ResourceServersManager.js
@@ -153,7 +153,7 @@ wrapPropertyMethod(ResourceServersManager, 'get', 'resource.get');
  *     // Handle error.
  *   }
  *
- *   console.log(resourceServer.name);  // 'newResourceServernName'
+ *   console.log(resourceServer.name);  // 'newResourceServerName'
  * });
  *
  * @param   {Object}    params            Resource Server parameters.

--- a/src/management/ResourceServersManager.js
+++ b/src/management/ResourceServersManager.js
@@ -1,7 +1,7 @@
-var ArgumentError = require('rest-facade').ArgumentError;
-var utils = require('../utils');
-var Auth0RestClient = require('../Auth0RestClient');
-var RetryRestClient = require('../RetryRestClient');
+const { ArgumentError } = require('rest-facade');
+const { wrapPropertyMethod } = require('../utils');
+const Auth0RestClient = require('../Auth0RestClient');
+const RetryRestClient = require('../RetryRestClient');
 
 /**
  * @class ResourceServersManager
@@ -21,42 +21,46 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} [options.retry]    Retry Policy Config
  */
 
-var ResourceServersManager = function(options) {
-  if (options === null || typeof options !== 'object') {
-    throw new ArgumentError('Must provide resource server options');
+class ResourceServersManager {
+  constructor(options) {
+    if (options === null || typeof options !== 'object') {
+      throw new ArgumentError('Must provide resource server options');
+    }
+
+    if (options.baseUrl === null || options.baseUrl === undefined) {
+      throw new ArgumentError('Must provide a base URL for the API');
+    }
+
+    if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
+      throw new ArgumentError('The provided base URL is invalid');
+    }
+
+    const { headers, baseUrl, tokenProvider, retry } = options;
+
+    /**
+     * Options object for the Rest Client instance.
+     *
+     * @type {Object}
+     */
+    const clientOptions = {
+      headers,
+      query: { repeatParams: false }
+    };
+
+    /**
+     * Provides an abstraction layer for consuming the
+     * {@link https://auth0.com/docs/api/v2#!/ResourceServers Auth0 Resource Servers endpoint}.
+     *
+     * @type {external:RestClient}
+     */
+    const auth0RestClient = new Auth0RestClient(
+      `${baseUrl}/resource-servers/:id`,
+      clientOptions,
+      tokenProvider
+    );
+    this.resource = new RetryRestClient(auth0RestClient, retry);
   }
-
-  if (options.baseUrl === null || options.baseUrl === undefined) {
-    throw new ArgumentError('Must provide a base URL for the API');
-  }
-
-  if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
-    throw new ArgumentError('The provided base URL is invalid');
-  }
-
-  /**
-   * Options object for the Rest Client instance.
-   *
-   * @type {Object}
-   */
-  var clientOptions = {
-    headers: options.headers,
-    query: { repeatParams: false }
-  };
-
-  /**
-   * Provides an abstraction layer for consuming the
-   * {@link https://auth0.com/docs/api/v2#!/ResourceServers Auth0 Resource Servers endpoint}.
-   *
-   * @type {external:RestClient}
-   */
-  var auth0RestClient = new Auth0RestClient(
-    options.baseUrl + '/resource-servers/:id',
-    clientOptions,
-    options.tokenProvider
-  );
-  this.resource = new RetryRestClient(auth0RestClient, options.retry);
-};
+}
 
 /**
  * Create an API (Resource Server).
@@ -78,7 +82,7 @@ var ResourceServersManager = function(options) {
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(ResourceServersManager, 'create', 'resource.create');
+wrapPropertyMethod(ResourceServersManager, 'create', 'resource.create');
 
 /**
  * Get all resource servers.
@@ -93,7 +97,7 @@ utils.wrapPropertyMethod(ResourceServersManager, 'create', 'resource.create');
  * </caption>
  *
  * // Pagination settings.
- * var params = {
+ * const params = {
  *   per_page: 10,
  *   page: 0
  * };
@@ -109,7 +113,7 @@ utils.wrapPropertyMethod(ResourceServersManager, 'create', 'resource.create');
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(ResourceServersManager, 'getAll', 'resource.getAll');
+wrapPropertyMethod(ResourceServersManager, 'getAll', 'resource.getAll');
 
 /**
  * Get a Resource Server.
@@ -132,7 +136,7 @@ utils.wrapPropertyMethod(ResourceServersManager, 'getAll', 'resource.getAll');
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(ResourceServersManager, 'get', 'resource.get');
+wrapPropertyMethod(ResourceServersManager, 'get', 'resource.get');
 
 /**
  * Update an existing resource server.
@@ -141,8 +145,8 @@ utils.wrapPropertyMethod(ResourceServersManager, 'get', 'resource.get');
  * @memberOf  module:management.ResourceServersManager.prototype
  *
  * @example
- * var data = { name: 'newResourceServerName' };
- * var params = { id: RESOURCE_SERVER_ID };
+ * const data = { name: 'newResourceServerName' };
+ * const params = { id: RESOURCE_SERVER_ID };
  *
  * management.resourceServers.update(params, data, function (err, resourceServer) {
  *   if (err) {
@@ -159,7 +163,7 @@ utils.wrapPropertyMethod(ResourceServersManager, 'get', 'resource.get');
  *
  * @return    {Promise|undefined}
  */
-utils.wrapPropertyMethod(ResourceServersManager, 'update', 'resource.patch');
+wrapPropertyMethod(ResourceServersManager, 'update', 'resource.patch');
 
 /**
  * Delete an existing Resource Server.
@@ -182,6 +186,6 @@ utils.wrapPropertyMethod(ResourceServersManager, 'update', 'resource.patch');
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(ResourceServersManager, 'delete', 'resource.delete');
+wrapPropertyMethod(ResourceServersManager, 'delete', 'resource.delete');
 
 module.exports = ResourceServersManager;

--- a/src/management/RulesConfigsManager.js
+++ b/src/management/RulesConfigsManager.js
@@ -1,14 +1,13 @@
-var ArgumentError = require('rest-facade').ArgumentError;
-var utils = require('../utils');
-var Auth0RestClient = require('../Auth0RestClient');
-var RetryRestClient = require('../RetryRestClient');
+const { ArgumentError } = require('rest-facade');
+const { wrapPropertyMethod } = require('../utils');
+const Auth0RestClient = require('../Auth0RestClient');
+const RetryRestClient = require('../RetryRestClient');
 
 /**
  * Simple facade for consuming a REST API endpoint.
  * @external RestClient
  * @see https://github.com/ngonzalvez/rest-facade
  */
-
 
 /**
  * @class RulesConfigsManager
@@ -22,39 +21,46 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} [options.headers]  Headers to be included in all requests.
  * @param {Object} [options.retry]    Retry Policy Config
  */
-var RulesConfigsManager = function (options) {
-  if (options === null || typeof options !== 'object') {
-    throw new ArgumentError('Must provide manager options');
+class RulesConfigsManager {
+  constructor(options) {
+    if (options === null || typeof options !== 'object') {
+      throw new ArgumentError('Must provide manager options');
+    }
+
+    if (options.baseUrl === null || options.baseUrl === undefined) {
+      throw new ArgumentError('Must provide a base URL for the API');
+    }
+
+    if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
+      throw new ArgumentError('The provided base URL is invalid');
+    }
+
+    const { headers, tokenProvider, retry, baseUrl } = options;
+
+    /**
+     * Options object for the Rest Client instance.
+     *
+     * @type {Object}
+     */
+    const clientOptions = {
+      headers,
+      query: { repeatParams: false }
+    };
+
+    /**
+     * Provides an abstraction layer for performing CRUD operations on
+     * {@link https://auth0.com/docs/api/v2#!/RulesConfigsManager Auth0 RulesConfigsManager}.
+     *
+     * @type {external:RestClient}
+     */
+    const auth0RestClient = new Auth0RestClient(
+      `${baseUrl}/rules-configs/:key`,
+      clientOptions,
+      tokenProvider
+    );
+    this.resource = new RetryRestClient(auth0RestClient, retry);
   }
-
-  if (options.baseUrl === null || options.baseUrl === undefined) {
-    throw new ArgumentError('Must provide a base URL for the API');
-  }
-
-  if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
-    throw new ArgumentError('The provided base URL is invalid');
-  }
-
-  /**
-   * Options object for the Rest Client instance.
-   *
-   * @type {Object}
-   */
-  var clientOptions = {
-    headers: options.headers,
-    query: { repeatParams: false }
-  };
-
-  /**
-   * Provides an abstraction layer for performing CRUD operations on
-   * {@link https://auth0.com/docs/api/v2#!/RulesConfigsManager Auth0 RulesConfigsManager}.
-   *
-   * @type {external:RestClient}
-   */
-  var auth0RestClient = new Auth0RestClient(options.baseUrl + '/rules-configs/:key', clientOptions, options.tokenProvider);
-  this.resource = new RetryRestClient(auth0RestClient, options.retry);
-};
-
+}
 
 /**
  * Set a new rules config.
@@ -63,9 +69,9 @@ var RulesConfigsManager = function (options) {
  * @memberOf  module:management.RulesConfigsManager.prototype
  *
  * @example
- * var params = { key: RULE_CONFIG_KEY };
- * var data =   { value: RULES_CONFIG_VALUE };
- *  
+ * const params = { key: RULE_CONFIG_KEY };
+ * const data =   { value: RULES_CONFIG_VALUE };
+ *
  * management.rulesConfigs.set(params, data, function (err, rulesConfig) {
  *   if (err) {
  *     // Handle error.
@@ -82,8 +88,7 @@ var RulesConfigsManager = function (options) {
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(RulesConfigsManager, 'set', 'resource.update');
-
+wrapPropertyMethod(RulesConfigsManager, 'set', 'resource.update');
 
 /**
  * Get all rules configs.
@@ -100,8 +105,7 @@ utils.wrapPropertyMethod(RulesConfigsManager, 'set', 'resource.update');
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(RulesConfigsManager, 'getAll', 'resource.getAll');
-
+wrapPropertyMethod(RulesConfigsManager, 'getAll', 'resource.getAll');
 
 /**
  * Delete an existing rules config.
@@ -124,6 +128,6 @@ utils.wrapPropertyMethod(RulesConfigsManager, 'getAll', 'resource.getAll');
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(RulesConfigsManager, 'delete', 'resource.delete');
+wrapPropertyMethod(RulesConfigsManager, 'delete', 'resource.delete');
 
 module.exports = RulesConfigsManager;

--- a/src/management/RulesManager.js
+++ b/src/management/RulesManager.js
@@ -1,7 +1,7 @@
-var ArgumentError = require('rest-facade').ArgumentError;
-var utils = require('../utils');
-var Auth0RestClient = require('../Auth0RestClient');
-var RetryRestClient = require('../RetryRestClient');
+const { ArgumentError } = require('rest-facade');
+const { wrapPropertyMethod } = require('../utils');
+const Auth0RestClient = require('../Auth0RestClient');
+const RetryRestClient = require('../RetryRestClient');
 
 /**
  * Simple facade for consuming a REST API endpoint.
@@ -21,42 +21,46 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} [options.headers]  Headers to be included in all requests.
  * @param {Object} [options.retry]    Retry Policy Config
  */
-var RulesManager = function(options) {
-  if (options === null || typeof options !== 'object') {
-    throw new ArgumentError('Must provide manager options');
+class RulesManager {
+  constructor(options) {
+    if (options === null || typeof options !== 'object') {
+      throw new ArgumentError('Must provide manager options');
+    }
+
+    if (options.baseUrl === null || options.baseUrl === undefined) {
+      throw new ArgumentError('Must provide a base URL for the API');
+    }
+
+    if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
+      throw new ArgumentError('The provided base URL is invalid');
+    }
+
+    const { headers, baseUrl, tokenProvider, retry } = options;
+
+    /**
+     * Options object for the Rest Client instance.
+     *
+     * @type {Object}
+     */
+    const clientOptions = {
+      headers,
+      query: { repeatParams: false }
+    };
+
+    /**
+     * Provides an abstraction layer for performing CRUD operations on
+     * {@link https://auth0.com/docs/api/v2#!/RulesManagers Auth0 RulesManagers}.
+     *
+     * @type {external:RestClient}
+     */
+    const auth0RestClient = new Auth0RestClient(
+      `${baseUrl}/rules/:id`,
+      clientOptions,
+      tokenProvider
+    );
+    this.resource = new RetryRestClient(auth0RestClient, retry);
   }
-
-  if (options.baseUrl === null || options.baseUrl === undefined) {
-    throw new ArgumentError('Must provide a base URL for the API');
-  }
-
-  if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
-    throw new ArgumentError('The provided base URL is invalid');
-  }
-
-  /**
-   * Options object for the Rest Client instance.
-   *
-   * @type {Object}
-   */
-  var clientOptions = {
-    headers: options.headers,
-    query: { repeatParams: false }
-  };
-
-  /**
-   * Provides an abstraction layer for performing CRUD operations on
-   * {@link https://auth0.com/docs/api/v2#!/RulesManagers Auth0 RulesManagers}.
-   *
-   * @type {external:RestClient}
-   */
-  var auth0RestClient = new Auth0RestClient(
-    options.baseUrl + '/rules/:id',
-    clientOptions,
-    options.tokenProvider
-  );
-  this.resource = new RetryRestClient(auth0RestClient, options.retry);
-};
+}
 
 /**
  * Create a new rule.
@@ -78,7 +82,7 @@ var RulesManager = function(options) {
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(RulesManager, 'create', 'resource.create');
+wrapPropertyMethod(RulesManager, 'create', 'resource.create');
 
 /**
  * Get all rules.
@@ -93,7 +97,7 @@ utils.wrapPropertyMethod(RulesManager, 'create', 'resource.create');
  * </caption>
  *
  * // Pagination settings.
- * var params = {
+ * const params = {
  *   per_page: 10,
  *   page: 0
  * };
@@ -109,7 +113,7 @@ utils.wrapPropertyMethod(RulesManager, 'create', 'resource.create');
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(RulesManager, 'getAll', 'resource.getAll');
+wrapPropertyMethod(RulesManager, 'getAll', 'resource.getAll');
 
 /**
  * Get an Auth0 rule.
@@ -132,7 +136,7 @@ utils.wrapPropertyMethod(RulesManager, 'getAll', 'resource.getAll');
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(RulesManager, 'get', 'resource.get');
+wrapPropertyMethod(RulesManager, 'get', 'resource.get');
 
 /**
  * Update an existing rule.
@@ -141,8 +145,8 @@ utils.wrapPropertyMethod(RulesManager, 'get', 'resource.get');
  * @memberOf  module:management.RulesManager.prototype
  *
  * @example
- * var data = { name: 'New name' };
- * var params = { id: RULE_ID };
+ * const data = { name: 'New name' };
+ * const params = { id: RULE_ID };
  *
  * // Using auth0 instance.
  * management.updateRule(params, data, function (err, rule) {
@@ -169,7 +173,7 @@ utils.wrapPropertyMethod(RulesManager, 'get', 'resource.get');
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(RulesManager, 'update', 'resource.patch');
+wrapPropertyMethod(RulesManager, 'update', 'resource.patch');
 
 /**
  * Delete an existing rule.
@@ -192,6 +196,6 @@ utils.wrapPropertyMethod(RulesManager, 'update', 'resource.patch');
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(RulesManager, 'delete', 'resource.delete');
+wrapPropertyMethod(RulesManager, 'delete', 'resource.delete');
 
 module.exports = RulesManager;

--- a/src/management/StatsManager.js
+++ b/src/management/StatsManager.js
@@ -1,6 +1,6 @@
-var ArgumentError = require('rest-facade').ArgumentError;
-var Auth0RestClient = require('../Auth0RestClient');
-var RetryRestClient = require('../RetryRestClient');
+const { ArgumentError } = require('rest-facade');
+const Auth0RestClient = require('../Auth0RestClient');
+const RetryRestClient = require('../RetryRestClient');
 
 /**
  * Simple facade for consuming a REST API endpoint.
@@ -19,105 +19,108 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} [options.headers]  Headers to be included in all requests.
  * @param {Object} [options.retry]    Retry Policy Config
  */
-var StatsManager = function(options) {
-  if (options === null || typeof options !== 'object') {
-    throw new ArgumentError('Must provide manager options');
-  }
+class StatsManager {
+  constructor(options) {
+    if (options === null || typeof options !== 'object') {
+      throw new ArgumentError('Must provide manager options');
+    }
 
-  if (options.baseUrl === null || options.baseUrl === undefined) {
-    throw new ArgumentError('Must provide a base URL for the API');
-  }
+    if (options.baseUrl === null || options.baseUrl === undefined) {
+      throw new ArgumentError('Must provide a base URL for the API');
+    }
 
-  if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
-    throw new ArgumentError('The provided base URL is invalid');
-  }
+    if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
+      throw new ArgumentError('The provided base URL is invalid');
+    }
 
-  var clientOptions = {
-    errorFormatter: { message: 'message', name: 'error' },
-    headers: options.headers,
-    query: { repeatParams: false }
-  };
+    const { headers, baseUrl, tokenProvider, retry } = options;
+
+    const clientOptions = {
+      errorFormatter: { message: 'message', name: 'error' },
+      headers,
+      query: { repeatParams: false }
+    };
+
+    /**
+     * Provides an abstraction layer for consuming the
+     * {@link https://auth0.com/docs/api/v2#!/Stats Stats endpoint}.
+     *
+     * @type {external:RestClient}
+     */
+    const auth0RestClient = new Auth0RestClient(
+      `${baseUrl}/stats/:type`,
+      clientOptions,
+      tokenProvider
+    );
+    this.stats = new RetryRestClient(auth0RestClient, retry);
+  }
 
   /**
-   * Provides an abstraction layer for consuming the
-   * {@link https://auth0.com/docs/api/v2#!/Stats Stats endpoint}.
+   * Get the daily stats.
    *
-   * @type {external:RestClient}
+   * @method    getDaily
+   * @memberOf  module:management.StatsManager.prototype
+   *
+   * @example
+   * const params = {
+   *   from: '{YYYYMMDD}',  // First day included in the stats.
+   *   to: '{YYYYMMDD}'  // Last day included in the stats.
+   * };
+   *
+   * management.stats.getDaily(params, function (err, stats) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   *
+   *   console.log(stats);
+   * });
+   *
+   * @param   {Object}    params        Stats parameters.
+   * @param   {String}    params.from   The first day in YYYYMMDD format.
+   * @param   {String}    params.to     The last day in YYYYMMDD format.
+   * @param   {Function}  [cb]          Callback function.
+   *
+   * @return  {Promise|undefined}
    */
-  var auth0RestClient = new Auth0RestClient(
-    options.baseUrl + '/stats/:type',
-    clientOptions,
-    options.tokenProvider
-  );
-  this.stats = new RetryRestClient(auth0RestClient, options.retry);
-};
+  getDaily(params = {}, cb) {
+    params.type = 'daily';
 
-/**
- * Get the daily stats.
- *
- * @method    getDaily
- * @memberOf  module:management.StatsManager.prototype
- *
- * @example
- * var params = {
- *   from: '{YYYYMMDD}',  // First day included in the stats.
- *   to: '{YYYYMMDD}'  // Last day included in the stats.
- * };
- *
- * management.stats.getDaily(params, function (err, stats) {
- *   if (err) {
- *     // Handle error.
- *   }
- *
- *   console.log(stats);
- * });
- *
- * @param   {Object}    params        Stats parameters.
- * @param   {String}    params.from   The first day in YYYYMMDD format.
- * @param   {String}    params.to     The last day in YYYYMMDD format.
- * @param   {Function}  [cb]          Callback function.
- *
- * @return  {Promise|undefined}
- */
-StatsManager.prototype.getDaily = function(params, cb) {
-  params = params || {};
-  params.type = 'daily';
+    if (cb && cb instanceof Function) {
+      return this.stats.get(params, cb);
+    }
 
-  if (cb && cb instanceof Function) {
-    return this.stats.get(params, cb);
+    return this.stats.get(params);
   }
 
-  return this.stats.get(params);
-};
+  /**
+   * Get a the active users count.
+   *
+   * @method    getActiveUsersCount
+   * @memberOf  module:management.StatsManager.prototype
+   *
+   * @example
+   * management.stats.getActiveUsersCount(function (err, usersCount) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   *
+   *   console.log(usersCount);
+   * });
+   *
+   * @param   {Function}  [cb]  Callback function.
+   *
+   * @return  {Promise|undefined}
+   */
+  getActiveUsersCount(cb) {
+    const options = { type: 'active-users' };
 
-/**
- * Get a the active users count.
- *
- * @method    getActiveUsersCount
- * @memberOf  module:management.StatsManager.prototype
- *
- * @example
- * management.stats.getActiveUsersCount(function (err, usersCount) {
- *   if (err) {
- *     // Handle error.
- *   }
- *
- *   console.log(usersCount);
- * });
- *
- * @param   {Function}  [cb]  Callback function.
- *
- * @return  {Promise|undefined}
- */
-StatsManager.prototype.getActiveUsersCount = function(cb) {
-  var options = { type: 'active-users' };
+    if (cb && cb instanceof Function) {
+      return this.stats.get(options, cb);
+    }
 
-  if (cb && cb instanceof Function) {
-    return this.stats.get(options, cb);
+    // Return a promise.
+    return this.stats.get(options);
   }
-
-  // Return a promise.
-  return this.stats.get(options);
-};
+}
 
 module.exports = StatsManager;

--- a/src/management/TenantManager.js
+++ b/src/management/TenantManager.js
@@ -1,6 +1,6 @@
-var ArgumentError = require('rest-facade').ArgumentError;
-var Auth0RestClient = require('../Auth0RestClient');
-var RetryRestClient = require('../RetryRestClient');
+const { ArgumentError } = require('rest-facade');
+const Auth0RestClient = require('../Auth0RestClient');
+const RetryRestClient = require('../RetryRestClient');
 
 /**
  * Simple facade for consuming a REST API endpoint.
@@ -19,92 +19,96 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} [options.headers]  Headers to be included in all requests.
  * @param {Object} [options.retry]    Retry Policy Config
  */
-var TenantManager = function(options) {
-  if (options === null || typeof options !== 'object') {
-    throw new ArgumentError('Must provide manager options');
-  }
+class TenantManager {
+  constructor(options) {
+    if (options === null || typeof options !== 'object') {
+      throw new ArgumentError('Must provide manager options');
+    }
 
-  if (options.baseUrl === null || options.baseUrl === undefined) {
-    throw new ArgumentError('Must provide a base URL for the API');
-  }
+    if (options.baseUrl === null || options.baseUrl === undefined) {
+      throw new ArgumentError('Must provide a base URL for the API');
+    }
 
-  if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
-    throw new ArgumentError('The provided base URL is invalid');
-  }
+    if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
+      throw new ArgumentError('The provided base URL is invalid');
+    }
 
-  var clientOptions = {
-    errorFormatter: { message: 'message', name: 'error' },
-    headers: options.headers,
-    query: { repeatParams: false }
-  };
+    const { headers, baseUrl, tokenProvider, retry } = options;
+
+    const clientOptions = {
+      errorFormatter: { message: 'message', name: 'error' },
+      headers,
+      query: { repeatParams: false }
+    };
+
+    /**
+     * Provides an abstraction layer for consuming the
+     * {@link https://auth0.com/docs/api/v2#!/Stats Stats endpoint}.
+     *
+     * @type {external:RestClient}
+     */
+    const auth0RestClient = new Auth0RestClient(
+      `${baseUrl}/tenants/settings`,
+      clientOptions,
+      tokenProvider
+    );
+    this.tenant = new RetryRestClient(auth0RestClient, retry);
+  }
 
   /**
-   * Provides an abstraction layer for consuming the
-   * {@link https://auth0.com/docs/api/v2#!/Stats Stats endpoint}.
+   * Update the tenant settings.
    *
-   * @type {external:RestClient}
+   * @method    updateSettings
+   * @memberOf  module:management.TenantManager.prototype
+   *
+   * @example
+   * management.tenant.updateSettings(data, function (err) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   * });
+   *
+   * @param   {Object}    data  The new tenant settings.
+   * @param   {Function}  [cb]  Callback function.
+   *
+   * @return  {Promise|undefined}
    */
-  var auth0RestClient = new Auth0RestClient(
-    options.baseUrl + '/tenants/settings',
-    clientOptions,
-    options.tokenProvider
-  );
-  this.tenant = new RetryRestClient(auth0RestClient, options.retry);
-};
+  updateSettings(data, cb) {
+    if (cb && cb instanceof Function) {
+      return this.tenant.patch({}, data, cb);
+    }
 
-/**
- * Update the tenant settings.
- *
- * @method    updateSettings
- * @memberOf  module:management.TenantManager.prototype
- *
- * @example
- * management.tenant.updateSettings(data, function (err) {
- *   if (err) {
- *     // Handle error.
- *   }
- * });
- *
- * @param   {Object}    data  The new tenant settings.
- * @param   {Function}  [cb]  Callback function.
- *
- * @return  {Promise|undefined}
- */
-TenantManager.prototype.updateSettings = function(data, cb) {
-  if (cb && cb instanceof Function) {
-    return this.tenant.patch({}, data, cb);
+    // Return a promise.
+    return this.tenant.patch({}, data);
   }
 
-  // Return a promise.
-  return this.tenant.patch({}, data);
-};
+  /**
+   * Get the tenant settings..
+   *
+   * @method    getSettings
+   * @memberOf  module:management.TenantManager.prototype
+   *
+   * @example
+   * management.tenant.getSettings(function (err, settings) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   *
+   *   console.log(settings);
+   * });
+   *
+   * @param   {Function}  [cb]  Callback function.
+   *
+   * @return  {Promise|undefined}
+   */
+  getSettings(cb) {
+    if (cb && cb instanceof Function) {
+      return this.tenant.get({}, cb);
+    }
 
-/**
- * Get the tenant settings..
- *
- * @method    getSettings
- * @memberOf  module:management.TenantManager.prototype
- *
- * @example
- * management.tenant.getSettings(function (err, settings) {
- *   if (err) {
- *     // Handle error.
- *   }
- *
- *   console.log(settings);
- * });
- *
- * @param   {Function}  [cb]  Callback function.
- *
- * @return  {Promise|undefined}
- */
-TenantManager.prototype.getSettings = function(cb) {
-  if (cb && cb instanceof Function) {
-    return this.tenant.get({}, cb);
+    // Return a promise.
+    return this.tenant.get({});
   }
-
-  // Return a promise.
-  return this.tenant.get({});
-};
+}
 
 module.exports = TenantManager;

--- a/src/management/TicketsManager.js
+++ b/src/management/TicketsManager.js
@@ -1,6 +1,6 @@
-var ArgumentError = require('rest-facade').ArgumentError;
-var Auth0RestClient = require('../Auth0RestClient');
-var RetryRestClient = require('../RetryRestClient');
+const { ArgumentError } = require('rest-facade');
+const Auth0RestClient = require('../Auth0RestClient');
+const RetryRestClient = require('../RetryRestClient');
 
 /**
  * @class
@@ -13,103 +13,107 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} [options.headers]  Headers to be included in all requests.
  * @param {Object} [options.retry]    Retry Policy Config
  */
-var TicketsManager = function(options) {
-  if (options === null || typeof options !== 'object') {
-    throw new ArgumentError('Must provide manager options');
-  }
+class TicketsManager {
+  constructor(options) {
+    if (options === null || typeof options !== 'object') {
+      throw new ArgumentError('Must provide manager options');
+    }
 
-  if (options.baseUrl === null || options.baseUrl === undefined) {
-    throw new ArgumentError('Must provide a base URL for the API');
-  }
+    if (options.baseUrl === null || options.baseUrl === undefined) {
+      throw new ArgumentError('Must provide a base URL for the API');
+    }
 
-  if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
-    throw new ArgumentError('The provided base URL is invalid');
-  }
+    if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
+      throw new ArgumentError('The provided base URL is invalid');
+    }
 
-  var clientOptions = {
-    errorFormatter: { message: 'message', name: 'error' },
-    headers: options.headers,
-    query: { repeatParams: false }
-  };
+    const { headers, baseUrl, tokenProvider, retry } = options;
+
+    const clientOptions = {
+      errorFormatter: { message: 'message', name: 'error' },
+      headers,
+      query: { repeatParams: false }
+    };
+
+    /**
+     * Provides an abstraction layer for consuming the
+     * {@link https://auth0.com/docs/api/v2#!/Tickets Tickets endpoint}.
+     *
+     * @type {external:RestClient}
+     */
+    const auth0RestClient = new Auth0RestClient(
+      `${baseUrl}/tickets/:type`,
+      clientOptions,
+      tokenProvider
+    );
+    this.ticket = new RetryRestClient(auth0RestClient, retry);
+  }
 
   /**
-   * Provides an abstraction layer for consuming the
-   * {@link https://auth0.com/docs/api/v2#!/Tickets Tickets endpoint}.
+   * Create a new password change ticket.
    *
-   * @type {external:RestClient}
+   * @method    changePassword
+   * @memberOf  module:management.TicketsManager.prototype
+   *
+   * @example
+   * const params = {
+   *   result_url: '{REDIRECT_URL}',  // Redirect after using the ticket.
+   *   user_id: '{USER_ID}',  // Optional.
+   *   email: '{USER_EMAIL}',  // Optional.
+   *   new_password: '{PASSWORD}'
+   * };
+   *
+   * management.tickets.changePassword(params, function (err) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   * });
+   *
+   * @param   {Function}  [cb]  Callback function.
+   * @return  {Promise}
    */
-  var auth0RestClient = new Auth0RestClient(
-    options.baseUrl + '/tickets/:type',
-    clientOptions,
-    options.tokenProvider
-  );
-  this.ticket = new RetryRestClient(auth0RestClient, options.retry);
-};
+  changePassword(data, cb) {
+    const params = { type: 'password-change' };
 
-/**
- * Create a new password change ticket.
- *
- * @method    changePassword
- * @memberOf  module:management.TicketsManager.prototype
- *
- * @example
- * var params = {
- *   result_url: '{REDIRECT_URL}',  // Redirect after using the ticket.
- *   user_id: '{USER_ID}',  // Optional.
- *   email: '{USER_EMAIL}',  // Optional.
- *   new_password: '{PASSWORD}'
- * };
- *
- * management.tickets.changePassword(params, function (err) {
- *   if (err) {
- *     // Handle error.
- *   }
- * });
- *
- * @param   {Function}  [cb]  Callback function.
- * @return  {Promise}
- */
-TicketsManager.prototype.changePassword = function(data, cb) {
-  var params = { type: 'password-change' };
+    if (cb && cb instanceof Function) {
+      return this.ticket.create(params, data, cb);
+    }
 
-  if (cb && cb instanceof Function) {
-    return this.ticket.create(params, data, cb);
+    // Return a promise.
+    return this.ticket.create(params, data);
   }
 
-  // Return a promise.
-  return this.ticket.create(params, data);
-};
+  /**
+   * Create an email verification ticket.
+   *
+   * @method    verifyEmail
+   * @memberOf  module:management.TicketsManager.prototype
+   *
+   * @example
+   * const data = {
+   *   user_id: '{USER_ID}',
+   *   result_url: '{REDIRECT_URL}' // Optional redirect after the ticket is used.
+   * };
+   *
+   * management.tickets.verifyEmail(data, function (err) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   * });
+   *
+   * @param   {Function}  [cb]  Callback function.
+   * @return  {Promise}
+   */
+  verifyEmail(data, cb) {
+    const params = { type: 'email-verification' };
 
-/**
- * Create an email verification ticket.
- *
- * @method    verifyEmail
- * @memberOf  module:management.TicketsManager.prototype
- *
- * @example
- * var data = {
- *   user_id: '{USER_ID}',
- *   result_url: '{REDIRECT_URL}' // Optional redirect after the ticket is used.
- * };
- *
- * management.tickets.verifyEmail(data, function (err) {
- *   if (err) {
- *     // Handle error.
- *   }
- * });
- *
- * @param   {Function}  [cb]  Callback function.
- * @return  {Promise}
- */
-TicketsManager.prototype.verifyEmail = function(data, cb) {
-  var params = { type: 'email-verification' };
+    if (cb && cb instanceof Function) {
+      return this.ticket.create(params, data, cb);
+    }
 
-  if (cb && cb instanceof Function) {
-    return this.ticket.create(params, data, cb);
+    // Return a promise.
+    return this.ticket.create(params, data);
   }
-
-  // Return a promise.
-  return this.ticket.create(params, data);
-};
+}
 
 module.exports = TicketsManager;

--- a/src/management/UsersManager.js
+++ b/src/management/UsersManager.js
@@ -1,6 +1,6 @@
-var ArgumentError = require('rest-facade').ArgumentError;
-var Auth0RestClient = require('../Auth0RestClient');
-var RetryRestClient = require('../RetryRestClient');
+const { ArgumentError } = require('rest-facade');
+const Auth0RestClient = require('../Auth0RestClient');
+const RetryRestClient = require('../RetryRestClient');
 
 /**
  * Simple facade for consuming a REST API endpoint.
@@ -19,606 +19,602 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} [options.headers]  Headers to be included in all requests.
  * @param {Object} [options.retry]    Retry Policy Config
  */
-var UsersManager = function(options) {
-  if (options === null || typeof options !== 'object') {
-    throw new ArgumentError('Must provide manager options');
+class UsersManager {
+  constructor(options) {
+    if (options === null || typeof options !== 'object') {
+      throw new ArgumentError('Must provide manager options');
+    }
+
+    if (options.baseUrl === null || options.baseUrl === undefined) {
+      throw new ArgumentError('Must provide a base URL for the API');
+    }
+
+    if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
+      throw new ArgumentError('The provided base URL is invalid');
+    }
+
+    const { headers, baseUrl, tokenProvider, retry } = options;
+
+    const clientOptions = {
+      errorFormatter: { message: 'message', name: 'error' },
+      headers,
+      query: { repeatParams: false }
+    };
+
+    const usersAuth0RestClient = new Auth0RestClient(
+      `${baseUrl}/users/:id`,
+      clientOptions,
+      tokenProvider
+    );
+    this.users = new RetryRestClient(usersAuth0RestClient, retry);
+
+    /**
+     * Provides an abstraction layer for consuming the
+     * {@link https://auth0.com/docs/api/v2#!/Users/delete_multifactor_by_provider
+     * Multifactor Provider endpoint}.
+     *
+     * @type {external:RestClient}
+     */
+    const multifactorAuth0RestClient = new Auth0RestClient(
+      `${baseUrl}/users/:id/multifactor/:provider`,
+      clientOptions,
+      tokenProvider
+    );
+    this.multifactor = new RetryRestClient(multifactorAuth0RestClient, retry);
+
+    /**
+     * Provides a simple abstraction layer for linking user accounts.
+     *
+     * @type {external:RestClient}
+     */
+    const identitiesAuth0RestClient = new Auth0RestClient(
+      `${baseUrl}/users/:id/identities/:provider/:user_id`,
+      clientOptions,
+      tokenProvider
+    );
+    this.identities = new RetryRestClient(identitiesAuth0RestClient, retry);
+
+    /**
+     * Provides a simple abstraction layer for user logs
+     *
+     * @type {external:RestClient}
+     */
+    const userLogsAuth0RestClient = new Auth0RestClient(
+      `${baseUrl}/users/:id/logs`,
+      clientOptions,
+      tokenProvider
+    );
+    this.userLogs = new RetryRestClient(userLogsAuth0RestClient, retry);
+
+    /**
+     * Provides an abstraction layer for retrieving Guardian enrollments.
+     *
+     * @type {external:RestClient}
+     */
+    const enrollmentsAuth0RestClient = new Auth0RestClient(
+      `${baseUrl}/users/:id/enrollments`,
+      clientOptions,
+      tokenProvider
+    );
+    this.enrollments = new RetryRestClient(enrollmentsAuth0RestClient, retry);
+
+    /**
+     * Provides an abstraction layer for the new "users-by-email" API
+     *
+     * @type {external:RestClient}
+     */
+    const usersByEmailClient = new Auth0RestClient(
+      `${baseUrl}/users-by-email`,
+      clientOptions,
+      tokenProvider
+    );
+    this.usersByEmail = new RetryRestClient(usersByEmailClient, retry);
+
+    /**
+     * Provides an abstraction layer for regenerating Guardian recovery codes.
+     *
+     * @type {external:RestClient}
+     */
+    const recoveryCodeRegenerationAuth0RestClients = new Auth0RestClient(
+      `${baseUrl}/users/:id/recovery-code-regeneration`,
+      clientOptions,
+      tokenProvider
+    );
+    this.recoveryCodeRegenerations = new RetryRestClient(
+      recoveryCodeRegenerationAuth0RestClients,
+      retry
+    );
   }
-
-  if (options.baseUrl === null || options.baseUrl === undefined) {
-    throw new ArgumentError('Must provide a base URL for the API');
-  }
-
-  if ('string' !== typeof options.baseUrl || options.baseUrl.length === 0) {
-    throw new ArgumentError('The provided base URL is invalid');
-  }
-
-  var clientOptions = {
-    errorFormatter: { message: 'message', name: 'error' },
-    headers: options.headers,
-    query: { repeatParams: false }
-  };
-
-  var usersAuth0RestClient = new Auth0RestClient(
-    options.baseUrl + '/users/:id',
-    clientOptions,
-    options.tokenProvider
-  );
-  this.users = new RetryRestClient(usersAuth0RestClient, options.retry);
 
   /**
-   * Provides an abstraction layer for consuming the
-   * {@link https://auth0.com/docs/api/v2#!/Users/delete_multifactor_by_provider
-   * Multifactor Provider endpoint}.
+   * Create a new user.
    *
-   * @type {external:RestClient}
+   * @method    create
+   * @memberOf  module:management.UsersManager.prototype
+   *
+   * @example
+   * management.users.create(data, function (err) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   *
+   *   // User created.
+   * });
+   *
+   * @param   {Object}    data    User data.
+   * @param   {Function}  [cb]    Callback function.
+   *
+   * @return  {Promise|undefined}
    */
-  var multifactorAuth0RestClient = new Auth0RestClient(
-    options.baseUrl + '/users/:id/multifactor/:provider',
-    clientOptions,
-    options.tokenProvider
-  );
-  this.multifactor = new RetryRestClient(multifactorAuth0RestClient, options.retry);
+  create(data, cb) {
+    if (cb && cb instanceof Function) {
+      return this.users.create(data, cb);
+    }
+
+    return this.users.create(data);
+  }
 
   /**
-   * Provides a simple abstraction layer for linking user accounts.
+   * Get all users.
    *
-   * @type {external:RestClient}
+   * @method    getAll
+   * @memberOf  module:management.UsersManager.prototype
+   *
+   * @example <caption>
+   *   This method takes an optional object as first argument that may be used to
+   *   specify pagination settings and the search query. If pagination options are
+   *   not present, the first page of a limited number of results will be returned.
+   * </caption>
+   *
+   * // Pagination settings.
+   * const params = {
+   *   per_page: 10,
+   *   page: 0
+   * };
+   *
+   * management.users.getAll(params, function (err, users) {
+   *   console.log(users.length);
+   * });
+   *
+   * @param   {Object}    [params]          Users params.
+   * @param   {Number}    [params.per_page] Number of results per page.
+   * @param   {Number}    [params.page]     Page number, zero indexed.
+   * @param   {Function}  [cb]              Callback function.
+   *
+   * @return  {Promise|undefined}
    */
-  var identitiesAuth0RestClient = new Auth0RestClient(
-    options.baseUrl + '/users/:id/identities/:provider/:user_id',
-    clientOptions,
-    options.tokenProvider
-  );
-  this.identities = new RetryRestClient(identitiesAuth0RestClient, options.retry);
+  getAll(params) {
+    return this.users.getAll.apply(this.users, arguments);
+  }
 
   /**
-   * Provides a simple abstraction layer for user logs
+   * Get Users by an Email Address
    *
-   * @type {external:RestClient}
+   * @method    getByEmail
+   * @memberOf  module:management.UsersManager.prototype
+   *
+   * @example <caption>
+   *   This method takes a first argument as the Email address to look for
+   *   users, and uses the /users-by-email API, not the search API
+   * </caption>
+   *
+   * management.users.getByEmail('email@address', function (err, users) {
+   *   console.log(users);
+   * });
+   *
+   * @param   {String}    [email]           Email address of user(s) to find
+   * @param   {Function}  [cb]              Callback function.
+   *
+   * @return  {Promise|undefined}
    */
-  var userLogsAuth0RestClient = new Auth0RestClient(
-    options.baseUrl + '/users/:id/logs',
-    clientOptions,
-    options.tokenProvider
-  );
-  this.userLogs = new RetryRestClient(userLogsAuth0RestClient, options.retry);
+  getByEmail(email, callback) {
+    return this.usersByEmail.getAll({ email }, callback);
+  }
 
   /**
-   * Provides an abstraction layer for retrieving Guardian enrollments.
+   * Get a user by its id.
    *
-   * @type {external:RestClient}
+   * @method    get
+   * @memberOf  module:management.UsersManager.prototype
+   *
+   * @example
+   * management.users.get({ id: USER_ID }, function (err, user) {
+   *   console.log(user);
+   * });
+   *
+   * @param   {Object}    data      The user data object.
+   * @param   {String}    data.id   The user id.
+   * @param   {Function}  [cb]      Callback function.
+   *
+   * @return  {Promise|undefined}
    */
-  var enrollmentsAuth0RestClient = new Auth0RestClient(
-    options.baseUrl + '/users/:id/enrollments',
-    clientOptions,
-    options.tokenProvider
-  );
-  this.enrollments = new RetryRestClient(enrollmentsAuth0RestClient, options.retry);
+  get(...args) {
+    return this.users.get.apply(this.users, args);
+  }
 
   /**
-   * Provides an abstraction layer for the new "users-by-email" API
+   * Update a user by its id.
    *
-   * @type {external:RestClient}
+   * @method    update
+   * @memberOf  module:management.UsersManager.prototype
+   *
+   * @example
+   * const params = { id: USER_ID };
+   *
+   * management.users.update(params, data, function (err, user) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   *
+   *   // Updated user.
+   *   console.log(user);
+   * });
+   *
+   * @param   {Object}    params      The user parameters.
+   * @param   {String}    params.id   The user id.
+   * @param   {Object}    data        New user data.
+   * @param   {Function}  [cb]        Callback function
+   *
+   * @return  {Promise|undefined}
    */
-  var usersByEmailClient = new Auth0RestClient(
-    options.baseUrl + '/users-by-email',
-    clientOptions,
-    options.tokenProvider
-  );
-  this.usersByEmail = new RetryRestClient(usersByEmailClient, options.retry);
+  update(...args) {
+    return this.users.patch.apply(this.users, args);
+  }
 
   /**
-   * Provides an abstraction layer for regenerating Guardian recovery codes.
+   * Update the user metadata.
    *
-   * @type {external:RestClient}
+   * @method    updateUserMetadata
+   * @memberOf  module:management.UsersManager.prototype
+   *
+   * @example
+   * const params = { id: USER_ID };
+   * const metadata = {
+   *   address: '123th Node.js Street'
+   * };
+   *
+   * management.users.updateUserMetadata(params, metadata, function (err, user) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   *
+   *   // Updated user.
+   *   console.log(user);
+   * });
+   *
+   * @param   {Object}    params      The user data object..
+   * @param   {String}    params.id   The user id.
+   * @param   {Object}    metadata    New user metadata.
+   * @param   {Function}  [cb]        Callback function
+   *
+   * @return  {Promise|undefined}
    */
-  var recoveryCodeRegenerationAuth0RestClients = new Auth0RestClient(
-    options.baseUrl + '/users/:id/recovery-code-regeneration',
-    clientOptions,
-    options.tokenProvider
-  );
-  this.recoveryCodeRegenerations = new RetryRestClient(
-    recoveryCodeRegenerationAuth0RestClients,
-    options.retry
-  );
-};
+  updateUserMetadata(params, metadata, cb) {
+    const data = { user_metadata: metadata };
 
-/**
- * Create a new user.
- *
- * @method    create
- * @memberOf  module:management.UsersManager.prototype
- *
- * @example
- * management.users.create(data, function (err) {
- *   if (err) {
- *     // Handle error.
- *   }
- *
- *   // User created.
- * });
- *
- * @param   {Object}    data    User data.
- * @param   {Function}  [cb]    Callback function.
- *
- * @return  {Promise|undefined}
- */
-UsersManager.prototype.create = function(data, cb) {
-  if (cb && cb instanceof Function) {
-    return this.users.create(data, cb);
+    if (cb && cb instanceof Function) {
+      return this.users.patch(params, data, cb);
+    }
+
+    return this.users.patch(params, data);
   }
 
-  return this.users.create(data);
-};
+  /**
+   * Update the app metadata.
+   *
+   * @method    updateAppMetadata
+   * @memberOf  module:management.UsersManager.prototype
+   *
+   * @example
+   * const params = { id: USER_ID };
+   * const metadata = {
+   *   foo: 'bar'
+   * };
+   *
+   * management.users.updateAppMetadata(params, metadata, function (err, user) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   *
+   *   // Updated user.
+   *   console.log(user);
+   * });
+   *
+   * @param   {Object}    params      The user data object..
+   * @param   {String}    params.id   The user id.
+   * @param   {Object}    metadata    New app metadata.
+   * @param   {Function}  [cb]        Callback function
+   *
+   * @return  {Promise|undefined}
+   */
+  updateAppMetadata(params, metadata, cb) {
+    const data = { app_metadata: metadata };
 
-/**
- * Get all users.
- *
- * @method    getAll
- * @memberOf  module:management.UsersManager.prototype
- *
- * @example <caption>
- *   This method takes an optional object as first argument that may be used to
- *   specify pagination settings and the search query. If pagination options are
- *   not present, the first page of a limited number of results will be returned.
- * </caption>
- *
- * // Pagination settings.
- * var params = {
- *   per_page: 10,
- *   page: 0
- * };
- *
- * management.users.getAll(params, function (err, users) {
- *   console.log(users.length);
- * });
- *
- * @param   {Object}    [params]          Users params.
- * @param   {Number}    [params.per_page] Number of results per page.
- * @param   {Number}    [params.page]     Page number, zero indexed.
- * @param   {Function}  [cb]              Callback function.
- *
- * @return  {Promise|undefined}
- */
-UsersManager.prototype.getAll = function(params) {
-  return this.users.getAll.apply(this.users, arguments);
-};
+    if (cb && cb instanceof Function) {
+      return this.users.patch(params, data, cb);
+    }
 
-/**
- * Get Users by an Email Address
- *
- * @method    getByEmail
- * @memberOf  module:management.UsersManager.prototype
- *
- * @example <caption>
- *   This method takes a first argument as the Email address to look for
- *   users, and uses the /users-by-email API, not the search API
- * </caption>
- *
- * management.users.getByEmail('email@address', function (err, users) {
- *   console.log(users);
- * });
- *
- * @param   {String}    [email]           Email address of user(s) to find
- * @param   {Function}  [cb]              Callback function.
- *
- * @return  {Promise|undefined}
- */
-UsersManager.prototype.getByEmail = function(email, callback) {
-  return this.usersByEmail.getAll({ email }, callback);
-};
-
-/**
- * Get a user by its id.
- *
- * @method    get
- * @memberOf  module:management.UsersManager.prototype
- *
- * @example
- * management.users.get({ id: USER_ID }, function (err, user) {
- *   console.log(user);
- * });
- *
- * @param   {Object}    data      The user data object.
- * @param   {String}    data.id   The user id.
- * @param   {Function}  [cb]      Callback function.
- *
- * @return  {Promise|undefined}
- */
-UsersManager.prototype.get = function() {
-  return this.users.get.apply(this.users, arguments);
-};
-
-/**
- * Update a user by its id.
- *
- * @method    update
- * @memberOf  module:management.UsersManager.prototype
- *
- * @example
- * var params = { id: USER_ID };
- *
- * management.users.update(params, data, function (err, user) {
- *   if (err) {
- *     // Handle error.
- *   }
- *
- *   // Updated user.
- *   console.log(user);
- * });
- *
- * @param   {Object}    params      The user parameters.
- * @param   {String}    params.id   The user id.
- * @param   {Object}    data        New user data.
- * @param   {Function}  [cb]        Callback function
- *
- * @return  {Promise|undefined}
- */
-UsersManager.prototype.update = function() {
-  return this.users.patch.apply(this.users, arguments);
-};
-
-/**
- * Update the user metadata.
- *
- * @method    updateUserMetadata
- * @memberOf  module:management.UsersManager.prototype
- *
- * @example
- * var params = { id: USER_ID };
- * var metadata = {
- *   address: '123th Node.js Street'
- * };
- *
- * management.users.updateUserMetadata(params, metadata, function (err, user) {
- *   if (err) {
- *     // Handle error.
- *   }
- *
- *   // Updated user.
- *   console.log(user);
- * });
- *
- * @param   {Object}    params      The user data object..
- * @param   {String}    params.id   The user id.
- * @param   {Object}    metadata    New user metadata.
- * @param   {Function}  [cb]        Callback function
- *
- * @return  {Promise|undefined}
- */
-UsersManager.prototype.updateUserMetadata = function(params, metadata, cb) {
-  var data = {
-    user_metadata: metadata
-  };
-
-  if (cb && cb instanceof Function) {
-    return this.users.patch(params, data, cb);
+    return this.users.patch(params, data);
   }
 
-  return this.users.patch(params, data);
-};
+  /**
+   * Delete a user by its id.
+   *
+   * @method    delete
+   * @memberOf  module:management.UsersManager.prototype
+   *
+   * @example
+   * management.users.delete({ id: USER_ID }, function (err) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   *
+   *   // User deleted.
+   * });
+   *
+   *
+   * @param   {Object}    params      The user data object..
+   * @param   {String}    params.id   The user id.
+   * @param   {Function}  [cb]        Callback function
+   *
+   * @return  {Promise|undefined}
+   */
+  delete(...args) {
+    const params = args[0];
+    if (typeof params !== 'object' || typeof params.id !== 'string') {
+      throw new ArgumentError('You must provide an id for the delete method');
+    }
 
-/**
- * Update the app metadata.
- *
- * @method    updateAppMetadata
- * @memberOf  module:management.UsersManager.prototype
- *
- * @example
- * var params = { id: USER_ID };
- * var metadata = {
- *   foo: 'bar'
- * };
- *
- * management.users.updateAppMetadata(params, metadata, function (err, user) {
- *   if (err) {
- *     // Handle error.
- *   }
- *
- *   // Updated user.
- *   console.log(user);
- * });
- *
- * @param   {Object}    params      The user data object..
- * @param   {String}    params.id   The user id.
- * @param   {Object}    metadata    New app metadata.
- * @param   {Function}  [cb]        Callback function
- *
- * @return  {Promise|undefined}
- */
-UsersManager.prototype.updateAppMetadata = function(params, metadata, cb) {
-  var data = {
-    app_metadata: metadata
-  };
-
-  if (cb && cb instanceof Function) {
-    return this.users.patch(params, data, cb);
+    return this.users.delete.apply(this.users, args);
   }
 
-  return this.users.patch(params, data);
-};
+  /**
+   * Delete all users.
+   *
+   * @method    deleteAll
+   * @memberOf  module:management.UsersManager.prototype
+   *
+   * @example
+   * management.users.deleteAll(function (err) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   *
+   *   // Users deleted
+   * });
+   *
+   * @param   {Function}  [cb]        Callback function
+   *
+   * @return  {Promise|undefined}
+   */
+  deleteAll(...args) {
+    const cb = args[0];
+    if (typeof cb !== 'function') {
+      const errorMsg = 'The deleteAll method only accepts a callback as argument';
 
-/**
- * Delete a user by its id.
- *
- * @method    delete
- * @memberOf  module:management.UsersManager.prototype
- *
- * @example
- * management.users.delete({ id: USER_ID }, function (err) {
- *   if (err) {
- *     // Handle error.
- *   }
- *
- *   // User deleted.
- * });
- *
- *
- * @param   {Object}    params      The user data object..
- * @param   {String}    params.id   The user id.
- * @param   {Function}  [cb]        Callback function
- *
- * @return  {Promise|undefined}
- */
-UsersManager.prototype.delete = function(params) {
-  if (typeof params !== 'object' || typeof params.id !== 'string') {
-    throw new ArgumentError('You must provide an id for the delete method');
+      throw new ArgumentError(errorMsg);
+    }
+
+    return this.users.delete.apply(this.users, args);
   }
 
-  return this.users.delete.apply(this.users, arguments);
-};
+  /**
+   * Delete a multifactor provider.
+   *
+   * @method    deleteMultifactorProvider
+   * @memberOf  module:management.UsersManager.prototype
+   *
+   * @example
+   * const params = { id: USER_ID, provider: MULTIFACTOR_PROVIDER };
+   *
+   * management.users.deleteMultifactorProvider(params, function (err, user) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   *
+   *   // Users accounts unlinked.
+   * });
+   *
+   * @param   {Object}    params            Data object.
+   * @param   {String}    params.id         The user id.
+   * @param   {String}    params.provider   Multifactor provider.
+   * @param   {Function}  [cb]              Callback function
+   *
+   * @return  {Promise|undefined}
+   */
+  deleteMultifactorProvider(params = {}, cb) {
+    if (!params.id || typeof params.id !== 'string') {
+      throw new ArgumentError('The id parameter must be a valid user id');
+    }
 
-/**
- * Delete all users.
- *
- * @method    deleteAll
- * @memberOf  module:management.UsersManager.prototype
- *
- * @example
- * management.users.deleteAll(function (err) {
- *   if (err) {
- *     // Handle error.
- *   }
- *
- *   // Users deleted
- * });
- *
- * @param   {Function}  [cb]        Callback function
- *
- * @return  {Promise|undefined}
- */
-UsersManager.prototype.deleteAll = function(cb) {
-  if (typeof cb !== 'function') {
-    var errorMsg = 'The deleteAll method only accepts a callback as argument';
+    if (!params.provider || typeof params.provider !== 'string') {
+      throw new ArgumentError('Must specify a provider');
+    }
 
-    throw new ArgumentError(errorMsg);
+    if (cb && cb instanceof Function) {
+      return this.multifactor.delete(params, cb);
+    }
+
+    return this.multifactor.delete(params);
   }
 
-  return this.users.delete.apply(this.users, arguments);
-};
+  /**
+   * Link the user with another account.
+   *
+   * @method    link
+   * @memberOf  module:management.UsersManager.prototype
+   *
+   * @example
+   * const userId = 'USER_ID';
+   * const params = {
+   *   user_id: 'OTHER_USER_ID',
+   *   connection_id: 'CONNECTION_ID'
+   * };
+   *
+   * management.users.link(userId, params, function (err, user) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   *
+   *   // Users linked.
+   * });
+   *
+   * @param   {String}    userId                ID of the primary user.
+   * @param   {Object}    params                Secondary user data.
+   * @param   {String}    params.user_id        ID of the user to be linked.
+   * @param   {String}    params.connection_id  ID of the connection to be used.
+   * @param   {Function}  [cb]                  Callback function.
+   *
+   * @return  {Promise|undefined}
+   */
+  link(userId, params = {}, cb) {
+    const query = { id: userId };
 
-/**
- * Delete a multifactor provider.
- *
- * @method    deleteMultifactorProvider
- * @memberOf  module:management.UsersManager.prototype
- *
- * @example
- * var params = { id: USER_ID, provider: MULTIFACTOR_PROVIDER };
- *
- * management.users.deleteMultifactorProvider(params, function (err, user) {
- *   if (err) {
- *     // Handle error.
- *   }
- *
- *   // Users accounts unlinked.
- * });
- *
- * @param   {Object}    params            Data object.
- * @param   {String}    params.id         The user id.
- * @param   {String}    params.provider   Multifactor provider.
- * @param   {Function}  [cb]              Callback function
- *
- * @return  {Promise|undefined}
- */
-UsersManager.prototype.deleteMultifactorProvider = function(params, cb) {
-  params = params || {};
+    // Require a user ID.
+    if (!userId) {
+      throw new ArgumentError('The userId cannot be null or undefined');
+    }
 
-  if (!params.id || typeof params.id !== 'string') {
-    throw new ArgumentError('The id parameter must be a valid user id');
+    if (typeof userId !== 'string') {
+      throw new ArgumentError('The userId has to be a string');
+    }
+
+    if (cb && cb instanceof Function) {
+      return this.identities.create(query, params, cb);
+    }
+
+    return this.identities.create(query, params);
   }
 
-  if (!params.provider || typeof params.provider !== 'string') {
-    throw new ArgumentError('Must specify a provider');
+  /**
+   * Unlink the given accounts.
+   *
+   * @method    unlink
+   * @memberOf  module:management.UsersManager.prototype
+   *
+   * @example
+   * const params = { id: USER_ID, provider: 'auht0', user_id: OTHER_USER_ID };
+   *
+   * management.users.unlink(params, function (err, user) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   *
+   *   // Users accounts unlinked.
+   * });
+   *
+   * @param   {Object}    params            Linked users data.
+   * @param   {String}    params.id         Primary user ID.
+   * @param   {String}    params.provider   Identity provider in use.
+   * @param   {String}    params.user_id    Secondary user ID.
+   * @param   {Function}  [cb]              Callback function.
+   *
+   * @return {Promise|undefined}
+   */
+  unlink(params = {}, cb) {
+    if (!params.id || typeof params.id !== 'string') {
+      throw new ArgumentError('id field is required');
+    }
+
+    if (!params.user_id || typeof params.user_id !== 'string') {
+      throw new ArgumentError('user_id field is required');
+    }
+
+    if (!params.provider || typeof params.provider !== 'string') {
+      throw new ArgumentError('provider field is required');
+    }
+
+    if (cb && cb instanceof Function) {
+      return this.identities.delete(params, cb);
+    }
+
+    return this.identities.delete(params);
   }
 
-  if (cb && cb instanceof Function) {
-    return this.multifactor.delete(params, cb);
+  /**
+   * Get user's log events.
+   *
+   * @method    logs
+   * @memberOf  module:management.UsersManager.prototype
+   *
+   * @example
+   * const params = { id: USER_ID, page: 0, per_page: 50, sort: 'date:-1', include_totals: true };
+   *
+   * management.users.logs(params, function (err, logs) {
+   *   if (err) {
+   *     // Handle error.
+   *   }
+   *
+   *   console.log(logs);
+   * });
+   *
+   * @param   {Object}    params                Get logs data.
+   * @param   {String}    params.id             User id.
+   * @param   {Number}    params.per_page       Number of results per page.
+   * @param   {Number}    params.page           Page number, zero indexed.
+   * @param   {String}    params.sort           The field to use for sorting. Use field:order where order is 1 for ascending and -1 for descending. For example date:-1.
+   * @param   {Boolean}   params.include_totals true if a query summary must be included in the result, false otherwise. Default false;
+   * @param   {Function}  [cb]                  Callback function.
+   *
+   * @return {Promise|undefined}
+   */
+  logs(params = {}, cb) {
+    if (!params.id || typeof params.id !== 'string') {
+      throw new ArgumentError('id field is required');
+    }
+
+    return this.userLogs.get(params, cb);
   }
 
-  return this.multifactor.delete(params);
-};
-
-/**
- * Link the user with another account.
- *
- * @method    link
- * @memberOf  module:management.UsersManager.prototype
- *
- * @example
- * var userId = 'USER_ID';
- * var params = {
- *   user_id: 'OTHER_USER_ID',
- *   connection_id: 'CONNECTION_ID'
- * };
- *
- * management.users.link(userId, params, function (err, user) {
- *   if (err) {
- *     // Handle error.
- *   }
- *
- *   // Users linked.
- * });
- *
- * @param   {String}    userId                ID of the primary user.
- * @param   {Object}    params                Secondary user data.
- * @param   {String}    params.user_id        ID of the user to be linked.
- * @param   {String}    params.connection_id  ID of the connection to be used.
- * @param   {Function}  [cb]                  Callback function.
- *
- * @return  {Promise|undefined}
- */
-UsersManager.prototype.link = function(userId, params, cb) {
-  var query = { id: userId };
-  params = params || {};
-
-  // Require a user ID.
-  if (!userId) {
-    throw new ArgumentError('The userId cannot be null or undefined');
-  }
-  if (typeof userId !== 'string') {
-    throw new ArgumentError('The userId has to be a string');
+  /**
+   * Get a list of Guardian enrollments.
+   *
+   * @method    getGuardianEnrollments
+   * @memberOf  module:management.UsersManager.prototype
+   *
+   * @example
+   * management.users.getGuardianEnrollments({ id: USER_ID }, function (err, enrollments) {
+   *   console.log(enrollments);
+   * });
+   *
+   * @param   {Object}    data      The user data object.
+   * @param   {String}    data.id   The user id.
+   * @param   {Function}  [cb]      Callback function.
+   *
+   * @return  {Promise|undefined}
+   */
+  getGuardianEnrollments(...args) {
+    return this.enrollments.get.apply(this.enrollments, args);
   }
 
-  if (cb && cb instanceof Function) {
-    return this.identities.create(query, params, cb);
+  /**
+   * Generate new Guardian recovery code.
+   *
+   * @method    regenerateRecoveryCode
+   * @memberOf  module:management.UsersManager.prototype
+   *
+   * @example
+   * management.users.regenerateRecoveryCode("USER_ID", function (err, result) {
+   *   console.log(result.recovery_code);
+   * });
+   *
+   * @param   {Object}    params                Get logs data.
+   * @param   {String}    params.id             User id.
+   * @param   {Function}  [cb]                  Callback function.
+   *
+   * @return  {Promise|undefined}
+   */
+  regenerateRecoveryCode(params, cb) {
+    if (!params || !params.id) {
+      throw new ArgumentError('The userId cannot be null or undefined');
+    }
+
+    if (cb && cb instanceof Function) {
+      return this.recoveryCodeRegenerations.create(params, {}, cb);
+    }
+
+    return this.recoveryCodeRegenerations.create(params, {});
   }
-
-  return this.identities.create(query, params);
-};
-
-/**
- * Unlink the given accounts.
- *
- * @method    unlink
- * @memberOf  module:management.UsersManager.prototype
- *
- * @example
- * var params = { id: USER_ID, provider: 'auht0', user_id: OTHER_USER_ID };
- *
- * management.users.unlink(params, function (err, user) {
- *   if (err) {
- *     // Handle error.
- *   }
- *
- *   // Users accounts unlinked.
- * });
- *
- * @param   {Object}    params            Linked users data.
- * @param   {String}    params.id         Primary user ID.
- * @param   {String}    params.provider   Identity provider in use.
- * @param   {String}    params.user_id    Secondary user ID.
- * @param   {Function}  [cb]              Callback function.
- *
- * @return {Promise|undefined}
- */
-UsersManager.prototype.unlink = function(params, cb) {
-  params = params || {};
-
-  if (!params.id || typeof params.id !== 'string') {
-    throw new ArgumentError('id field is required');
-  }
-
-  if (!params.user_id || typeof params.user_id !== 'string') {
-    throw new ArgumentError('user_id field is required');
-  }
-
-  if (!params.provider || typeof params.provider !== 'string') {
-    throw new ArgumentError('provider field is required');
-  }
-
-  if (cb && cb instanceof Function) {
-    return this.identities.delete(params, cb);
-  }
-
-  return this.identities.delete(params);
-};
-
-/**
- * Get user's log events.
- *
- * @method    logs
- * @memberOf  module:management.UsersManager.prototype
- *
- * @example
- * var params = { id: USER_ID, page: 0, per_page: 50, sort: 'date:-1', include_totals: true };
- *
- * management.users.logs(params, function (err, logs) {
- *   if (err) {
- *     // Handle error.
- *   }
- *
- *   console.log(logs);
- * });
- *
- * @param   {Object}    params                Get logs data.
- * @param   {String}    params.id             User id.
- * @param   {Number}    params.per_page       Number of results per page.
- * @param   {Number}    params.page           Page number, zero indexed.
- * @param   {String}    params.sort           The field to use for sorting. Use field:order where order is 1 for ascending and -1 for descending. For example date:-1.
- * @param   {Boolean}   params.include_totals true if a query summary must be included in the result, false otherwise. Default false;
- * @param   {Function}  [cb]                  Callback function.
- *
- * @return {Promise|undefined}
- */
-UsersManager.prototype.logs = function(params, cb) {
-  params = params || {};
-
-  if (!params.id || typeof params.id !== 'string') {
-    throw new ArgumentError('id field is required');
-  }
-
-  return this.userLogs.get(params, cb);
-};
-
-/**
- * Get a list of Guardian enrollments.
- *
- * @method    getGuardianEnrollments
- * @memberOf  module:management.UsersManager.prototype
- *
- * @example
- * management.users.getGuardianEnrollments({ id: USER_ID }, function (err, enrollments) {
- *   console.log(enrollments);
- * });
- *
- * @param   {Object}    data      The user data object.
- * @param   {String}    data.id   The user id.
- * @param   {Function}  [cb]      Callback function.
- *
- * @return  {Promise|undefined}
- */
-UsersManager.prototype.getGuardianEnrollments = function() {
-  return this.enrollments.get.apply(this.enrollments, arguments);
-};
-
-/**
- * Generate new Guardian recovery code.
- *
- * @method    regenerateRecoveryCode
- * @memberOf  module:management.UsersManager.prototype
- *
- * @example
- * management.users.regenerateRecoveryCode("USER_ID", function (err, result) {
- *   console.log(result.recovery_code);
- * });
- *
- * @param   {Object}    params                Get logs data.
- * @param   {String}    params.id             User id.
- * @param   {Function}  [cb]                  Callback function.
- *
- * @return  {Promise|undefined}
- */
-UsersManager.prototype.regenerateRecoveryCode = function(params, cb) {
-  if (!params || !params.id) {
-    throw new ArgumentError('The userId cannot be null or undefined');
-  }
-
-  if (cb && cb instanceof Function) {
-    return this.recoveryCodeRegenerations.create(params, {}, cb);
-  }
-
-  return this.recoveryCodeRegenerations.create(params, {});
-};
+}
 
 module.exports = UsersManager;

--- a/src/management/UsersManager.js
+++ b/src/management/UsersManager.js
@@ -493,7 +493,7 @@ class UsersManager {
    * @memberOf  module:management.UsersManager.prototype
    *
    * @example
-   * const params = { id: USER_ID, provider: 'auht0', user_id: OTHER_USER_ID };
+   * const params = { id: USER_ID, provider: 'auth0', user_id: OTHER_USER_ID };
    *
    * management.users.unlink(params, function (err, user) {
    *   if (err) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,7 +44,7 @@ module.exports = {
 
   /**
    * Perform a request with the given settings and return a promise that resolves
-   * when the request is successfull and rejects when there's an error.
+   * when the request is successful and rejects when there's an error.
    *
    * @method    getRequestPromise
    * @memberOf  module:utils

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,3 @@
-const Promise = require('bluebird');
 const request = require('request');
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,73 +1,73 @@
-var Promise = require('bluebird');
-var request = require('request');
+const Promise = require('bluebird');
+const request = require('request');
 
 /**
  * @module utils
  */
-var utils = (module.exports = {});
+module.exports = {
+  /**
+   * Given a JSON string, convert it to its base64 representation.
+   *
+   * @method    jsonToBase64
+   * @memberOf  module:utils
+   */
+  jsonToBase64(json) {
+    const bytes = new Buffer(JSON.stringify(json));
 
-/**
- * Given a JSON string, convert it to its base64 representation.
- *
- * @method    jsonToBase64
- * @memberOf  module:utils
- */
-utils.jsonToBase64 = function(json) {
-  var bytes = new Buffer(JSON.stringify(json));
+    return bytes
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+  },
 
-  return bytes
-    .toString('base64')
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '');
-};
+  /**
+   * Simple wrapper that, given a class, a property name and a method name,
+   * creates a new method in the class that is a wrapper for the given
+   * property method.
+   *
+   * @method    wrapPropertyMethod
+   * @memberOf  module:utils
+   */
+  wrapPropertyMethod(Parent, name, propertyMethod) {
+    const path = propertyMethod.split('.');
+    const property = path.shift();
+    const method = path.pop();
 
-/**
- * Simple wrapper that, given a class, a property name and a method name,
- * creates a new method in the class that is a wrapper for the given
- * property method.
- *
- * @method    wrapPropertyMethod
- * @memberOf  module:utils
- */
-utils.wrapPropertyMethod = function(Parent, name, propertyMethod) {
-  var path = propertyMethod.split('.');
-  var property = path.shift();
-  var method = path.pop();
-
-  Object.defineProperty(Parent.prototype, name, {
-    enumerable: false,
-    get: function() {
-      return this[property][method].bind(this[property]);
-    }
-  });
-};
-
-/**
- * Perform a request with the given settings and return a promise that resolves
- * when the request is successfull and rejects when there's an error.
- *
- * @method    getRequestPromise
- * @memberOf  module:utils
- */
-utils.getRequestPromise = function(settings) {
-  return new Promise(function(resolve, reject) {
-    request(
-      {
-        url: settings.url,
-        method: settings.method,
-        body: settings.data,
-        json: typeof settings.data === 'object',
-        headers: settings.headers
-      },
-      function(err, res, body) {
-        if (err) {
-          reject(err);
-          return;
-        }
-
-        resolve(res.body);
+    Object.defineProperty(Parent.prototype, name, {
+      enumerable: false,
+      get() {
+        return this[property][method].bind(this[property]);
       }
-    );
-  });
+    });
+  },
+
+  /**
+   * Perform a request with the given settings and return a promise that resolves
+   * when the request is successfull and rejects when there's an error.
+   *
+   * @method    getRequestPromise
+   * @memberOf  module:utils
+   */
+  getRequestPromise(settings) {
+    return new Promise((resolve, reject) => {
+      request(
+        {
+          url: settings.url,
+          method: settings.method,
+          body: settings.data,
+          json: typeof settings.data === 'object',
+          headers: settings.headers
+        },
+        (err, res, body) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+
+          resolve(res.body);
+        }
+      );
+    });
+  }
 };

--- a/test/auth/authentication-client.tests.js
+++ b/test/auth/authentication-client.tests.js
@@ -1,5 +1,7 @@
 var expect = require('chai').expect;
 
+const proxy = require('../util-constructor-proxy');
+
 var ArgumentError = require('rest-facade').ArgumentError;
 
 var AuthenticationClient = require('../../src/auth');
@@ -14,14 +16,14 @@ var ensureProperty = require('../utils').ensureProperty;
 describe('AuthenticationClient', function() {
   describe('#constructor', function() {
     it('should raise an error when no options object is provided', function() {
-      expect(AuthenticationClient).to.throw(
+      expect(proxy(AuthenticationClient)).to.throw(
         ArgumentError,
         'Authentication Client SDK options must be an object'
       );
     });
 
     it('should raise an error when the domain is not valid', function() {
-      var client = AuthenticationClient.bind(null, { token: 'token', domain: '' });
+      var client = proxy(AuthenticationClient, { token: 'token', domain: '' });
 
       expect(client).to.throw(ArgumentError, 'Must provide a domain');
     });

--- a/test/auth/database-auth.tests.js
+++ b/test/auth/database-auth.tests.js
@@ -65,7 +65,8 @@ describe('DatabaseAuthenticator', function() {
     });
 
     it('should require an object as first argument', function() {
-      expect(this.authenticator.signIn).to.throw(ArgumentError, 'Missing user data object');
+      const signIn = this.authenticator.signIn.bind(this.authenticator);
+      expect(signIn).to.throw(ArgumentError, 'Missing user data object');
     });
 
     it('should require a username', function() {
@@ -266,7 +267,8 @@ describe('DatabaseAuthenticator', function() {
     });
 
     it('should require an object as first argument', function() {
-      expect(this.authenticator.signUp).to.throw(ArgumentError, 'Missing user data object');
+      const signup = this.authenticator.signUp.bind(this.authenticator);
+      expect(signup).to.throw(ArgumentError, 'Missing user data object');
     });
 
     it('should require an email', function() {
@@ -378,7 +380,8 @@ describe('DatabaseAuthenticator', function() {
     });
 
     it('should require an object as first argument', function() {
-      expect(this.authenticator.changePassword).to.throw(ArgumentError, 'Missing user data object');
+      const changePass = this.authenticator.changePassword.bind(this.authenticator);
+      expect(changePass).to.throw(ArgumentError, 'Missing user data object');
     });
 
     it('should require an email', function() {
@@ -489,10 +492,10 @@ describe('DatabaseAuthenticator', function() {
     });
 
     it('should require an object as first argument', function() {
-      expect(this.authenticator.requestChangePasswordEmail).to.throw(
-        ArgumentError,
-        'Missing user data object'
+      const requestChangePasswordEmail = this.authenticator.requestChangePasswordEmail.bind(
+        this.authenticator
       );
+      expect(requestChangePasswordEmail).to.throw(ArgumentError, 'Missing user data object');
     });
 
     it('should require an email', function() {

--- a/test/auth/database-auth.tests.js
+++ b/test/auth/database-auth.tests.js
@@ -2,6 +2,8 @@ var expect = require('chai').expect;
 var extend = require('util')._extend;
 var nock = require('nock');
 
+const proxy = require('../util-constructor-proxy');
+
 // Constants.
 var SRC_DIR = '../../src';
 var DOMAIN = 'tenant.auth0.com';
@@ -24,14 +26,14 @@ describe('DatabaseAuthenticator', function() {
 
   describe('#constructor', function() {
     it('should require an options object', function() {
-      expect(Authenticator).to.throw(ArgumentError, 'Missing authenticator options');
+      expect(proxy(Authenticator)).to.throw(ArgumentError, 'Missing authenticator options');
 
-      expect(Authenticator.bind(null, 1)).to.throw(
+      expect(proxy(Authenticator, 1)).to.throw(
         ArgumentError,
         'The authenticator options must be an object'
       );
 
-      expect(Authenticator.bind(null, validOptions)).to.not.throw(ArgumentError);
+      expect(proxy(Authenticator, validOptions)).to.not.throw(ArgumentError);
     });
   });
 

--- a/test/auth/oauth-with-idtoken-validation.tests.js
+++ b/test/auth/oauth-with-idtoken-validation.tests.js
@@ -1,5 +1,4 @@
 var expect = require('chai').expect;
-var Promise = require('bluebird');
 var sinon = require('sinon');
 var proxyquire = require('proxyquire');
 

--- a/test/auth/oauth.tests.js
+++ b/test/auth/oauth.tests.js
@@ -1,7 +1,6 @@
 var expect = require('chai').expect;
 var extend = require('util')._extend;
 var nock = require('nock');
-var Promise = require('bluebird');
 var sinon = require('sinon');
 
 const proxy = require('../util-constructor-proxy');
@@ -27,6 +26,7 @@ describe('OAuthAuthenticator', function() {
   beforeEach(function() {
     sinon.spy(OAUthWithIDTokenValidation.prototype, 'create');
   });
+
   afterEach(function() {
     OAUthWithIDTokenValidation.prototype.create.restore();
     nock.cleanAll();
@@ -470,7 +470,7 @@ describe('OAuthAuthenticator', function() {
     it('should return a promise when no callback is given', function() {
       var returnValue = this.authenticator.socialSignIn(userData);
 
-      expect(returnValue).to.be.an.instanceOf(Promise);
+      expect(returnValue.then).to.be.a('function');
     });
 
     it('should not return a promise when a callback is given', function() {

--- a/test/auth/oauth.tests.js
+++ b/test/auth/oauth.tests.js
@@ -4,6 +4,7 @@ var nock = require('nock');
 var sinon = require('sinon');
 
 const proxy = require('../util-constructor-proxy');
+const Promise = require('bluebird');
 
 // Constants.
 var SRC_DIR = '../../src';
@@ -470,7 +471,7 @@ describe('OAuthAuthenticator', function() {
     it('should return a promise when no callback is given', function() {
       var returnValue = this.authenticator.socialSignIn(userData);
 
-      expect(returnValue.then).to.be.a('function');
+      expect(returnValue).to.be.instanceof(Promise);
     });
 
     it('should not return a promise when a callback is given', function() {

--- a/test/auth/oauth.tests.js
+++ b/test/auth/oauth.tests.js
@@ -72,7 +72,8 @@ describe('OAuthAuthenticator', function() {
     });
 
     it('should require an object as first argument', function() {
-      expect(this.authenticator.signIn).to.throw(ArgumentError, 'Missing user data object');
+      const signIn = this.authenticator.signIn.bind(this.authenticator);
+      expect(signIn).to.throw(ArgumentError, 'Missing user data object');
     });
 
     it('should require a connection', function() {
@@ -252,7 +253,8 @@ describe('OAuthAuthenticator', function() {
     });
 
     it('should require an object as first argument', function() {
-      expect(this.authenticator.passwordGrant).to.throw(ArgumentError, 'Missing user data object');
+      const passwordGrant = this.authenticator.passwordGrant.bind(this.authenticator);
+      expect(passwordGrant).to.throw(ArgumentError, 'Missing user data object');
     });
 
     it('should require a username', function() {
@@ -585,10 +587,10 @@ describe('OAuthAuthenticator', function() {
     });
 
     it('should require an object as first argument', function() {
-      expect(this.authenticator.clientCredentialsGrant).to.throw(
-        ArgumentError,
-        'Missing options object'
+      const clientCredentialsGrant = this.authenticator.clientCredentialsGrant.bind(
+        this.authenticator
       );
+      expect(clientCredentialsGrant).to.throw(ArgumentError, 'Missing options object');
     });
 
     it('should require the client_id', function() {
@@ -716,10 +718,10 @@ describe('OAuthAuthenticator', function() {
     });
 
     it('should require an object as first argument', function() {
-      expect(this.authenticator.authorizationCodeGrant).to.throw(
-        ArgumentError,
-        'Missing options object'
+      const authorizationCodeGrant = this.authenticator.authorizationCodeGrant.bind(
+        this.authenticator
       );
+      expect(authorizationCodeGrant).to.throw(ArgumentError, 'Missing options object');
     });
 
     it('should require a code', function() {

--- a/test/auth/oauth.tests.js
+++ b/test/auth/oauth.tests.js
@@ -4,6 +4,8 @@ var nock = require('nock');
 var Promise = require('bluebird');
 var sinon = require('sinon');
 
+const proxy = require('../util-constructor-proxy');
+
 // Constants.
 var SRC_DIR = '../../src';
 var DOMAIN = 'tenant.auth0.com';
@@ -32,14 +34,14 @@ describe('OAuthAuthenticator', function() {
 
   describe('#constructor', function() {
     it('should require an options object', function() {
-      expect(Authenticator).to.throw(ArgumentError, 'Missing authenticator options');
+      expect(proxy(Authenticator)).to.throw(ArgumentError, 'Missing authenticator options');
 
-      expect(Authenticator.bind(null, 1)).to.throw(
+      expect(proxy(Authenticator, 1)).to.throw(
         ArgumentError,
         'The authenticator options must be an object'
       );
 
-      expect(Authenticator.bind(null, validOptions)).to.not.throw(ArgumentError);
+      expect(proxy(Authenticator, validOptions)).to.not.throw(ArgumentError);
     });
   });
 

--- a/test/auth/passwordless.tests.js
+++ b/test/auth/passwordless.tests.js
@@ -2,6 +2,8 @@ var expect = require('chai').expect;
 var extend = require('util')._extend;
 var nock = require('nock');
 
+const proxy = require('../util-constructor-proxy');
+
 // Constants.
 var SRC_DIR = '../../src';
 var DOMAIN = 'tenant.auth0.com';
@@ -24,14 +26,14 @@ describe('PasswordlessAuthenticator', function() {
 
   describe('#constructor', function() {
     it('should require an options object', function() {
-      expect(Authenticator).to.throw(ArgumentError, 'Missing authenticator options');
+      expect(proxy(Authenticator)).to.throw(ArgumentError, 'Missing authenticator options');
 
-      expect(Authenticator.bind(null, 1)).to.throw(
+      expect(proxy(Authenticator, 1)).to.throw(
         ArgumentError,
         'The authenticator options must be an object'
       );
 
-      expect(Authenticator.bind(null, validOptions)).to.not.throw(ArgumentError);
+      expect(proxy(Authenticator, validOptions)).to.not.throw(ArgumentError);
     });
   });
 

--- a/test/auth/passwordless.tests.js
+++ b/test/auth/passwordless.tests.js
@@ -65,7 +65,8 @@ describe('PasswordlessAuthenticator', function() {
     });
 
     it('should require an object as first argument', function() {
-      expect(this.authenticator.signIn).to.throw(ArgumentError, 'Missing user data object');
+      const signIn = this.authenticator.signIn.bind(this.authenticator);
+      expect(signIn).to.throw(ArgumentError, 'Missing user data object');
     });
 
     it('should require a phone number', function() {
@@ -265,7 +266,8 @@ describe('PasswordlessAuthenticator', function() {
     });
 
     it('should require an object as first argument', function() {
-      expect(this.authenticator.sendEmail).to.throw(ArgumentError, 'Missing user data object');
+      const sendEmail = this.authenticator.sendEmail.bind(this.authenticator);
+      expect(sendEmail).to.throw(ArgumentError, 'Missing user data object');
     });
 
     it('should require an email', function() {
@@ -429,7 +431,8 @@ describe('PasswordlessAuthenticator', function() {
     });
 
     it('should require an object as first argument', function() {
-      expect(this.authenticator.sendSMS).to.throw(ArgumentError, 'Missing user data object');
+      const sendSMS = this.authenticator.sendSMS.bind(this.authenticator);
+      expect(sendSMS).to.throw(ArgumentError, 'Missing user data object');
     });
 
     it('should require a phone number', function() {

--- a/test/auth/tokens-manager.tests.js
+++ b/test/auth/tokens-manager.tests.js
@@ -5,7 +5,6 @@ const proxy = require('../util-constructor-proxy');
 
 var BASE_URL = 'https://tenant.auth0.com';
 
-var Promise = require('bluebird');
 var ArgumentError = require('rest-facade').ArgumentError;
 var TokensManager = require('../../src/auth/TokensManager');
 
@@ -81,7 +80,7 @@ describe('TokensManager', function() {
     it('should return a promise when no callback is provided', function() {
       var returnValue = manager.getInfo('VALID_TOKEN');
 
-      expect(returnValue).to.be.a('promise');
+      expect(returnValue.then).to.be.a('function');
     });
 
     it('should not return a promise when a callback is provided', function() {
@@ -216,7 +215,7 @@ describe('TokensManager', function() {
       };
       var returnValue = manager.getDelegationToken(data);
 
-      expect(returnValue).to.be.an.instanceOf(Promise);
+      expect(returnValue.then).to.be.a('function');
     });
 
     it('should not return a promise when a callback is given', function() {

--- a/test/auth/tokens-manager.tests.js
+++ b/test/auth/tokens-manager.tests.js
@@ -80,7 +80,7 @@ describe('TokensManager', function() {
     it('should return a promise when no callback is provided', function() {
       var returnValue = manager.getInfo('VALID_TOKEN');
 
-      expect(returnValue.then).to.be.a('function');
+      expect(returnValue).to.be.instanceof(Promise);
     });
 
     it('should not return a promise when a callback is provided', function() {
@@ -215,7 +215,7 @@ describe('TokensManager', function() {
       };
       var returnValue = manager.getDelegationToken(data);
 
-      expect(returnValue.then).to.be.a('function');
+      expect(returnValue).to.be.instanceof(Promise);
     });
 
     it('should not return a promise when a callback is given', function() {

--- a/test/auth/tokens-manager.tests.js
+++ b/test/auth/tokens-manager.tests.js
@@ -1,6 +1,8 @@
 var expect = require('chai').expect;
 var nock = require('nock');
 
+const proxy = require('../util-constructor-proxy');
+
 var BASE_URL = 'https://tenant.auth0.com';
 
 var Promise = require('bluebird');
@@ -23,11 +25,11 @@ describe('TokensManager', function() {
 
   describe('#constructor', function() {
     it('should require an options object', function() {
-      expect(TokensManager).to.throw(ArgumentError, 'Missing tokens manager options');
+      expect(proxy(TokensManager)).to.throw(ArgumentError, 'Missing tokens manager options');
     });
 
     it('should require a base URL', function() {
-      var manager = TokensManager.bind(null, {});
+      var manager = proxy(TokensManager, {});
 
       expect(manager).to.throw(ArgumentError, 'baseUrl field is required');
     });

--- a/test/auth/tokens-manager.tests.js
+++ b/test/auth/tokens-manager.tests.js
@@ -81,7 +81,7 @@ describe('TokensManager', function() {
     it('should return a promise when no callback is provided', function() {
       var returnValue = manager.getInfo('VALID_TOKEN');
 
-      expect(returnValue).to.be.an.instanceOf(Promise);
+      expect(returnValue).to.be.a('promise');
     });
 
     it('should not return a promise when a callback is provided', function() {
@@ -158,13 +158,13 @@ describe('TokensManager', function() {
       );
     });
 
-    it('should not accept an ID token and a refresh token simulatenously', function() {
+    it('should not accept an ID token and a refresh token simultaneously', function() {
       var data = { id_token: 'foo', refresh_token: 'bar' };
       var getDelegationToken = manager.getDelegationToken.bind(manager, data);
 
       expect(getDelegationToken).to.throw(
         ArgumentError,
-        'id_token and refresh_token fields cannot be specified simulatenously'
+        'id_token and refresh_token fields cannot be specified simultaneously'
       );
     });
 

--- a/test/auth/users-manager.tests.js
+++ b/test/auth/users-manager.tests.js
@@ -1,6 +1,7 @@
 var expect = require('chai').expect;
 var nock = require('nock');
-var Promise = require('bluebird');
+
+const proxy = require('../util-constructor-proxy');
 
 var BASE_URL = 'https://tenant.auth0.com';
 var CLIENT_ID = 'TEST_CLIENT_ID';
@@ -23,11 +24,11 @@ describe('UsersManager', function() {
 
   describe('#constructor', function() {
     it('should require an options object', function() {
-      expect(UsersManager).to.throw(ArgumentError, 'Missing users manager options');
+      expect(proxy(UsersManager)).to.throw(ArgumentError, 'Missing users manager options');
     });
 
     it('should require a base URL', function() {
-      expect(UsersManager.bind(null, {})).to.throw(ArgumentError, 'baseUrl field is required');
+      expect(proxy(UsersManager, {})).to.throw(ArgumentError, 'baseUrl field is required');
     });
   });
 

--- a/test/auth0-rest-client.tests.js
+++ b/test/auth0-rest-client.tests.js
@@ -1,6 +1,8 @@
 var expect = require('chai').expect;
 var nock = require('nock');
 
+const proxy = require('./util-constructor-proxy');
+
 var ArgumentError = require('rest-facade').ArgumentError;
 var ManagementTokenProvider = require('../src/management/ManagementTokenProvider');
 var Auth0RestClient = require('../src/Auth0RestClient');
@@ -17,16 +19,16 @@ describe('Auth0RestClient', function() {
   });
 
   it('should raise an error when no resource Url is provided', function() {
-    expect(Auth0RestClient).to.throw(ArgumentError, 'Must provide a Resource Url');
+    expect(proxy(Auth0RestClient)).to.throw(ArgumentError, 'Must provide a Resource Url');
   });
 
   it('should raise an error when resource Url is invalid', function() {
-    var client = Auth0RestClient.bind(null, '');
+    var client = proxy(Auth0RestClient, '');
     expect(client).to.throw(ArgumentError, 'The provided Resource Url is invalid');
   });
 
   it('should raise an error when no options is provided', function() {
-    var client = Auth0RestClient.bind(null, '/some-resource');
+    var client = proxy(Auth0RestClient, '/some-resource');
     expect(client).to.throw(ArgumentError, 'Must provide options');
   });
 

--- a/test/management/blacklisted-tokens.tests.js
+++ b/test/management/blacklisted-tokens.tests.js
@@ -1,6 +1,8 @@
 var expect = require('chai').expect;
 var nock = require('nock');
 
+const proxy = require('../util-constructor-proxy');
+
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
 
@@ -28,17 +30,20 @@ describe('BlacklistedTokensManager', function() {
 
   describe('#constructor', function() {
     it('should error when no options are provided', function() {
-      expect(BlacklistedTokensManager).to.throw(ArgumentError, 'Must provide client options');
+      expect(proxy(BlacklistedTokensManager)).to.throw(
+        ArgumentError,
+        'Must provide client options'
+      );
     });
 
     it('should throw an error when no base URL is provided', function() {
-      var client = BlacklistedTokensManager.bind(null, {});
+      var client = proxy(BlacklistedTokensManager, {});
 
       expect(client).to.throw(ArgumentError, 'Must provide a base URL for the API');
     });
 
     it('should throw an error when the base URL is invalid', function() {
-      var client = BlacklistedTokensManager.bind(null, { baseUrl: '' });
+      var client = proxy(BlacklistedTokensManager, { baseUrl: '' });
 
       expect(client).to.throw(ArgumentError, 'The provided base URL is invalid');
     });

--- a/test/management/client-grants.tests.js
+++ b/test/management/client-grants.tests.js
@@ -1,6 +1,7 @@
 var expect = require('chai').expect;
 var nock = require('nock');
-var Promise = require('bluebird');
+
+const proxy = require('../util-constructor-proxy');
 
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
@@ -35,17 +36,17 @@ describe('ClientGrantsManager', function() {
 
   describe('#constructor', function() {
     it('should error when no options are provided', function() {
-      expect(ClientGrantsManager).to.throw(ArgumentError, 'Must provide client options');
+      expect(proxy(ClientGrantsManager)).to.throw(ArgumentError, 'Must provide client options');
     });
 
     it('should throw an error when no base URL is provided', function() {
-      var grants = ClientGrantsManager.bind(null, {});
+      var grants = proxy(ClientGrantsManager, {});
 
       expect(grants).to.throw(ArgumentError, 'Must provide a base URL for the API');
     });
 
     it('should throw an error when the base URL is invalid', function() {
-      var grants = ClientGrantsManager.bind(null, { baseUrl: '' });
+      var grants = proxy(ClientGrantsManager, { baseUrl: '' });
 
       expect(grants).to.throw(ArgumentError, 'The provided base URL is invalid');
     });

--- a/test/management/client.tests.js
+++ b/test/management/client.tests.js
@@ -1,6 +1,7 @@
 var expect = require('chai').expect;
 var nock = require('nock');
-var Promise = require('bluebird');
+
+const proxy = require('../util-constructor-proxy');
 
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
@@ -35,17 +36,17 @@ describe('ClientsManager', function() {
 
   describe('#constructor', function() {
     it('should error when no options are provided', function() {
-      expect(ClientsManager).to.throw(ArgumentError, 'Must provide client options');
+      expect(proxy(ClientsManager)).to.throw(ArgumentError, 'Must provide client options');
     });
 
     it('should throw an error when no base URL is provided', function() {
-      var client = ClientsManager.bind(null, {});
+      var client = proxy(ClientsManager, {});
 
       expect(client).to.throw(ArgumentError, 'Must provide a base URL for the API');
     });
 
     it('should throw an error when the base URL is invalid', function() {
-      var client = ClientsManager.bind(null, { baseUrl: '' });
+      var client = proxy(ClientsManager, { baseUrl: '' });
 
       expect(client).to.throw(ArgumentError, 'The provided base URL is invalid');
     });

--- a/test/management/connections.tests.js
+++ b/test/management/connections.tests.js
@@ -1,6 +1,8 @@
 var expect = require('chai').expect;
 var nock = require('nock');
 
+const proxy = require('../util-constructor-proxy');
+
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
 
@@ -28,17 +30,17 @@ describe('ConnectionsManager', function() {
 
   describe('#constructor', function() {
     it('should error when no options are provided', function() {
-      expect(ConnectionsManager).to.throw(ArgumentError, 'Must provide client options');
+      expect(proxy(ConnectionsManager)).to.throw(ArgumentError, 'Must provide client options');
     });
 
     it('should throw an error when no base URL is provided', function() {
-      var client = ConnectionsManager.bind(null, {});
+      var client = proxy(ConnectionsManager, {});
 
       expect(client).to.throw(ArgumentError, 'Must provide a base URL for the API');
     });
 
     it('should throw an error when the base URL is invalid', function() {
-      var client = ConnectionsManager.bind(null, { baseUrl: '' });
+      var client = proxy(ConnectionsManager, { baseUrl: '' });
 
       expect(client).to.throw(ArgumentError, 'The provided base URL is invalid');
     });

--- a/test/management/device-credentials.tests.js
+++ b/test/management/device-credentials.tests.js
@@ -1,6 +1,8 @@
 var expect = require('chai').expect;
 var nock = require('nock');
 
+const proxy = require('../util-constructor-proxy');
+
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
 
@@ -28,17 +30,20 @@ describe('DeviceCredentialsManager', function() {
 
   describe('#constructor', function() {
     it('should error when no options are provided', function() {
-      expect(DeviceCredentialsManager).to.throw(ArgumentError, 'Must provide manager options');
+      expect(proxy(DeviceCredentialsManager)).to.throw(
+        ArgumentError,
+        'Must provide manager options'
+      );
     });
 
     it('should throw an error when no base URL is provided', function() {
-      var client = DeviceCredentialsManager.bind(null, {});
+      var client = proxy(DeviceCredentialsManager, {});
 
       expect(client).to.throw(ArgumentError, 'Must provide a base URL for the API');
     });
 
     it('should throw an error when the base URL is invalid', function() {
-      var client = DeviceCredentialsManager.bind(null, { baseUrl: '' });
+      var client = proxy(DeviceCredentialsManager, { baseUrl: '' });
 
       expect(client).to.throw(ArgumentError, 'The provided base URL is invalid');
     });

--- a/test/management/email-provider.tests.js
+++ b/test/management/email-provider.tests.js
@@ -1,6 +1,8 @@
 var expect = require('chai').expect;
 var nock = require('nock');
 
+const proxy = require('../util-constructor-proxy');
+
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
 
@@ -28,17 +30,17 @@ describe('EmailProviderManager', function() {
 
   describe('#constructor', function() {
     it('should error when no options are provided', function() {
-      expect(EmailProviderManager).to.throw(ArgumentError, 'Must provide client options');
+      expect(proxy(EmailProviderManager)).to.throw(ArgumentError, 'Must provide client options');
     });
 
     it('should throw an error when no base URL is provided', function() {
-      var client = EmailProviderManager.bind(null, {});
+      var client = proxy(EmailProviderManager, {});
 
       expect(client).to.throw(ArgumentError, 'Must provide a base URL for the API');
     });
 
     it('should throw an error when the base URL is invalid', function() {
-      var client = EmailProviderManager.bind(null, { baseUrl: '' });
+      var client = proxy(EmailProviderManager, { baseUrl: '' });
 
       expect(client).to.throw(ArgumentError, 'The provided base URL is invalid');
     });

--- a/test/management/email-templates.tests.js
+++ b/test/management/email-templates.tests.js
@@ -3,6 +3,8 @@ var nock = require('nock');
 var EmailTemplatesManager = require('../../src/management/EmailTemplatesManager');
 var ArgumentError = require('rest-facade').ArgumentError;
 
+const proxy = require('../util-constructor-proxy');
+
 var API_URL = 'https://tenant.auth0.com';
 const TEMPLATE_NAME = 'foobar';
 const DEFAULT_PARAMS = { name: TEMPLATE_NAME };
@@ -37,17 +39,17 @@ describe('EmailTemplatesManager', function() {
 
   describe('#constructor', function() {
     it('should error when no options are provided', function() {
-      expect(EmailTemplatesManager).to.throw(ArgumentError, 'Must provide manager options');
+      expect(proxy(EmailTemplatesManager)).to.throw(ArgumentError, 'Must provide manager options');
     });
 
     it('should throw an error when no base URL is provided', function() {
-      var client = EmailTemplatesManager.bind(null, {});
+      var client = proxy(EmailTemplatesManager, {});
 
       expect(client).to.throw(ArgumentError, 'Must provide a valid string as base URL for the API');
     });
 
     it('should throw an error when the base URL is invalid', function() {
-      var client = EmailTemplatesManager.bind(null, { baseUrl: '' });
+      var client = proxy(EmailTemplatesManager, { baseUrl: '' });
 
       expect(client).to.throw(ArgumentError, 'Must provide a valid string as base URL for the API');
     });

--- a/test/management/guardian.tests.js
+++ b/test/management/guardian.tests.js
@@ -1,6 +1,8 @@
 var expect = require('chai').expect;
 var nock = require('nock');
 
+const proxy = require('../util-constructor-proxy');
+
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenants.auth0.com';
 
@@ -28,17 +30,17 @@ describe('GuardianManager', function() {
 
   describe('#constructor', function() {
     it('should error when no options are provided', function() {
-      expect(GuardianManager).to.throw(ArgumentError, 'Must provide manager options');
+      expect(proxy(GuardianManager)).to.throw(ArgumentError, 'Must provide manager options');
     });
 
     it('should throw an error when no base URL is provided', function() {
-      var manager = GuardianManager.bind(null, {});
+      var manager = proxy(GuardianManager, {});
 
       expect(manager).to.throw(ArgumentError, 'Must provide a base URL for the API');
     });
 
     it('should throw an error when the base URL is invalid', function() {
-      var manager = GuardianManager.bind(null, { baseUrl: '' });
+      var manager = proxy(GuardianManager, { baseUrl: '' });
 
       expect(manager).to.throw(ArgumentError, 'The provided base URL is invalid');
     });

--- a/test/management/jobs.tests.js
+++ b/test/management/jobs.tests.js
@@ -4,6 +4,8 @@ var nock = require('nock');
 var extractParts = require('../utils').extractParts;
 var fs = require('fs');
 
+const proxy = require('../util-constructor-proxy');
+
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
 
@@ -38,17 +40,17 @@ describe('JobsManager', function() {
 
   describe('#constructor', function() {
     it('should error when no options are provided', function() {
-      expect(JobsManager).to.throw(ArgumentError, 'Must provide client options');
+      expect(proxy(JobsManager)).to.throw(ArgumentError, 'Must provide client options');
     });
 
     it('should throw an error when no base URL is provided', function() {
-      var client = JobsManager.bind(null, {});
+      var client = proxy(JobsManager, {});
 
       expect(client).to.throw(ArgumentError, 'Must provide a base URL for the API');
     });
 
     it('should throw an error when the base URL is invalid', function() {
-      var client = JobsManager.bind(null, { baseUrl: '' });
+      var client = proxy(JobsManager, { baseUrl: '' });
 
       expect(client).to.throw(ArgumentError, 'The provided base URL is invalid');
     });

--- a/test/management/logs.tests.js
+++ b/test/management/logs.tests.js
@@ -1,6 +1,8 @@
 var expect = require('chai').expect;
 var nock = require('nock');
 
+const proxy = require('../util-constructor-proxy');
+
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
 
@@ -28,17 +30,17 @@ describe('LogsManager', function() {
 
   describe('#constructor', function() {
     it('should error when no options are provided', function() {
-      expect(LogsManager).to.throw(ArgumentError, 'Must provide client options');
+      expect(proxy(LogsManager)).to.throw(ArgumentError, 'Must provide client options');
     });
 
     it('should throw an error when no base URL is provided', function() {
-      var client = LogsManager.bind(null, {});
+      var client = proxy(LogsManager, {});
 
       expect(client).to.throw(ArgumentError, 'Must provide a base URL for the API');
     });
 
     it('should throw an error when the base URL is invalid', function() {
-      var client = LogsManager.bind(null, { baseUrl: '' });
+      var client = proxy(LogsManager, { baseUrl: '' });
 
       expect(client).to.throw(ArgumentError, 'The provided base URL is invalid');
     });

--- a/test/management/management-client.tests.js
+++ b/test/management/management-client.tests.js
@@ -1,6 +1,8 @@
 var expect = require('chai').expect;
 var assign = Object.assign || require('object.assign');
 
+const proxy = require('../util-constructor-proxy');
+
 var ManagementClient = require('../../src/management');
 
 var ArgumentError = require('rest-facade').ArgumentError;
@@ -46,7 +48,7 @@ describe('ManagementClient', function() {
   });
 
   it('should raise an error when no options object is provided', function() {
-    expect(ManagementClient).to.throw(
+    expect(proxy(ManagementClient)).to.throw(
       ArgumentError,
       'Management API SDK options must be an object'
     );
@@ -55,7 +57,7 @@ describe('ManagementClient', function() {
   it('should raise an error when the domain is not set', function() {
     var config = assign({}, withTokenConfig);
     delete config.domain;
-    var client = ManagementClient.bind(null, config);
+    var client = proxy(ManagementClient, config);
 
     expect(client).to.throw(ArgumentError, 'Must provide a domain');
   });
@@ -63,7 +65,7 @@ describe('ManagementClient', function() {
   it('should raise an error when the domain is not valid', function() {
     var config = assign({}, withTokenConfig);
     config.domain = '';
-    var client = ManagementClient.bind(null, config);
+    var client = proxy(ManagementClient, config);
 
     expect(client).to.throw(ArgumentError, 'Must provide a domain');
   });
@@ -71,7 +73,7 @@ describe('ManagementClient', function() {
   it('should raise an error when the token is not valid', function() {
     var config = assign({}, withTokenConfig);
     config.token = '';
-    var client = ManagementClient.bind(null, config);
+    var client = proxy(ManagementClient, config);
 
     expect(client).to.throw(ArgumentError, 'Must provide a token');
   });
@@ -79,7 +81,7 @@ describe('ManagementClient', function() {
   it('should raise an error when the token and clientId are not set', function() {
     var config = assign({}, withTokenProviderConfig);
     delete config.clientId;
-    var client = ManagementClient.bind(null, config);
+    var client = proxy(ManagementClient, config);
 
     expect(client).to.throw(ArgumentError, 'Must provide a clientId');
   });
@@ -87,7 +89,7 @@ describe('ManagementClient', function() {
   it('should raise an error when the token and clientSecret are not set', function() {
     var config = assign({}, withTokenProviderConfig);
     delete config.clientSecret;
-    var client = ManagementClient.bind(null, config);
+    var client = proxy(ManagementClient, config);
 
     expect(client).to.throw(ArgumentError, 'Must provide a clientSecret');
   });
@@ -139,10 +141,10 @@ describe('ManagementClient', function() {
         property: 'tenant',
         cls: TenantManager
       },
-      'RulesConfigsManager': {
+      RulesConfigsManager: {
         property: 'rulesConfigs',
         cls: RulesConfigsManager
-      },
+      }
     };
 
     before(function() {

--- a/test/management/management-token-provider.tests.js
+++ b/test/management/management-token-provider.tests.js
@@ -1,5 +1,6 @@
 var expect = require('chai').expect;
 var nock = require('nock');
+const proxy = require('../util-constructor-proxy');
 var assign = Object.assign || require('object.assign');
 var ArgumentError = require('rest-facade').ArgumentError;
 var APIError = require('rest-facade').APIError;
@@ -21,13 +22,13 @@ describe('ManagementTokenProvider', function() {
   });
 
   it('should raise an error when no options object is provided', function() {
-    expect(ManagementTokenProvider).to.throw(ArgumentError, 'Options must be an object');
+    expect(proxy(ManagementTokenProvider)).to.throw(ArgumentError, 'Options must be an object');
   });
 
   it('should raise an error when domain is not set', function() {
     var config = assign({}, defaultConfig);
     delete config.domain;
-    var provider = ManagementTokenProvider.bind(null, config);
+    var provider = proxy(ManagementTokenProvider, config);
 
     expect(provider).to.throw(ArgumentError, 'Must provide a domain');
   });
@@ -35,7 +36,7 @@ describe('ManagementTokenProvider', function() {
   it('should raise an error when domain is not valid', function() {
     var config = assign({}, defaultConfig);
     config.domain = '';
-    var provider = ManagementTokenProvider.bind(null, config);
+    var provider = proxy(ManagementTokenProvider, config);
 
     expect(provider).to.throw(ArgumentError, 'Must provide a domain');
   });
@@ -43,7 +44,7 @@ describe('ManagementTokenProvider', function() {
   it('should raise an error when clientId is not set', function() {
     var config = assign({}, defaultConfig);
     delete config.clientId;
-    var provider = ManagementTokenProvider.bind(null, config);
+    var provider = proxy(ManagementTokenProvider, config);
 
     expect(provider).to.throw(ArgumentError, 'Must provide a clientId');
   });
@@ -51,7 +52,7 @@ describe('ManagementTokenProvider', function() {
   it('should raise an error when clientId is not valid', function() {
     var config = assign({}, defaultConfig);
     config.clientId = '';
-    var provider = ManagementTokenProvider.bind(null, config);
+    var provider = proxy(ManagementTokenProvider, config);
 
     expect(provider).to.throw(ArgumentError, 'Must provide a clientId');
   });
@@ -59,7 +60,7 @@ describe('ManagementTokenProvider', function() {
   it('should raise an error when clientSecret is not set', function() {
     var config = assign({}, defaultConfig);
     delete config.clientSecret;
-    var provider = ManagementTokenProvider.bind(null, config);
+    var provider = proxy(ManagementTokenProvider, config);
 
     expect(provider).to.throw(ArgumentError, 'Must provide a clientSecret');
   });
@@ -67,7 +68,7 @@ describe('ManagementTokenProvider', function() {
   it('should raise an error when clientSecret is not valid', function() {
     var config = assign({}, defaultConfig);
     config.clientSecret = '';
-    var provider = ManagementTokenProvider.bind(null, config);
+    var provider = proxy(ManagementTokenProvider, config);
 
     expect(provider).to.throw(ArgumentError, 'Must provide a clientSecret');
   });
@@ -75,7 +76,7 @@ describe('ManagementTokenProvider', function() {
   it('should raise an error when enableCache is not of type boolean', function() {
     var config = assign({}, defaultConfig);
     config.enableCache = 'string';
-    var provider = ManagementTokenProvider.bind(null, config);
+    var provider = proxy(ManagementTokenProvider, config);
 
     expect(provider).to.throw(ArgumentError, 'enableCache must be a boolean');
   });
@@ -83,7 +84,7 @@ describe('ManagementTokenProvider', function() {
   it('should raise an error when scope is not of type string', function() {
     var config = assign({}, defaultConfig);
     config.scope = ['foo', 'bar'];
-    var provider = ManagementTokenProvider.bind(null, config);
+    var provider = proxy(ManagementTokenProvider, config);
 
     expect(provider).to.throw(ArgumentError, 'scope must be a string');
   });
@@ -119,7 +120,7 @@ describe('ManagementTokenProvider', function() {
   it('should raise an error when the cacheTTLInSeconds is not of type number', function() {
     var config = assign({}, defaultConfig);
     config.cacheTTLInSeconds = 'string';
-    var provider = ManagementTokenProvider.bind(null, config);
+    var provider = proxy(ManagementTokenProvider, config);
 
     expect(provider).to.throw(ArgumentError, 'cacheTTLInSeconds must be a number');
   });
@@ -127,7 +128,7 @@ describe('ManagementTokenProvider', function() {
   it('should raise an error when the cacheTTLInSeconds is not a greater than 0', function() {
     var config = assign({}, defaultConfig);
     config.cacheTTLInSeconds = -1;
-    var provider = ManagementTokenProvider.bind(null, config);
+    var provider = proxy(ManagementTokenProvider, config);
 
     expect(provider).to.throw(ArgumentError, 'cacheTTLInSeconds must be a greater than 0');
   });

--- a/test/management/resource-servers.tests.js
+++ b/test/management/resource-servers.tests.js
@@ -1,6 +1,7 @@
 var expect = require('chai').expect;
 var nock = require('nock');
-var Promise = require('bluebird');
+
+const proxy = require('../util-constructor-proxy');
 
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
@@ -35,20 +36,20 @@ describe('ResourceServersManager', function() {
 
   describe('#constructor', function() {
     it('should error when no options are provided', function() {
-      expect(ResourceServersManager).to.throw(
+      expect(proxy(ResourceServersManager)).to.throw(
         ArgumentError,
         'Must provide resource server options'
       );
     });
 
     it('should throw an error when no base URL is provided', function() {
-      var resourceServerManager = ResourceServersManager.bind(null, {});
+      var resourceServerManager = proxy(ResourceServersManager, {});
 
       expect(resourceServerManager).to.throw(ArgumentError, 'Must provide a base URL for the API');
     });
 
     it('should throw an error when the base URL is invalid', function() {
-      var resourceServerManager = ResourceServersManager.bind(null, { baseUrl: '' });
+      var resourceServerManager = proxy(ResourceServersManager, { baseUrl: '' });
 
       expect(resourceServerManager).to.throw(ArgumentError, 'The provided base URL is invalid');
     });

--- a/test/management/rules-configs.tests.js
+++ b/test/management/rules-configs.tests.js
@@ -1,15 +1,16 @@
 var expect = require('chai').expect;
 var nock = require('nock');
 
+const proxy = require('../util-constructor-proxy');
+
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
 
 var RulesConfigsManager = require(SRC_DIR + '/management/RulesConfigsManager');
 var ArgumentError = require('rest-facade').ArgumentError;
 
-
-describe('RulesConfigsManager', function () {
-  before(function () {
+describe('RulesConfigsManager', function() {
+  before(function() {
     this.token = 'TOKEN';
     this.rulesConfigs = new RulesConfigsManager({
       headers: { authorization: 'Bearer ' + this.token },
@@ -17,79 +18,62 @@ describe('RulesConfigsManager', function () {
     });
   });
 
-  describe('instance', function () {
+  describe('instance', function() {
     var methods = ['set', 'getAll', 'delete'];
 
-    methods.forEach(function (method) {
-      it('should have a ' + method + ' method', function () {
-        expect(this.rulesConfigs[method])
-          .to.exist
-          .to.be.an.instanceOf(Function);
-      })
+    methods.forEach(function(method) {
+      it('should have a ' + method + ' method', function() {
+        expect(this.rulesConfigs[method]).to.exist.to.be.an.instanceOf(Function);
+      });
     });
   });
 
-  describe('#constructor', function () {
-    it('should error when no options are provided', function () {
-      expect(RulesConfigsManager)
-        .to.throw(ArgumentError, 'Must provide manager options');
+  describe('#constructor', function() {
+    it('should error when no options are provided', function() {
+      expect(proxy(RulesConfigsManager)).to.throw(ArgumentError, 'Must provide manager options');
     });
 
+    it('should throw an error when no base URL is provided', function() {
+      var client = proxy(RulesConfigsManager, {});
 
-    it('should throw an error when no base URL is provided', function () {
-      var client = RulesConfigsManager.bind(null, {});
-
-      expect(client)
-        .to.throw(ArgumentError, 'Must provide a base URL for the API');
+      expect(client).to.throw(ArgumentError, 'Must provide a base URL for the API');
     });
 
+    it('should throw an error when the base URL is invalid', function() {
+      var client = proxy(RulesConfigsManager, { baseUrl: '' });
 
-    it('should throw an error when the base URL is invalid', function () {
-      var client = RulesConfigsManager.bind(null, { baseUrl: '' });
-
-      expect(client)
-        .to.throw(ArgumentError, 'The provided base URL is invalid');
+      expect(client).to.throw(ArgumentError, 'The provided base URL is invalid');
     });
   });
 
-  describe('#getAll', function () {
-
-    it('should accept a callback', function (done) {
-      this
-        .rulesConfigs
-        .getAll(function () {
-          done();
-        });
+  describe('#getAll', function() {
+    it('should accept a callback', function(done) {
+      this.rulesConfigs.getAll(function() {
+        done();
+      });
     });
 
-
-    it('should return a promise if no callback is given', function (done) {
-      this
-        .rulesConfigs
+    it('should return a promise if no callback is given', function(done) {
+      this.rulesConfigs
         .getAll()
         .then(done.bind(null, null))
         .catch(done.bind(null, null));
     });
 
-
-    it('should pass any errors to the promise catch handler', function (done) {
+    it('should pass any errors to the promise catch handler', function(done) {
       nock.cleanAll();
 
       var request = nock(API_URL)
         .get('/rules-configs')
         .reply(500);
 
-      this
-        .rulesConfigs
-        .getAll()
-        .catch(function (err) {
-          expect(err).to.exist;
-          done();
-        });
+      this.rulesConfigs.getAll().catch(function(err) {
+        expect(err).to.exist;
+        done();
+      });
     });
 
-
-    it('should pass the body of the response to the "then" handler', function (done) {
+    it('should pass the body of the response to the "then" handler', function(done) {
       nock.cleanAll();
 
       var data = [{ key: 'dbconnectionstring' }];
@@ -97,60 +81,45 @@ describe('RulesConfigsManager', function () {
         .get('/rules-configs')
         .reply(200, data);
 
-      this
-        .rulesConfigs
-        .getAll()
-        .then(function (rulesConfigs) {
-          expect(rulesConfigs)
-            .to.be.an.instanceOf(Array);
+      this.rulesConfigs.getAll().then(function(rulesConfigs) {
+        expect(rulesConfigs).to.be.an.instanceOf(Array);
 
-          expect(rulesConfigs.length)
-            .to.equal(data.length);
+        expect(rulesConfigs.length).to.equal(data.length);
 
-          expect(rulesConfigs[0].key)
-            .to.equal(data[0].key);
+        expect(rulesConfigs[0].key).to.equal(data[0].key);
 
-          done();
-        });
+        done();
+      });
     });
 
-
-    it('should perform a GET request to rules-configs', function (done) {
+    it('should perform a GET request to rules-configs', function(done) {
       nock.cleanAll();
 
       var request = nock(API_URL)
         .get('/rules-configs')
         .reply(200);
 
-      this
-        .rulesConfigs
-        .getAll()
-        .then(function () {
-          expect(request.isDone()).to.be.true;
-          done();
-        });
+      this.rulesConfigs.getAll().then(function() {
+        expect(request.isDone()).to.be.true;
+        done();
+      });
     });
 
-
-    it('should include the token in the Authorization header', function (done) {
+    it('should include the token in the Authorization header', function(done) {
       nock.cleanAll();
 
       var request = nock(API_URL)
         .get('/rules-configs')
         .matchHeader('Authorization', 'Bearer ' + this.token)
-        .reply(200)
+        .reply(200);
 
-      this
-        .rulesConfigs
-        .getAll()
-        .then(function () {
-          expect(request.isDone()).to.be.true;
-          done();
-        });
+      this.rulesConfigs.getAll().then(function() {
+        expect(request.isDone()).to.be.true;
+        done();
+      });
     });
 
-
-    it('should pass the parameters in the query-string', function (done) {
+    it('should pass the parameters in the query-string', function(done) {
       nock.cleanAll();
 
       var params = {
@@ -160,198 +129,154 @@ describe('RulesConfigsManager', function () {
       var request = nock(API_URL)
         .get('/rules-configs')
         .query(params)
-        .reply(200)
+        .reply(200);
 
-      this
-        .rulesConfigs
-        .getAll(params)
-        .then(function () {
-          expect(request.isDone())
-            .to.be.true;
+      this.rulesConfigs.getAll(params).then(function() {
+        expect(request.isDone()).to.be.true;
 
-          done();
-        });
+        done();
+      });
     });
   });
 
-  describe('#set', function () {
-
-    beforeEach(function () {
+  describe('#set', function() {
+    beforeEach(function() {
       this.data = { value: 'foobar' };
       this.params = { key: 'KEY' };
     });
 
-    it('should accept a callback', function (done) {
-      this
-        .rulesConfigs
-        .set(this.params, this.data, function () {
-          done();
-        });
+    it('should accept a callback', function(done) {
+      this.rulesConfigs.set(this.params, this.data, function() {
+        done();
+      });
     });
 
-    it('should return a promise if no callback is given', function (done) {
-      this
-        .rulesConfigs
+    it('should return a promise if no callback is given', function(done) {
+      this.rulesConfigs
         .set(this.params, this.data)
         .then(done.bind(null, null))
         .catch(done.bind(null, null));
     });
 
-    it('should pass any errors to the promise catch handler', function (done) {
+    it('should pass any errors to the promise catch handler', function(done) {
       nock.cleanAll();
 
       var request = nock(API_URL)
         .put('/rules-configs/' + this.params.key)
         .reply(500);
 
-      this
-        .rulesConfigs
-        .set(this.params, this.data)
-        .catch(function (err) {
-          expect(err)
-            .to.exist;
+      this.rulesConfigs.set(this.params, this.data).catch(function(err) {
+        expect(err).to.exist;
 
-          done();
-        });
+        done();
+      });
     });
 
-    it('should perform a PUT request to /rules-configs/{KEY}', function (done) {
+    it('should perform a PUT request to /rules-configs/{KEY}', function(done) {
       nock.cleanAll();
 
       var request = nock(API_URL)
         .put('/rules-configs/' + this.params.key, this.data)
         .reply(200);
 
-      this
-        .rulesConfigs
+      this.rulesConfigs
         .set(this.params, this.data)
-        .then(function () {
-          expect(request.isDone())
-            .to.be.true;
+        .then(function() {
+          expect(request.isDone()).to.be.true;
 
           done();
         })
-        .catch(function (err) {
+        .catch(function(err) {
           console.error(err);
           expect.fail();
           done();
         });
     });
 
-    it('should pass the data in the body of the request', function (done) {
+    it('should pass the data in the body of the request', function(done) {
       nock.cleanAll();
 
       var request = nock(API_URL)
         .put('/rules-configs/' + this.params.key, this.data)
         .reply(200);
 
-      this
-        .rulesConfigs
-        .set(this.params, this.data)
-        .then(function () {
-          expect(request.isDone())
-            .to.be.true;
+      this.rulesConfigs.set(this.params, this.data).then(function() {
+        expect(request.isDone()).to.be.true;
 
-          done();
-        });
+        done();
+      });
     });
 
-    it('should include the token in the Authorization header', function (done) {
+    it('should include the token in the Authorization header', function(done) {
       nock.cleanAll();
 
       var request = nock(API_URL)
         .put('/rules-configs/' + this.params.key, this.data)
         .matchHeader('Authorization', 'Bearer ' + this.token)
-        .reply(200)
+        .reply(200);
 
-      this
-        .rulesConfigs
-        .set(this.params, this.data)
-        .then(function () {
-          expect(request.isDone())
-            .to.be.true;
+      this.rulesConfigs.set(this.params, this.data).then(function() {
+        expect(request.isDone()).to.be.true;
 
-          done();
-        });
+        done();
+      });
     });
   });
 
-  describe('#delete', function () {
+  describe('#delete', function() {
     var key = 'KEY';
 
-    beforeEach(function () {
+    beforeEach(function() {
       this.request = nock(API_URL)
         .delete('/rules-configs/' + key)
         .reply(200);
     });
 
-
-    it('should accept a callback', function (done) {
-      this
-        .rulesConfigs
-        .delete({ key: key }, done.bind(null, null));
+    it('should accept a callback', function(done) {
+      this.rulesConfigs.delete({ key: key }, done.bind(null, null));
     });
 
-
-    it('should return a promise when no callback is given', function (done) {
-      this
-        .rulesConfigs
-        .delete({ key: key })
-        .then(done.bind(null, null));
+    it('should return a promise when no callback is given', function(done) {
+      this.rulesConfigs.delete({ key: key }).then(done.bind(null, null));
     });
 
-
-    it('should perform a delete request to /rules-configs/' + key, function (done) {
+    it('should perform a delete request to /rules-configs/' + key, function(done) {
       var request = this.request;
- 
-      this
-        .rulesConfigs
-        .delete({ key: key })
-        .then(function () {
-          expect(request.isDone())
-            .to.be.true;
 
-          done();
-        });
+      this.rulesConfigs.delete({ key: key }).then(function() {
+        expect(request.isDone()).to.be.true;
+
+        done();
+      });
     });
 
-
-    it('should pass any errors to the promise catch handler', function (done) {
+    it('should pass any errors to the promise catch handler', function(done) {
       nock.cleanAll();
 
       var request = nock(API_URL)
         .delete('/rules-configs/' + key)
         .reply(500);
 
-      this
-        .rulesConfigs
-        .delete({ key: key })
-        .catch(function (err) {
-          expect(err)
-            .to.exist;
+      this.rulesConfigs.delete({ key: key }).catch(function(err) {
+        expect(err).to.exist;
 
-          done();
-        });
+        done();
+      });
     });
 
-
-    it('should include the token in the authorization header', function (done) {
+    it('should include the token in the authorization header', function(done) {
       nock.cleanAll();
 
       var request = nock(API_URL)
         .delete('/rules-configs/' + key)
         .matchHeader('authorization', 'Bearer ' + this.token)
-        .reply(200)
+        .reply(200);
 
-      this
-        .rulesConfigs
-        .delete({ key: key })
-        .then(function () {
-          expect(request.isDone())
-            .to.be.true;
+      this.rulesConfigs.delete({ key: key }).then(function() {
+        expect(request.isDone()).to.be.true;
 
-          done();
-        });
+        done();
+      });
     });
   });
 });

--- a/test/management/rules.tests.js
+++ b/test/management/rules.tests.js
@@ -1,6 +1,8 @@
 var expect = require('chai').expect;
 var nock = require('nock');
 
+const proxy = require('../util-constructor-proxy');
+
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
 
@@ -28,17 +30,17 @@ describe('RulesManager', function() {
 
   describe('#constructor', function() {
     it('should error when no options are provided', function() {
-      expect(RulesManager).to.throw(ArgumentError, 'Must provide manager options');
+      expect(proxy(RulesManager)).to.throw(ArgumentError, 'Must provide manager options');
     });
 
     it('should throw an error when no base URL is provided', function() {
-      var client = RulesManager.bind(null, {});
+      var client = proxy(RulesManager, {});
 
       expect(client).to.throw(ArgumentError, 'Must provide a base URL for the API');
     });
 
     it('should throw an error when the base URL is invalid', function() {
-      var client = RulesManager.bind(null, { baseUrl: '' });
+      var client = proxy(RulesManager, { baseUrl: '' });
 
       expect(client).to.throw(ArgumentError, 'The provided base URL is invalid');
     });

--- a/test/management/stats.tests.js
+++ b/test/management/stats.tests.js
@@ -1,6 +1,8 @@
 var expect = require('chai').expect;
 var nock = require('nock');
 
+const proxy = require('../util-constructor-proxy');
+
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
 
@@ -28,17 +30,17 @@ describe('StatsManager', function() {
 
   describe('#constructor', function() {
     it('should error when no options are provided', function() {
-      expect(StatsManager).to.throw(ArgumentError, 'Must provide manager options');
+      expect(proxy(StatsManager)).to.throw(ArgumentError, 'Must provide manager options');
     });
 
     it('should throw an error when no base URL is provided', function() {
-      var client = StatsManager.bind(null, {});
+      var client = proxy(StatsManager, {});
 
       expect(client).to.throw(ArgumentError, 'Must provide a base URL for the API');
     });
 
     it('should throw an error when the base URL is invalid', function() {
-      var client = StatsManager.bind(null, { baseUrl: '' });
+      var client = proxy(StatsManager, { baseUrl: '' });
 
       expect(client).to.throw(ArgumentError, 'The provided base URL is invalid');
     });

--- a/test/management/tenant.tests.js
+++ b/test/management/tenant.tests.js
@@ -1,6 +1,8 @@
 var expect = require('chai').expect;
 var nock = require('nock');
 
+const proxy = require('../util-constructor-proxy');
+
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenants.auth0.com';
 
@@ -28,17 +30,17 @@ describe('TenantManager', function() {
 
   describe('#constructor', function() {
     it('should error when no options are provided', function() {
-      expect(TenantManager).to.throw(ArgumentError, 'Must provide manager options');
+      expect(proxy(TenantManager)).to.throw(ArgumentError, 'Must provide manager options');
     });
 
     it('should throw an error when no base URL is provided', function() {
-      var manager = TenantManager.bind(null, {});
+      var manager = proxy(TenantManager, {});
 
       expect(manager).to.throw(ArgumentError, 'Must provide a base URL for the API');
     });
 
     it('should throw an error when the base URL is invalid', function() {
-      var manager = TenantManager.bind(null, { baseUrl: '' });
+      var manager = proxy(TenantManager, { baseUrl: '' });
 
       expect(manager).to.throw(ArgumentError, 'The provided base URL is invalid');
     });

--- a/test/management/tickets.tests.js
+++ b/test/management/tickets.tests.js
@@ -1,6 +1,8 @@
 var expect = require('chai').expect;
 var nock = require('nock');
 
+const proxy = require('../util-constructor-proxy');
+
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenants.auth0.com';
 
@@ -28,17 +30,17 @@ describe('TicketsManager', function() {
 
   describe('#constructor', function() {
     it('should error when no options are provided', function() {
-      expect(TicketsManager).to.throw(ArgumentError, 'Must provide manager options');
+      expect(proxy(TicketsManager)).to.throw(ArgumentError, 'Must provide manager options');
     });
 
     it('should throw an error when no base URL is provided', function() {
-      var manager = TicketsManager.bind(null, {});
+      var manager = proxy(TicketsManager, {});
 
       expect(manager).to.throw(ArgumentError, 'Must provide a base URL for the API');
     });
 
     it('should throw an error when the base URL is invalid', function() {
-      var manager = TicketsManager.bind(null, { baseUrl: '' });
+      var manager = proxy(TicketsManager, { baseUrl: '' });
 
       expect(manager).to.throw(ArgumentError, 'The provided base URL is invalid');
     });

--- a/test/management/users.tests.js
+++ b/test/management/users.tests.js
@@ -1,6 +1,8 @@
 var expect = require('chai').expect;
 var nock = require('nock');
 
+const proxy = require('../util-constructor-proxy');
+
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenants.auth0.com';
 
@@ -43,17 +45,17 @@ describe('UsersManager', function() {
 
   describe('#constructor', function() {
     it('should error when no options are provided', function() {
-      expect(UsersManager).to.throw(ArgumentError, 'Must provide manager options');
+      expect(proxy(UsersManager)).to.throw(ArgumentError, 'Must provide manager options');
     });
 
     it('should throw an error when no base URL is provided', function() {
-      var manager = UsersManager.bind(null, {});
+      var manager = proxy(UsersManager, {});
 
       expect(manager).to.throw(ArgumentError, 'Must provide a base URL for the API');
     });
 
     it('should throw an error when the base URL is invalid', function() {
-      var manager = UsersManager.bind(null, { baseUrl: '' });
+      var manager = proxy(UsersManager, { baseUrl: '' });
 
       expect(manager).to.throw(ArgumentError, 'The provided base URL is invalid');
     });

--- a/test/retry-rest-client.tests.js
+++ b/test/retry-rest-client.tests.js
@@ -1,6 +1,8 @@
 var expect = require('chai').expect;
 var nock = require('nock');
 
+const proxy = require('./util-constructor-proxy');
+
 var Promise = require('bluebird');
 var ArgumentError = require('rest-facade').ArgumentError;
 var RestClient = require('rest-facade').Client;
@@ -14,18 +16,18 @@ describe('RetryRestClient', function() {
   });
 
   it('should raise an error when no RestClient is provided', function() {
-    expect(RetryRestClient).to.throw(ArgumentError, 'Must provide RestClient');
+    expect(proxy(RetryRestClient)).to.throw(ArgumentError, 'Must provide RestClient');
   });
 
   it('should raise an error when enabled is not of type boolean', function() {
     var options = { enabled: {} };
-    var client = RetryRestClient.bind(null, {}, options);
+    var client = proxy(RetryRestClient, {}, options);
     expect(client).to.throw(ArgumentError, 'Must provide enabled boolean value');
   });
 
   it('should raise an error when maxRetries is negative', function() {
     var options = { maxRetries: -1 };
-    var client = RetryRestClient.bind(null, {}, options);
+    var client = proxy(RetryRestClient, {}, options);
     expect(client).to.throw(ArgumentError, 'Must provide maxRetries as a positive number');
   });
 

--- a/test/util-constructor-proxy.js
+++ b/test/util-constructor-proxy.js
@@ -1,0 +1,2 @@
+// Test utility function to delay class instantiation
+module.exports = (ClassObject, ...args) => () => new ClassObject(...args);

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,9 +61,9 @@
   integrity sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==
 
 "@types/node@*":
-  version "10.11.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.3.tgz#c055536ac8a5e871701aa01914be5731539d01ee"
-  integrity sha512-3AvcEJAh9EMatxs+OxAlvAEs7OTy6AG94mcH1iqyVDwVVndekLxzwkWQ/Z4SDbY6GO2oyUXyWW8tQ4rENSSQVQ==
+  version "10.11.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.4.tgz#e8bd933c3f78795d580ae41d86590bfc1f4f389d"
+  integrity sha512-ojnbBiKkZFYRfQpmtnnWTMw+rzGp/JiystjluW9jgN3VzRwilXddJ6aGQ9V/7iuDG06SBgn7ozW9k3zcAnYjYQ==
 
 "@types/range-parser@*":
   version "1.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,9 +61,9 @@
   integrity sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==
 
 "@types/node@*":
-  version "10.7.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.7.1.tgz#b704d7c259aa40ee052eec678758a68d07132a2e"
-  integrity sha512-EGoI4ylB/lPOaqXqtzAyL8HcgOuCtH2hkEaLmkueOYufsTFWBn4VCvlCDC2HW8Q+9iF+QVC3sxjDKQYjHQeZ9w==
+  version "10.11.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.3.tgz#c055536ac8a5e871701aa01914be5731539d01ee"
+  integrity sha512-3AvcEJAh9EMatxs+OxAlvAEs7OTy6AG94mcH1iqyVDwVVndekLxzwkWQ/Z4SDbY6GO2oyUXyWW8tQ4rENSSQVQ==
 
 "@types/range-parser@*":
   version "1.2.2"
@@ -78,7 +78,12 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-abbrev@1, abbrev@1.0.x:
+abbrev@1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
+  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
+abbrev@1.0.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
   integrity sha1-kbR5JYinc4wl813W9jdSovh3YTU=
@@ -88,38 +93,12 @@ acorn@^3.0.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
   integrity sha1-ReN/s56No/JbruP/U2niu18iAXo=
 
-agent-base@2, agent-base@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-2.1.1.tgz#d6de10d5af6132d5bd692427d46fc538539094c7"
-  integrity sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=
-  dependencies:
-    extend "~3.0.0"
-    semver "~5.0.1"
-
-agent-base@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.1.1.tgz#92d8a4fc2524a3b09b3666a33b6c97960f23d6a4"
-  integrity sha512-yWGUUmCZD/33IRjG2It94PzixT8lX+47Uq8fjmd0cgQWITCMrJuXFaVIMnGDmDnZGGKAGdwTx8UGeU8lMR2urA==
+agent-base@4, agent-base@^4.1.0, agent-base@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
+  integrity sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==
   dependencies:
     es6-promisify "^5.0.0"
-
-ajv@^4.9.1:
-  version "4.11.8"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
-  integrity sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=
-  dependencies:
-    co "^4.6.0"
-    json-stable-stringify "^1.0.1"
-
-ajv@^5.1.0:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.3.tgz#c06f598778c44c6b161abafe3466b81ad1814ed2"
-  integrity sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=
-  dependencies:
-    co "^4.6.0"
-    fast-deep-equal "^1.0.0"
-    json-schema-traverse "^0.3.0"
-    json-stable-stringify "^1.0.1"
 
 ajv@^5.3.0:
   version "5.5.2"
@@ -150,6 +129,11 @@ ansi-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
   integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
 
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -163,30 +147,30 @@ ansi-styles@^3.2.1:
     color-convert "^1.9.0"
 
 anymatch@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.0.tgz#a3e52fa39168c825ff57b0248126ce5a8ff95507"
-  integrity sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.2.tgz#553dcb8f91e3c889845dfdba34c77721b90b9d7a"
+  integrity sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==
   dependencies:
-    arrify "^1.0.0"
     micromatch "^2.1.5"
+    normalize-path "^2.0.0"
 
 aproba@^1.0.3:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.1.2.tgz#45c6629094de4e96f693ef7eab74ae079c240fc1"
-  integrity sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
+  integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
 
 are-we-there-yet@~1.1.2:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz#bb5dca382bb94f05e15194373d16fd3ba1ca110d"
-  integrity sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
+  integrity sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
 argparse@^1.0.7:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
-  integrity sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
 
@@ -202,25 +186,37 @@ arr-diff@^2.0.0:
   dependencies:
     arr-flatten "^1.0.1"
 
-arr-flatten@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.0.3.tgz#a274ed85ac08849b6bd7847c4580745dc51adfb1"
-  integrity sha1-onTthawIhJtr14R8RYB0XcUa37E=
+arr-diff@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
+  integrity sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=
+
+arr-flatten@^1.0.1, arr-flatten@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
+  integrity sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==
+
+arr-union@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
+  integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
 
 array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
   integrity sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=
 
-arrify@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
-  integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
+array-unique@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
+  integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
 asn1@~0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
-  integrity sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
+  integrity sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==
+  dependencies:
+    safer-buffer "~2.1.0"
 
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
@@ -244,17 +240,27 @@ assertion-error@1.0.0:
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.0.tgz#c7f85438fdd466bc7ca16ab90c81513797a5d23b"
   integrity sha1-x/hUOP3UZrx8oWq5DIFRN5el0js=
 
+assertion-error@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
+assign-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
+  integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
+
 ast-types@0.x.x:
-  version "0.9.14"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.14.tgz#d34ba5dffb9d15a44351fd2a9d82e4ab2838b5ba"
-  integrity sha512-Ebvx7/0lLboCdyEmAw/4GqwBeKIijPveXNiVGhCGCNxc7z26T5he7DC6ARxu8ByKuzUZZcLog+VP8GMyZrBzJw==
+  version "0.11.5"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.11.5.tgz#9890825d660c03c28339f315e9fa0a360e31ec28"
+  integrity sha512-oJjo+5e7/vEc2FBK8gUalV0pba4L3VdBIs2EKhOLHLcOd2FgQIVQN9xb0eZ9IjEWyAL7vq6fGJxOvVvdCHNyMw==
 
 async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
   integrity sha1-GdOGodntxufByF04iu28xW0zYC0=
 
-async@1.x, async@^1.3.0, async@^1.4.0:
+async@1.x, async@^1.3.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
@@ -263,6 +269,13 @@ async@^0.9.0:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
   integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
+
+async@^2.5.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
+  integrity sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==
+  dependencies:
+    lodash "^4.17.10"
 
 async@~0.2.10, async@~0.2.6:
   version "0.2.10"
@@ -274,6 +287,11 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
+atob@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
+  integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
+
 aws-sign2@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
@@ -284,12 +302,7 @@ aws-sign2@~0.7.0:
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
   integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
-aws4@^1.2.1, aws4@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
-  integrity sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=
-
-aws4@^1.8.0:
+aws4@^1.2.1, aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
@@ -305,48 +318,49 @@ balanced-match@^1.0.0:
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
 base64-js@^1.0.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.0.tgz#a39992d723584811982be5e290bb6a53d86700f1"
-  integrity sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
+  integrity sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==
+
+base@^0.11.1:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
+  integrity sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==
+  dependencies:
+    cache-base "^1.0.1"
+    class-utils "^0.3.5"
+    component-emitter "^1.2.1"
+    define-property "^1.0.0"
+    isobject "^3.0.1"
+    mixin-deep "^1.2.0"
+    pascalcase "^0.1.1"
 
 bcrypt-pbkdf@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
-  integrity sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
+  integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
 
 big.js@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.1.3.tgz#4cada2193652eb3ca9ec8e55c9015669c9806978"
-  integrity sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg=
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
+  integrity sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==
 
 binary-extensions@^1.0.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.8.0.tgz#48ec8d16df4377eae5fa5884682480af4d95c774"
-  integrity sha1-SOyNFt9Dd+rl+liEaCSAr02Vx3Q=
-
-block-stream@*:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
-  integrity sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=
-  dependencies:
-    inherits "~2.0.0"
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.12.0.tgz#c2d780f53d45bba8317a8902d4ceeaf3a6385b14"
+  integrity sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==
 
 bluebird@^2.10.2:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
   integrity sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=
 
-bluebird@^3.5.2:
+bluebird@~3.5.0:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.2.tgz#1be0908e054a751754549c270489c1505d4ab15a"
   integrity sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==
-
-bluebird@~3.5.0:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
-  integrity sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==
 
 boom@2.x.x:
   version "2.10.1"
@@ -355,24 +369,10 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-boom@4.x.x:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-4.3.1.tgz#4f8a3005cb4a7e3889f749030fd25b96e01d2e31"
-  integrity sha1-T4owBctKfjiJ90kDD9JbluAdLjE=
-  dependencies:
-    hoek "4.x.x"
-
-boom@5.x.x:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-5.2.0.tgz#5dd9da6ee3a5f302077436290cb717d3f4a54e02"
-  integrity sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==
-  dependencies:
-    hoek "4.x.x"
-
 brace-expansion@^1.1.7:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
-  integrity sha1-wHshHHyVLsH479Uad+8NHTmQopI=
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -385,6 +385,22 @@ braces@^1.8.2:
     expand-range "^1.8.1"
     preserve "^0.2.0"
     repeat-element "^1.1.2"
+
+braces@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
+  integrity sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==
+  dependencies:
+    arr-flatten "^1.1.0"
+    array-unique "^0.3.2"
+    extend-shallow "^2.0.1"
+    fill-range "^4.0.0"
+    isobject "^3.0.1"
+    repeat-element "^1.1.2"
+    snapdragon "^0.8.1"
+    snapdragon-node "^2.0.1"
+    split-string "^3.0.2"
+    to-regex "^3.0.1"
 
 browserify-aes@0.4.0:
   version "0.4.0"
@@ -424,6 +440,21 @@ bytes@3.0.0:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
   integrity sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
 
+cache-base@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
+  integrity sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==
+  dependencies:
+    collection-visit "^1.0.0"
+    component-emitter "^1.2.1"
+    get-value "^2.0.6"
+    has-value "^1.0.0"
+    isobject "^3.0.1"
+    set-value "^2.0.0"
+    to-object-path "^0.3.0"
+    union-value "^1.0.0"
+    unset-value "^1.0.0"
+
 camel-case@^1.1.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-1.2.2.tgz#1aca7c4d195359a2ce9955793433c6e5542511f2"
@@ -462,7 +493,16 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-"chai@>=1.9.2 <4.0.0", chai@^2.2.0:
+"chai@>=1.9.2 <4.0.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-3.5.0.tgz#4d02637b067fe958bdbfdd3a40ec56fef7373247"
+  integrity sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=
+  dependencies:
+    assertion-error "^1.0.1"
+    deep-eql "^0.1.3"
+    type-detect "^1.0.0"
+
+chai@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-2.3.0.tgz#8a2f6a34748da801090fd73287b2aa739a4e909a"
   integrity sha1-ii9qNHSNqAEJD9cyh7Kqc5pOkJo=
@@ -482,9 +522,9 @@ chalk@^1.1.1:
     supports-color "^2.0.0"
 
 chalk@^2.3.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
-  integrity sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
   dependencies:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
@@ -533,10 +573,25 @@ chokidar@^1.0.0:
   optionalDependencies:
     fsevents "^1.0.0"
 
-ci-info@^1.0.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.3.tgz#710193264bb05c77b8c90d02f5aaf22216a667b2"
-  integrity sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==
+chownr@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
+  integrity sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==
+
+ci-info@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
+  integrity sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==
+
+class-utils@^0.3.5:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
+  integrity sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==
+  dependencies:
+    arr-union "^3.1.0"
+    define-property "^0.2.5"
+    isobject "^3.0.0"
+    static-extend "^0.1.1"
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -548,9 +603,9 @@ cliui@^2.1.0:
     wordwrap "0.0.2"
 
 clone@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.2.tgz#260b7a99ebb1edfe247538175f783243cb19d149"
-  integrity sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
+  integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
 co@^4.6.0:
   version "4.6.0"
@@ -563,37 +618,45 @@ code-point-at@^1.0.0:
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
 codecov@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/codecov/-/codecov-2.2.0.tgz#2d06817ceb8891eca6368836d4fb6bf6cc04ffd1"
-  integrity sha1-LQaBfOuIkeymNog21Ptr9swE/9E=
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-2.3.1.tgz#7dda945cd58a1f6081025b5b03ee01a2ef20f86e"
+  integrity sha1-fdqUXNWKH2CBAltbA+4Bou8g+G4=
   dependencies:
     argv "0.0.2"
-    request "2.79.0"
+    request "2.77.0"
     urlgrey "0.4.4"
 
-color-convert@^1.9.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
-  integrity sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==
+collection-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
+  integrity sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=
   dependencies:
-    color-name "^1.1.1"
+    map-visit "^1.0.0"
+    object-visit "^1.0.0"
 
-color-name@^1.1.1:
+color-convert@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
+  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
+  dependencies:
+    color-name "1.1.3"
+
+color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-combined-stream@1.0.6, combined-stream@~1.0.6:
+combined-stream@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
   integrity sha1-cj599ugBrFYTETp+RFqbactjKBg=
   dependencies:
     delayed-stream "~1.0.0"
 
-combined-stream@^1.0.5, combined-stream@~1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
-  integrity sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=
+combined-stream@^1.0.5, combined-stream@~1.0.5, combined-stream@~1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
+  integrity sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==
   dependencies:
     delayed-stream "~1.0.0"
 
@@ -608,13 +671,16 @@ commander@2.3.0:
   integrity sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=
 
 commander@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
-  integrity sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
-  dependencies:
-    graceful-readlink ">= 1.0.0"
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.18.0.tgz#2bf063ddee7c7891176981a2cc798e5754bc6970"
+  integrity sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ==
 
-component-emitter@^1.2.0:
+commander@~2.17.1:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
+  integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
+
+component-emitter@^1.2.0, component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
   integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
@@ -650,11 +716,16 @@ constants-browserify@^1.0.0:
   integrity sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
 
 cookiejar@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.1.tgz#41ad57b1b555951ec171412a81942b1e8200d34a"
-  integrity sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
+  integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
 
-core-util-is@~1.0.0:
+copy-descriptor@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
+  integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
+
+core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
@@ -679,13 +750,6 @@ cryptiles@2.x.x:
   integrity sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=
   dependencies:
     boom "2.x.x"
-
-cryptiles@3.x.x:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.2.tgz#a89fbb220f5ce25ec56e8c4aa8a4fd7b5b0d29fe"
-  integrity sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=
-  dependencies:
-    boom "5.x.x"
 
 crypto-browserify@3.3.0:
   version "3.3.0"
@@ -728,38 +792,45 @@ date-now@^0.1.4:
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
   integrity sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=
 
-debug@2, debug@^2.6.8:
+debug@2, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
 
-debug@2.2.0, debug@^2.2.0:
+debug@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   integrity sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=
   dependencies:
     ms "0.7.1"
 
-debug@^3.1.0:
+debug@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   dependencies:
     ms "2.0.0"
 
-debug@~0.7.4:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-0.7.4.tgz#06e1ea8082c2cb14e39806e22e2f6f757f92af39"
-  integrity sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=
+debug@^3.1.0:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.5.tgz#c2418fbfd7a29f4d4f70ff4cea604d4b64c46407"
+  integrity sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==
+  dependencies:
+    ms "^2.1.1"
 
 decamelize@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
-deep-eql@0.1.3:
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+  integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+
+deep-eql@0.1.3, deep-eql@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-0.1.3.tgz#ef558acab8de25206cd713906d74e56930eb69f2"
   integrity sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=
@@ -771,10 +842,10 @@ deep-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
   integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
 
-deep-extend@~0.4.0:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
-  integrity sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -785,6 +856,28 @@ deepmerge@^1.5.1:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"
   integrity sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ==
+
+define-property@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
+  integrity sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=
+  dependencies:
+    is-descriptor "^0.1.0"
+
+define-property@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-1.0.0.tgz#769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6"
+  integrity sha1-dp66rz9KY6rTr56NMEybvnm/sOY=
+  dependencies:
+    is-descriptor "^1.0.0"
+
+define-property@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-2.0.2.tgz#d459689e8d654ba77e02a817f8710d702cb16e9d"
+  integrity sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==
+  dependencies:
+    is-descriptor "^1.0.2"
+    isobject "^3.0.1"
 
 degenerator@^1.0.4:
   version "1.0.4"
@@ -805,10 +898,15 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-depd@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
-  integrity sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=
+depd@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
+  integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
+detect-libc@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 diff@1.4.0:
   version "1.4.0"
@@ -816,9 +914,9 @@ diff@1.4.0:
   integrity sha1-fyjS657nsVqX79ic5j3P2qPMur8=
 
 domain-browser@^1.1.1:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
-  integrity sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
+  integrity sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==
 
 dot-case@^1.1.0:
   version "1.1.2"
@@ -828,11 +926,12 @@ dot-case@^1.1.0:
     sentence-case "^1.1.2"
 
 ecc-jsbn@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
-  integrity sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
+  integrity sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=
   dependencies:
     jsbn "~0.1.0"
+    safer-buffer "^2.1.0"
 
 ecdsa-sig-formatter@1.0.10:
   version "1.0.10"
@@ -856,16 +955,16 @@ enhanced-resolve@~0.9.0:
     tapable "^0.1.8"
 
 errno@^0.1.3:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
-  integrity sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
+  integrity sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==
   dependencies:
-    prr "~0.0.0"
+    prr "~1.0.1"
 
 es6-promise@^4.0.3:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.1.1.tgz#8811e90915d9a0dba36274f0b242dbda78f9c92a"
-  integrity sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.5.tgz#da6d0d5692efb461e082c14817fe2427d8f5d054"
+  integrity sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==
 
 es6-promisify@^5.0.0:
   version "5.0.0"
@@ -902,18 +1001,18 @@ escodegen@1.8.x:
     source-map "~0.2.0"
 
 escodegen@1.x.x:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.9.0.tgz#9811a2f265dc1cd3894420ee3717064b632b8852"
-  integrity sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.11.0.tgz#b27a9389481d5bfd5bec76f7bb1eb3f8f4556589"
+  integrity sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==
   dependencies:
     esprima "^3.1.3"
     estraverse "^4.2.0"
     esutils "^2.0.2"
     optionator "^0.8.1"
   optionalDependencies:
-    source-map "~0.5.6"
+    source-map "~0.6.1"
 
-esprima@2.7.x, esprima@^2.6.0, esprima@^2.7.1:
+esprima@2.7.x, esprima@^2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
   integrity sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=
@@ -922,6 +1021,11 @@ esprima@3.x.x, esprima@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
   integrity sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
+
+esprima@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 estraverse@^1.9.1:
   version "1.9.3"
@@ -963,6 +1067,19 @@ expand-brackets@^0.1.4:
   dependencies:
     is-posix-bracket "^0.1.0"
 
+expand-brackets@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
+  integrity sha1-t3c14xXOMPa27/D4OwQVGiJEliI=
+  dependencies:
+    debug "^2.3.3"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    posix-character-classes "^0.1.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
 expand-range@^1.8.1:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337"
@@ -970,12 +1087,22 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-extend@3, extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
-  integrity sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=
+extend-shallow@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  integrity sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=
+  dependencies:
+    is-extendable "^0.1.0"
 
-extend@~3.0.2:
+extend-shallow@^3.0.0, extend-shallow@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
+  integrity sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=
+  dependencies:
+    assign-symbols "^1.0.0"
+    is-extendable "^1.0.1"
+
+extend@3, extend@^3.0.0, extend@~3.0.0, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -987,15 +1114,34 @@ extglob@^0.3.1:
   dependencies:
     is-extglob "^1.0.0"
 
-extsprintf@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
-  integrity sha1-4QgOBljjALBilJkMxw4VAiNf1VA=
+extglob@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
+  integrity sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==
+  dependencies:
+    array-unique "^0.3.2"
+    define-property "^1.0.0"
+    expand-brackets "^2.1.4"
+    extend-shallow "^2.0.1"
+    fragment-cache "^0.2.1"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
+extsprintf@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
+  integrity sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
+
+extsprintf@^1.2.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
+  integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
 fast-deep-equal@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
-  integrity sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
+  integrity sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -1033,15 +1179,25 @@ fill-keys@^1.0.2:
     merge-descriptors "~1.0.0"
 
 fill-range@^2.1.0:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.3.tgz#50b77dfd7e469bc7492470963699fe7a8485a723"
-  integrity sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.4.tgz#eb1e773abb056dcd8df2bfdf6af59b8b3a936565"
+  integrity sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==
   dependencies:
     is-number "^2.1.0"
     isobject "^2.0.0"
-    randomatic "^1.1.3"
+    randomatic "^3.0.0"
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
+
+fill-range@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
+  integrity sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+    to-regex-range "^2.1.0"
 
 find-up@^2.1.0:
   version "2.1.0"
@@ -1050,7 +1206,7 @@ find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
-for-in@^1.0.1:
+for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
@@ -1067,13 +1223,13 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-form-data@^2.3.1, form-data@~2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.1.tgz#6fb94fbd71885306d73d15cc497fe4cc4ecd44bf"
-  integrity sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=
+form-data@^2.3.1, form-data@~2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
+  integrity sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=
   dependencies:
     asynckit "^0.4.0"
-    combined-stream "^1.0.5"
+    combined-stream "1.0.6"
     mime-types "^2.1.12"
 
 form-data@~2.1.1:
@@ -1085,15 +1241,6 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-form-data@~2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
-  integrity sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "1.0.6"
-    mime-types "^2.1.12"
-
 formatio@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
@@ -1101,10 +1248,24 @@ formatio@1.1.1:
   dependencies:
     samsam "~1.1"
 
-formidable@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.1.1.tgz#96b8886f7c3c3508b932d6bd70c4d3a88f35f1a9"
-  integrity sha1-lriIb3w8NQi5Mta9cMTTqI818ak=
+formidable@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
+  integrity sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==
+
+fragment-cache@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
+  integrity sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=
+  dependencies:
+    map-cache "^0.2.2"
+
+fs-minipass@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
+  integrity sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==
+  dependencies:
+    minipass "^2.2.1"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -1112,31 +1273,12 @@ fs.realpath@^1.0.0:
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
 fsevents@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.2.tgz#3282b713fb3ad80ede0e9fcf4611b5aa6fc033f4"
-  integrity sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.4.tgz#f41dcb1af2582af3692da36fc55cbd8e1041c426"
+  integrity sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==
   dependencies:
-    nan "^2.3.0"
-    node-pre-gyp "^0.6.36"
-
-fstream-ignore@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/fstream-ignore/-/fstream-ignore-1.0.5.tgz#9c31dae34767018fe1d249b24dada67d092da105"
-  integrity sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=
-  dependencies:
-    fstream "^1.0.0"
-    inherits "2"
-    minimatch "^3.0.0"
-
-fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
-  integrity sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=
-  dependencies:
-    graceful-fs "^4.1.2"
-    inherits "~2.0.0"
-    mkdirp ">=0.5 0"
-    rimraf "2"
+    nan "^2.9.2"
+    node-pre-gyp "^0.10.0"
 
 ftp@~0.3.10:
   version "0.3.10"
@@ -1161,9 +1303,11 @@ gauge@~2.7.3:
     wide-align "^1.1.0"
 
 generate-function@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.0.0.tgz#6858fe7c0969b7d4e9093337647ac79f60dfbe74"
-  integrity sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.3.1.tgz#f069617690c10c868e73b8465746764f97c3479f"
+  integrity sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==
+  dependencies:
+    is-property "^1.0.2"
 
 generate-object-property@^1.1.0:
   version "1.2.0"
@@ -1178,9 +1322,9 @@ get-stream@^3.0.0:
   integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
 
 get-uri@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/get-uri/-/get-uri-2.0.1.tgz#dbdcacacd8c608a38316869368117697a1631c59"
-  integrity sha512-7aelVrYqCLuVjq2kEKRTH8fXPTC0xKTkM+G7UlFkEwCXY3sFbSxvY375JoFowOAYbkaU47SrBvOefUlLZZ+6QA==
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/get-uri/-/get-uri-2.0.2.tgz#5c795e71326f6ca1286f2fc82575cd2bab2af578"
+  integrity sha512-ZD325dMZOgerGqF/rF6vZXyFGTAay62svjQIT+X/oU2PtxYpFxvSkbsdi+oxIrsNxlZVd4y8wUDqkaExWTI/Cw==
   dependencies:
     data-uri-to-buffer "1"
     debug "2"
@@ -1188,6 +1332,11 @@ get-uri@^2.0.0:
     file-uri-to-path "1"
     ftp "~0.3.10"
     readable-stream "2"
+
+get-value@^2.0.3, get-value@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
+  integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -1231,9 +1380,9 @@ glob@^5.0.15:
     path-is-absolute "^1.0.0"
 
 glob@^7.0.5:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
-  integrity sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
+  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -1242,15 +1391,10 @@ glob@^7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.9:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
-
-"graceful-readlink@>= 1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
-  integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
 
 growl@1.9.2:
   version "1.9.2"
@@ -1258,20 +1402,15 @@ growl@1.9.2:
   integrity sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=
 
 handlebars@^4.0.1:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.10.tgz#3d30c718b09a3d96f23ea4cc1f403c4d3ba9ff4f"
-  integrity sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=
+  version "4.0.12"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.12.tgz#2c15c8a96d46da5e266700518ba8cb8d919d5bc5"
+  integrity sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==
   dependencies:
-    async "^1.4.0"
+    async "^2.5.0"
     optimist "^0.6.1"
-    source-map "^0.4.4"
+    source-map "^0.6.1"
   optionalDependencies:
-    uglify-js "^2.6"
-
-har-schema@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
-  integrity sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=
+    uglify-js "^3.1.4"
 
 har-schema@^2.0.0:
   version "2.0.0"
@@ -1287,22 +1426,6 @@ har-validator@~2.0.6:
     commander "^2.9.0"
     is-my-json-valid "^2.12.4"
     pinkie-promise "^2.0.0"
-
-har-validator@~4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
-  integrity sha1-M0gdDxu/9gDdID11gSpqX7oALio=
-  dependencies:
-    ajv "^4.9.1"
-    har-schema "^1.0.5"
-
-har-validator@~5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd"
-  integrity sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=
-  dependencies:
-    ajv "^5.1.0"
-    har-schema "^2.0.0"
 
 har-validator@~5.1.0:
   version "5.1.0"
@@ -1334,6 +1457,37 @@ has-unicode@^2.0.0:
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
   integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
 
+has-value@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
+  integrity sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=
+  dependencies:
+    get-value "^2.0.3"
+    has-values "^0.1.4"
+    isobject "^2.0.0"
+
+has-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-1.0.0.tgz#18b281da585b1c5c51def24c930ed29a0be6b177"
+  integrity sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=
+  dependencies:
+    get-value "^2.0.6"
+    has-values "^1.0.0"
+    isobject "^3.0.0"
+
+has-values@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-0.1.4.tgz#6d61de95d91dfca9b9a02089ad384bff8f62b771"
+  integrity sha1-bWHeldkd/Km5oCCJrThL/49it3E=
+
+has-values@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-1.0.0.tgz#95b0b63fec2146619a6fe57fe75628d5a39efe4f"
+  integrity sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=
+  dependencies:
+    is-number "^3.0.0"
+    kind-of "^4.0.0"
+
 hawk@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
@@ -1344,44 +1498,28 @@ hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
-hawk@~6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
-  integrity sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==
-  dependencies:
-    boom "4.x.x"
-    cryptiles "3.x.x"
-    hoek "4.x.x"
-    sntp "2.x.x"
-
 hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
   integrity sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=
 
-hoek@4.x.x:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
-  integrity sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==
-
-http-errors@1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736"
-  integrity sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=
+http-errors@1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
+  integrity sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=
   dependencies:
-    depd "1.1.1"
+    depd "~1.1.2"
     inherits "2.0.3"
-    setprototypeof "1.0.3"
-    statuses ">= 1.3.1 < 2"
+    setprototypeof "1.1.0"
+    statuses ">= 1.4.0 < 2"
 
-http-proxy-agent@1, http-proxy-agent@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-1.0.0.tgz#cc1ce38e453bf984a0f7702d2dd59c73d081284a"
-  integrity sha1-zBzjjkU7+YSg93AtLdWcc9CBKEo=
+http-proxy-agent@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz#e4821beef5b2142a2026bd73926fe537631c5405"
+  integrity sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==
   dependencies:
-    agent-base "2"
-    debug "2"
-    extend "3"
+    agent-base "4"
+    debug "3.1.0"
 
 http-signature@~1.1.0:
   version "1.1.1"
@@ -1406,14 +1544,13 @@ https-browserify@0.0.1:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
   integrity sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=
 
-https-proxy-agent@1, https-proxy-agent@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz#35f7da6c48ce4ddbfa264891ac593ee5ff8671e6"
-  integrity sha1-NffabEjOTdv6JkiRrFk+5f+GceY=
+https-proxy-agent@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
+  integrity sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==
   dependencies:
-    agent-base "2"
-    debug "2"
-    extend "3"
+    agent-base "^4.1.0"
+    debug "^3.1.0"
 
 husky@^0.14.3:
   version "0.14.3"
@@ -1424,20 +1561,36 @@ husky@^0.14.3:
     normalize-path "^1.0.0"
     strip-indent "^2.0.0"
 
-iconv-lite@0.4.19:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
-  integrity sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==
+iconv-lite@0.4.23:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
+  integrity sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
+
+iconv-lite@^0.4.4:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
 
 ieee754@^1.1.4:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
-  integrity sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"
+  integrity sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==
+
+ignore-walk@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.1.tgz#a83e62e7d272ac0e3b551aaa82831a19b69f82f8"
+  integrity sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==
+  dependencies:
+    minimatch "^3.0.4"
 
 ignore@^3.3.7:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
-  integrity sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
+  integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
 
 indexof@0.0.1:
   version "0.0.1"
@@ -1452,7 +1605,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
@@ -1463,9 +1616,9 @@ inherits@2.0.1:
   integrity sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=
 
 ini@~1.3.0:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
-  integrity sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
+  integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
 
 interpret@^0.6.4:
   version "0.6.6"
@@ -1477,6 +1630,20 @@ ip@^1.1.4, ip@^1.1.5:
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
   integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
 
+is-accessor-descriptor@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
+  integrity sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=
+  dependencies:
+    kind-of "^3.0.2"
+
+is-accessor-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz#169c2f6d3df1f992618072365c9b0ea1f6878656"
+  integrity sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==
+  dependencies:
+    kind-of "^6.0.0"
+
 is-binary-path@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898"
@@ -1485,16 +1652,48 @@ is-binary-path@^1.0.0:
     binary-extensions "^1.0.0"
 
 is-buffer@^1.1.5, is-buffer@~1.1.1:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.5.tgz#1f3b26ef613b214b88cbca23cc6c01d87961eecc"
-  integrity sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
 is-ci@^1.0.10:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.1.0.tgz#247e4162e7860cebbdaf30b774d6b0ac7dcfe7a5"
-  integrity sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.1.tgz#e3779c8ee17fccf428488f6e281187f2e632841c"
+  integrity sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==
   dependencies:
-    ci-info "^1.0.0"
+    ci-info "^1.5.0"
+
+is-data-descriptor@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
+  integrity sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=
+  dependencies:
+    kind-of "^3.0.2"
+
+is-data-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
+  integrity sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==
+  dependencies:
+    kind-of "^6.0.0"
+
+is-descriptor@^0.1.0:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca"
+  integrity sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==
+  dependencies:
+    is-accessor-descriptor "^0.1.6"
+    is-data-descriptor "^0.1.4"
+    kind-of "^5.0.0"
+
+is-descriptor@^1.0.0, is-descriptor@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-1.0.2.tgz#3b159746a66604b04f8c81524ba365c5f14d86ec"
+  integrity sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==
+  dependencies:
+    is-accessor-descriptor "^1.0.0"
+    is-data-descriptor "^1.0.0"
+    kind-of "^6.0.2"
 
 is-dotfile@^1.0.0:
   version "1.0.3"
@@ -1508,10 +1707,17 @@ is-equal-shallow@^0.1.3:
   dependencies:
     is-primitive "^2.0.0"
 
-is-extendable@^0.1.1:
+is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
   integrity sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=
+
+is-extendable@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4"
+  integrity sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==
+  dependencies:
+    is-plain-object "^2.0.4"
 
 is-extglob@^1.0.0:
   version "1.0.0"
@@ -1524,6 +1730,11 @@ is-fullwidth-code-point@^1.0.0:
   integrity sha1-754xOG8DGn8NZDr4L95QxFfvAMs=
   dependencies:
     number-is-nan "^1.0.0"
+
+is-fullwidth-code-point@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+  integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
 
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
@@ -1539,13 +1750,19 @@ is-lower-case@^1.1.0:
   dependencies:
     lower-case "^1.1.0"
 
+is-my-ip-valid@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz#7b351b8e8edd4d3995d4d066680e664d94696824"
+  integrity sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==
+
 is-my-json-valid@^2.12.4:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz#f079dd9bfdae65ee2038aae8acbc86ab109e3693"
-  integrity sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz#8fd6e40363cd06b963fa877d444bfb5eddc62175"
+  integrity sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==
   dependencies:
     generate-function "^2.0.0"
     generate-object-property "^1.1.0"
+    is-my-ip-valid "^1.0.0"
     jsonpointer "^4.0.0"
     xtend "^4.0.0"
 
@@ -1563,10 +1780,22 @@ is-number@^3.0.0:
   dependencies:
     kind-of "^3.0.2"
 
+is-number@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
+  integrity sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==
+
 is-object@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
   integrity sha1-iVJojF7C/9awPsyF52ngKQMINHA=
+
+is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+  integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
+  dependencies:
+    isobject "^3.0.1"
 
 is-posix-bracket@^0.1.0:
   version "0.1.1"
@@ -1578,7 +1807,7 @@ is-primitive@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
   integrity sha1-IHurkWOEmcB7Kt8kCkGochADRXU=
 
-is-property@^1.0.0:
+is-property@^1.0.0, is-property@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
   integrity sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=
@@ -1605,6 +1834,11 @@ is-upper-case@^1.1.0:
   dependencies:
     upper-case "^1.1.0"
 
+is-windows@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+  integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
+
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
@@ -1626,6 +1860,11 @@ isobject@^2.0.0:
   integrity sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=
   dependencies:
     isarray "1.0.0"
+
+isobject@^3.0.0, isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+  integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -1661,12 +1900,12 @@ jade@0.26.3:
     mkdirp "0.3.0"
 
 js-yaml@3.x:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
-  integrity sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
+  integrity sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==
   dependencies:
     argparse "^1.0.7"
-    esprima "^2.6.0"
+    esprima "^4.0.0"
 
 js2xmlparser@~3.0.0:
   version "3.0.0"
@@ -1699,9 +1938,9 @@ jsdoc@^3.5.5:
     underscore "~1.8.3"
 
 json-loader@^0.5.4:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.4.tgz#8baa1365a632f58a3c46d20175fc6002c96e37de"
-  integrity sha1-i6oTZaYy9Yo8RtIBdfxgAsluN94=
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.7.tgz#dca14a70235ff82f0ac9a3abeb60d337a365185d"
+  integrity sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==
 
 json-schema-traverse@^0.3.0:
   version "0.3.1"
@@ -1713,13 +1952,6 @@ json-schema@0.2.3:
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
   integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
 
-json-stable-stringify@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
-  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
-  dependencies:
-    jsonify "~0.0.0"
-
 json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -1729,11 +1961,6 @@ json5@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
   integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
-
-jsonify@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
-  integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
 jsonpointer@^4.0.0:
   version "4.0.1"
@@ -1756,14 +1983,14 @@ jsonwebtoken@^8.3.0:
     ms "^2.1.1"
 
 jsprim@^1.2.2:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.0.tgz#a3b87e40298d8c380552d8cc7628a0bb95a22918"
-  integrity sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
+  integrity sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
   dependencies:
     assert-plus "1.0.0"
-    extsprintf "1.0.2"
+    extsprintf "1.3.0"
     json-schema "0.2.3"
-    verror "1.3.6"
+    verror "1.10.0"
 
 jwa@^1.1.5:
   version "1.1.6"
@@ -1794,7 +2021,7 @@ jws@^3.1.5:
     jwa "^1.1.5"
     safe-buffer "^5.0.1"
 
-kind-of@^3.0.2:
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
   integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
@@ -1807,6 +2034,16 @@ kind-of@^4.0.0:
   integrity sha1-IIE989cSkosgc3hpGkUGb65y3Vc=
   dependencies:
     is-buffer "^1.1.5"
+
+kind-of@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
+  integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
+
+kind-of@^6.0.0, kind-of@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
+  integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
 klaw@~2.0.0:
   version "2.0.0"
@@ -1896,15 +2133,10 @@ lodash@2.4.1:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.1.tgz#5b7723034dda4d262e5a46fb2c58d7cc22f71420"
   integrity sha1-W3cjA03aTSYuWkb7LFjXzCL3FCA=
 
-lodash@^4.17.4:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
-  integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
-
-lodash@~4.5.1:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.5.1.tgz#80e8a074ca5f3893a6b1c10b2a636492d710c316"
-  integrity sha1-gOigdMpfOJOmscELKmNkktcQwxY=
+lodash@^4.17.10, lodash@^4.17.4:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 lolex@1.3.2:
   version "1.3.2"
@@ -1933,18 +2165,13 @@ lru-cache@2:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
   integrity sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=
 
-lru-cache@^4.0.1:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.2.tgz#45234b2e6e2f2b33da125624c4664929a0224c3f"
-  integrity sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==
+lru-cache@^4.0.1, lru-cache@^4.1.2:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
+  integrity sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
-
-lru-cache@~2.6.5:
-  version "2.6.5"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.6.5.tgz#e56d6354148ede8d7707b58d143220fd08df0fd5"
-  integrity sha1-5W1jVBSO3o13B7WNFDIg/QjfD9U=
 
 lru-cache@~4.0.0:
   version "4.0.2"
@@ -1954,17 +2181,7 @@ lru-cache@~4.0.0:
     pseudomap "^1.0.1"
     yallist "^2.0.0"
 
-lru-memoizer@^1.11.1:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/lru-memoizer/-/lru-memoizer-1.11.1.tgz#0693f6100593914c02e192bf9b8d93884cbf50d3"
-  integrity sha1-BpP2EAWTkUwC4ZK/m42TiEy/UNM=
-  dependencies:
-    lock "~0.1.2"
-    lodash "~4.5.1"
-    lru-cache "~4.0.0"
-    very-fast-args "^1.1.0"
-
-lru-memoizer@^1.6.0:
+lru-memoizer@^1.11.1, lru-memoizer@^1.6.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/lru-memoizer/-/lru-memoizer-1.12.0.tgz#efe65706cc8a9cc653f80f0d5a6ea38ad950e352"
   integrity sha1-7+ZXBsyKnMZT+A8NWm6jitlQ41I=
@@ -1974,10 +2191,27 @@ lru-memoizer@^1.6.0:
     lru-cache "~4.0.0"
     very-fast-args "^1.1.0"
 
+map-cache@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
+  integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
+
+map-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
+  integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
+  dependencies:
+    object-visit "^1.0.0"
+
 marked@~0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
-  integrity sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.19.tgz#5d47f709c4c9fc3c216b6d46127280f40b39d790"
+  integrity sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==
+
+math-random@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac"
+  integrity sha1-izqsWIuKZuSXXjzepn97sylgH6w=
 
 md5@^2.1.0, md5@^2.2.1:
   version "2.2.1"
@@ -2030,41 +2264,36 @@ micromatch@^2.1.5:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-mime-db@~1.27.0:
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.27.0.tgz#820f572296bbd20ec25ed55e5b5de869e5436eb1"
-  integrity sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=
-
-mime-db@~1.30.0:
-  version "1.30.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
-  integrity sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=
-
-mime-db@~1.35.0:
-  version "1.35.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.35.0.tgz#0569d657466491283709663ad379a99b90d9ab47"
-  integrity sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==
-
-mime-types@^2.1.12, mime-types@~2.1.7:
-  version "2.1.15"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.15.tgz#a4ebf5064094569237b8cf70046776d09fc92aed"
-  integrity sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=
+micromatch@^3.1.10:
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
+  integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
   dependencies:
-    mime-db "~1.27.0"
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    braces "^2.3.1"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    extglob "^2.0.4"
+    fragment-cache "^0.2.1"
+    kind-of "^6.0.2"
+    nanomatch "^1.2.9"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.2"
 
-mime-types@~2.1.17:
-  version "2.1.17"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
-  integrity sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=
-  dependencies:
-    mime-db "~1.30.0"
+mime-db@~1.36.0:
+  version "1.36.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.36.0.tgz#5020478db3c7fe93aad7bbcc4dcf869c43363397"
+  integrity sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==
 
-mime-types@~2.1.19:
-  version "2.1.19"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.19.tgz#71e464537a7ef81c15f2db9d97e913fc0ff606f0"
-  integrity sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==
+mime-types@^2.1.12, mime-types@~2.1.19, mime-types@~2.1.7:
+  version "2.1.20"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.20.tgz#930cb719d571e903738520f8470911548ca2cc19"
+  integrity sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==
   dependencies:
-    mime-db "~1.35.0"
+    mime-db "~1.36.0"
 
 mime@^1.4.1:
   version "1.6.0"
@@ -2084,14 +2313,14 @@ minimatch@0.3:
     lru-cache "2"
     sigmund "~1.0.0"
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8, minimist@~0.0.1:
+minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
@@ -2101,12 +2330,40 @@ minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
+minimist@~0.0.1:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
+  integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
+
+minipass@^2.2.1, minipass@^2.3.3:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.4.tgz#4768d7605ed6194d6d576169b9e12ef71e9d9957"
+  integrity sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
+minizlib@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.1.0.tgz#11e13658ce46bc3a70a267aac58359d1e0c29ceb"
+  integrity sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==
+  dependencies:
+    minipass "^2.2.1"
+
+mixin-deep@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
+  integrity sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==
+  dependencies:
+    for-in "^1.0.2"
+    is-extendable "^1.0.1"
+
 mkdirp@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.0.tgz#1bbf5ab1ba827af23575143490426455f481fe1e"
   integrity sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=
 
-mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -2114,21 +2371,22 @@ mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdi
     minimist "0.0.8"
 
 mocha-junit-reporter@^1.13.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/mocha-junit-reporter/-/mocha-junit-reporter-1.13.0.tgz#030db8c530b244667253b03861d4cd336f7e56c8"
-  integrity sha1-Aw24xTCyRGZyU7A4YdTNM29+Vsg=
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/mocha-junit-reporter/-/mocha-junit-reporter-1.18.0.tgz#9209a3fba30025ae3ae5e6bfe7f9c5bc3c2e8ee2"
+  integrity sha512-y3XuqKa2+HRYtg0wYyhW/XsLm2Ps+pqf9HaTAt7+MVUAKFJaNAHOrNseTZo9KCxjfIbxUWwckP5qCDDPUmjSWA==
   dependencies:
     debug "^2.2.0"
     md5 "^2.1.0"
     mkdirp "~0.5.1"
+    strip-ansi "^4.0.0"
     xml "^1.0.0"
 
 mocha-multi@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/mocha-multi/-/mocha-multi-0.11.0.tgz#5cd48e04dbe7657d7e997880c4ccd021aaf51aa5"
-  integrity sha1-XNSOBNvnZX1+mXiAxMzQIar1GqU=
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/mocha-multi/-/mocha-multi-0.11.1.tgz#38f94242aff5d5e8313f61afcd0012bb7c478a52"
+  integrity sha512-bhZG9KwPIG/7K0P0kbB5wpwPEurDvaOIZbhVxSkAj8QhVHMxwOjQjnP6FaAd7qzwUgtbNODLo59vdyIJLHQopg==
   dependencies:
-    debug "~0.7.4"
+    debug "^3.1.0"
     is-string "^1.0.4"
     mkdirp "^0.5.1"
     object-assign "^4.1.1"
@@ -2155,14 +2413,14 @@ module-not-found-error@^1.0.0:
   integrity sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=
 
 moment@^2.18.1:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
-  integrity sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
+  integrity sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=
 
 mri@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.0.tgz#5c0a3f29c8ccffbbb1ec941dcec09d71fa32f36a"
-  integrity sha1-XAo/KcjM/7ux7JQdzsCdcfoy82o=
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.1.tgz#85aa26d3daeeeedf80dc5984af95cc5ca5cad9f1"
+  integrity sha1-haom09ru7t+A3FmEr5XMXKXK2fE=
 
 ms@0.7.1:
   version "0.7.1"
@@ -2179,10 +2437,36 @@ ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-nan@^2.3.0:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
-  integrity sha1-5P805slf37WuzAjeZZb0NgWn20U=
+nan@^2.9.2:
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.1.tgz#90e22bccb8ca57ea4cd37cc83d3819b52eea6766"
+  integrity sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==
+
+nanomatch@^1.2.9:
+  version "1.2.13"
+  resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
+  integrity sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    fragment-cache "^0.2.1"
+    is-windows "^1.0.2"
+    kind-of "^6.0.2"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
+needle@^2.2.1:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.4.tgz#51931bff82533b1928b7d1d69e01f1b00ffd2a4e"
+  integrity sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==
+  dependencies:
+    debug "^2.1.2"
+    iconv-lite "^0.4.4"
+    sax "^1.2.4"
 
 netmask@^1.0.6:
   version "1.0.6"
@@ -2231,20 +2515,26 @@ node-libs-browser@^0.7.0:
     util "^0.10.3"
     vm-browserify "0.0.4"
 
-node-pre-gyp@^0.6.36:
-  version "0.6.36"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz#db604112cb74e0d477554e9b505b17abddfab786"
-  integrity sha1-22BBEst04NR3VU6bUFsXq936t4Y=
+node-pre-gyp@^0.10.0:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
+  integrity sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==
   dependencies:
+    detect-libc "^1.0.2"
     mkdirp "^0.5.1"
+    needle "^2.2.1"
     nopt "^4.0.1"
+    npm-packlist "^1.1.6"
     npmlog "^4.0.2"
-    rc "^1.1.7"
-    request "^2.81.0"
+    rc "^1.2.7"
     rimraf "^2.6.1"
     semver "^5.3.0"
-    tar "^2.2.1"
-    tar-pack "^3.4.0"
+    tar "^4"
+
+node-uuid@~1.4.7:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
+  integrity sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=
 
 nopt@3.x:
   version "3.0.6"
@@ -2266,12 +2556,25 @@ normalize-path@^1.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
   integrity sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=
 
-normalize-path@^2.0.1:
+normalize-path@^2.0.0, normalize-path@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
   integrity sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=
   dependencies:
     remove-trailing-separator "^1.0.1"
+
+npm-bundled@^1.0.1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.5.tgz#3c1732b7ba936b3a10325aef616467c0ccbcc979"
+  integrity sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==
+
+npm-packlist@^1.1.6:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.1.11.tgz#84e8c683cbe7867d34b1d357d893ce29e28a02de"
+  integrity sha512-CxKlZ24urLkJk+9kCm48RTQ7L4hsmgSVzEk0TLGPzzyuFxD7VNgy5Sl24tOLMzQv773a/NeJ1ce1DKeacqffEA==
+  dependencies:
+    ignore-walk "^3.0.1"
+    npm-bundled "^1.0.1"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -2281,9 +2584,9 @@ npm-run-path@^2.0.0:
     path-key "^2.0.0"
 
 npmlog@^4.0.2:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.0.tgz#dc59bee85f64f00ed424efb2af0783df25d1c0b5"
-  integrity sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
+  integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
   dependencies:
     are-we-there-yet "~1.1.2"
     console-control-strings "~1.1.0"
@@ -2295,7 +2598,7 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
-oauth-sign@~0.8.1, oauth-sign@~0.8.2:
+oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
   integrity sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=
@@ -2310,6 +2613,22 @@ object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
+object-copy@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
+  integrity sha1-fn2Fi3gb18mRpBupde04EnVOmYw=
+  dependencies:
+    copy-descriptor "^0.1.0"
+    define-property "^0.2.5"
+    kind-of "^3.0.3"
+
+object-visit@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
+  integrity sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=
+  dependencies:
+    isobject "^3.0.0"
+
 object.omit@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
@@ -2318,7 +2637,14 @@ object.omit@^2.0.0:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
 
-once@1.x, once@^1.3.0, once@^1.3.3:
+object.pick@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
+  integrity sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
+  dependencies:
+    isobject "^3.0.1"
+
+once@1.x, once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
@@ -2361,9 +2687,9 @@ os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
 osenv@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.4.tgz#42fe6d5953df06c8064be6f176c3d05aaaa34644"
-  integrity sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
+  integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
@@ -2374,9 +2700,9 @@ p-finally@^1.0.0:
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
 
 p-limit@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.2.0.tgz#0e92b6bedcb59f022c13d0f1949dc82d15909f1c"
-  integrity sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
+  integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
   dependencies:
     p-try "^1.0.0"
 
@@ -2392,16 +2718,16 @@ p-try@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
   integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
 
-pac-proxy-agent@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/pac-proxy-agent/-/pac-proxy-agent-2.0.0.tgz#beb17cd2b06a20b379d57e1b2e2c29be0dfe5f9a"
-  integrity sha512-t57UiJpi5mFLTvjheC1SNSwIhml3+ElNOj69iRrydtQXZJr8VIFYSDtyPi/3ZysA62kD2dmww6pDlzk0VaONZg==
+pac-proxy-agent@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/pac-proxy-agent/-/pac-proxy-agent-2.0.2.tgz#90d9f6730ab0f4d2607dcdcd4d3d641aa26c3896"
+  integrity sha512-cDNAN1Ehjbf5EHkNY5qnRhGPUCp6SnpyVof5fRzN800QV1Y2OkzbH9rmjZkbBRa8igof903yOnjIl6z0SlAhxA==
   dependencies:
-    agent-base "^2.1.1"
-    debug "^2.6.8"
+    agent-base "^4.2.0"
+    debug "^3.1.0"
     get-uri "^2.0.0"
-    http-proxy-agent "^1.0.0"
-    https-proxy-agent "^1.0.0"
+    http-proxy-agent "^2.1.0"
+    https-proxy-agent "^2.2.1"
     pac-resolver "^3.0.0"
     raw-body "^2.2.0"
     socks-proxy-agent "^3.0.0"
@@ -2446,6 +2772,11 @@ pascal-case@^1.1.0:
   dependencies:
     camel-case "^1.1.1"
     upper-case-first "^1.1.0"
+
+pascalcase@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
+  integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
 path-browserify@0.0.0:
   version "0.0.0"
@@ -2494,11 +2825,6 @@ pem@^1.13.1:
     os-tmpdir "^1.0.1"
     which "^1.3.1"
 
-performance-now@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
-  integrity sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=
-
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -2516,6 +2842,11 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
+posix-character-classes@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
+  integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -2527,14 +2858,14 @@ preserve@^0.2.0:
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
 prettier@^1.12.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.12.0.tgz#d26fc5894b9230de97629b39cae225b503724ce8"
-  integrity sha512-Wz0SMncgaglBzDcohH3ZIAi4nVpzOIEweFzCOmgVEoRSeO72b4dcKGfgxoRGVMaFlh1r7dlVaJ+f3CIHfeH6xg==
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.3.tgz#90238dd4c0684b7edce5f83b0fb7328e48bd0895"
+  integrity sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==
 
 pretty-quick@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/pretty-quick/-/pretty-quick-1.4.1.tgz#9d41f778d2d4d940ec603d1293a0998e84c4722c"
-  integrity sha512-Q4V2GAflSaM739kKH63utbfI2n4s2fCDCyjFC4ykxA9ueb7FknLcLAZSKa3DejHMt5q9Fq395eKTZ9wYwoILBw==
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/pretty-quick/-/pretty-quick-1.7.0.tgz#6be2a707f874b56a461f6508c9fbd5d1c9234930"
+  integrity sha512-bKoLGOy2rvPKcypkzYqlyqBBAtf0yKV7VK0C/7E4m541dY98rxZsbBt4GDRa/mc74EBPCeuiFe1fkKiyqjUKVg==
   dependencies:
     chalk "^2.3.0"
     execa "^0.8.0"
@@ -2542,10 +2873,10 @@ pretty-quick@^1.4.1:
     ignore "^3.3.7"
     mri "^1.1.0"
 
-process-nextick-args@~1.0.6:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
-  integrity sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=
+process-nextick-args@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+  integrity sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==
 
 process@^0.11.0:
   version "0.11.10"
@@ -2558,18 +2889,23 @@ propagate@0.3.x:
   integrity sha1-46hEBKfs6CDda76p9tkk4xNa4Jw=
 
 proxy-agent@2:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-agent/-/proxy-agent-2.1.0.tgz#a3a2b3866debfeb79bb791f345dc9bc876e7ff86"
-  integrity sha512-I23qaUnXmU/ItpXWQcMj9wMcZQTXnJNI7nakSR+q95Iht8H0+w3dCgTJdfnOQqOCX1FZwKLSgurCyEt11LM6OA==
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/proxy-agent/-/proxy-agent-2.3.1.tgz#3d49d863d46cf5f37ca8394848346ea02373eac6"
+  integrity sha512-CNKuhC1jVtm8KJYFTS2ZRO71VCBx3QSA92So/e6NrY6GoJonkx3Irnk4047EsCcswczwqAekRj3s8qLRGahSKg==
   dependencies:
-    agent-base "2"
-    debug "2"
-    extend "3"
-    http-proxy-agent "1"
-    https-proxy-agent "1"
-    lru-cache "~2.6.5"
-    pac-proxy-agent "^2.0.0"
-    socks-proxy-agent "2"
+    agent-base "^4.2.0"
+    debug "^3.1.0"
+    http-proxy-agent "^2.1.0"
+    https-proxy-agent "^2.2.1"
+    lru-cache "^4.1.2"
+    pac-proxy-agent "^2.0.1"
+    proxy-from-env "^1.0.0"
+    socks-proxy-agent "^3.0.0"
+
+proxy-from-env@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
+  integrity sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=
 
 proxyquire@^2.1.0:
   version "2.1.0"
@@ -2580,10 +2916,10 @@ proxyquire@^2.1.0:
     module-not-found-error "^1.0.0"
     resolve "~1.8.1"
 
-prr@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
-  integrity sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=
+prr@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
+  integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
 
 pseudomap@^1.0.1, pseudomap@^1.0.2:
   version "1.0.2"
@@ -2605,25 +2941,15 @@ punycode@^1.2.4, punycode@^1.4.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
-qs@^6.5.1, qs@~6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
-  integrity sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==
+qs@^6.5.1, qs@~6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
+  integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
 qs@~6.3.0:
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
   integrity sha1-51vV9uJoEioqDgvaYwslUMFmUCw=
-
-qs@~6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
-  integrity sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=
-
-qs@~6.5.2:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
-  integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
 querystring-es3@^0.2.0:
   version "0.2.1"
@@ -2635,30 +2961,31 @@ querystring@0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
-randomatic@^1.1.3:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
-  integrity sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==
+randomatic@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.1.0.tgz#36f2ca708e9e567f5ed2ec01949026d50aa10116"
+  integrity sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==
   dependencies:
-    is-number "^3.0.0"
-    kind-of "^4.0.0"
+    is-number "^4.0.0"
+    kind-of "^6.0.0"
+    math-random "^1.0.1"
 
 raw-body@^2.2.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.2.tgz#bcd60c77d3eb93cde0050295c3f379389bc88f89"
-  integrity sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.3.tgz#1b324ece6b5706e153855bc1148c65bb7f6ea0c3"
+  integrity sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==
   dependencies:
     bytes "3.0.0"
-    http-errors "1.6.2"
-    iconv-lite "0.4.19"
+    http-errors "1.6.3"
+    iconv-lite "0.4.23"
     unpipe "1.0.0"
 
-rc@^1.1.7:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.1.tgz#2e03e8e42ee450b8cb3dce65be1bf8974e1dfd95"
-  integrity sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=
+rc@^1.2.7:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
   dependencies:
-    deep-extend "~0.4.0"
+    deep-extend "^0.6.0"
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
@@ -2673,69 +3000,62 @@ readable-stream@1.1.x:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
-  integrity sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==
+readable-stream@2, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.3.5, readable-stream@^2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
     isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
+    process-nextick-args "~2.0.0"
     safe-buffer "~5.1.1"
-    string_decoder "~1.0.3"
-    util-deprecate "~1.0.1"
-
-readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.6:
-  version "2.2.11"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.11.tgz#0796b31f8d7688007ff0b93a8088d34aa17c0f72"
-  integrity sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    safe-buffer "~5.0.1"
-    string_decoder "~1.0.0"
+    string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
 readdirp@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.1.0.tgz#4ed0ad060df3073300c48440373f72d1cc642d78"
-  integrity sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz#0e87622a3325aa33e892285caf8b4e846529a525"
+  integrity sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==
   dependencies:
-    graceful-fs "^4.1.2"
-    minimatch "^3.0.2"
+    graceful-fs "^4.1.11"
+    micromatch "^3.1.10"
     readable-stream "^2.0.2"
-    set-immediate-shim "^1.0.1"
 
 regex-cache@^0.4.2:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.3.tgz#9b1a6c35d4d0dfcef5711ae651e8e9d3d7114145"
-  integrity sha1-mxpsNdTQ3871cRrmUejp09cRQUU=
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.4.tgz#75bdc58a2a1496cec48a12835bc54c8d562336dd"
+  integrity sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==
   dependencies:
     is-equal-shallow "^0.1.3"
-    is-primitive "^2.0.0"
+
+regex-not@^1.0.0, regex-not@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
+  integrity sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==
+  dependencies:
+    extend-shallow "^3.0.2"
+    safe-regex "^1.1.0"
 
 remove-trailing-separator@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz#69b062d978727ad14dc6b56ba4ab772fd8d70511"
-  integrity sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
+  integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
 
 repeat-element@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
-  integrity sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
+  integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
 
-repeat-string@^1.5.2:
+repeat-string@^1.5.2, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
-request@2.79.0:
-  version "2.79.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
-  integrity sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=
+request@2.77.0:
+  version "2.77.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.77.0.tgz#2b00d82030ededcc97089ffa5d8810a9c2aa314b"
+  integrity sha1-KwDYIDDt7cyXCJ/6XYgQqcKqMUs=
   dependencies:
     aws-sign2 "~0.6.0"
     aws4 "^1.2.1"
@@ -2751,14 +3071,14 @@ request@2.79.0:
     isstream "~0.1.2"
     json-stringify-safe "~5.0.1"
     mime-types "~2.1.7"
+    node-uuid "~1.4.7"
     oauth-sign "~0.8.1"
     qs "~6.3.0"
     stringstream "~0.0.4"
     tough-cookie "~2.3.0"
     tunnel-agent "~0.4.1"
-    uuid "^3.0.0"
 
-request@^2.73.0:
+request@^2.73.0, request@^2.83.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -2784,68 +3104,17 @@ request@^2.73.0:
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
-request@^2.81.0:
-  version "2.81.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
-  integrity sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=
-  dependencies:
-    aws-sign2 "~0.6.0"
-    aws4 "^1.2.1"
-    caseless "~0.12.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.0"
-    forever-agent "~0.6.1"
-    form-data "~2.1.1"
-    har-validator "~4.2.1"
-    hawk "~3.1.3"
-    http-signature "~1.1.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.7"
-    oauth-sign "~0.8.1"
-    performance-now "^0.2.0"
-    qs "~6.4.0"
-    safe-buffer "^5.0.1"
-    stringstream "~0.0.4"
-    tough-cookie "~2.3.0"
-    tunnel-agent "^0.6.0"
-    uuid "^3.0.0"
-
-request@^2.83.0:
-  version "2.83.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
-  integrity sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==
-  dependencies:
-    aws-sign2 "~0.7.0"
-    aws4 "^1.6.0"
-    caseless "~0.12.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.1"
-    forever-agent "~0.6.1"
-    form-data "~2.3.1"
-    har-validator "~5.0.3"
-    hawk "~6.0.2"
-    http-signature "~1.2.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.17"
-    oauth-sign "~0.8.2"
-    performance-now "^2.1.0"
-    qs "~6.5.1"
-    safe-buffer "^5.1.1"
-    stringstream "~0.0.5"
-    tough-cookie "~2.3.3"
-    tunnel-agent "^0.6.0"
-    uuid "^3.1.0"
-
 requizzle@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/requizzle/-/requizzle-0.2.1.tgz#6943c3530c4d9a7e46f1cddd51c158fc670cdbde"
   integrity sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=
   dependencies:
     underscore "~1.6.0"
+
+resolve-url@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
+  integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
 resolve@1.1.x:
   version "1.1.7"
@@ -2870,6 +3139,11 @@ rest-facade@^1.10.1:
     superagent "^3.8.0"
     superagent-proxy "^1.0.2"
 
+ret@~0.1.10:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
+  integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
+
 retry@^0.10.1:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
@@ -2882,10 +3156,10 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.5.1, rimraf@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
-  integrity sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=
+rimraf@^2.6.1:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
+  integrity sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==
   dependencies:
     glob "^7.0.5"
 
@@ -2894,40 +3168,42 @@ ripemd160@0.2.0:
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-0.2.0.tgz#2bf198bde167cacfa51c0a928e84b68bbe171fce"
   integrity sha1-K/GYveFnys+lHAqSjoS2i74XH84=
 
-safe-buffer@^5.0.1:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.0.tgz#fe4c8460397f9eaaaa58e73be46273408a45e223"
-  integrity sha512-aSLEDudu6OoRr/2rU609gRmnYboRLxgDG1z9o2Q0os7236FwvcqIOO8r8U5JUEwivZOhDaKlFO4SbPTJYyBEyQ==
-
-safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
-  integrity sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==
-
-safe-buffer@^5.1.2:
+safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@~5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
-  integrity sha1-0mPKVGls2KMGtcplUekt5XkY++c=
+safe-regex@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
+  integrity sha1-QKNmnzsHfR6UPURinhV91IAjvy4=
+  dependencies:
+    ret "~0.1.10"
 
-samsam@1.1.2, samsam@~1.1:
+"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+samsam@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
   integrity sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=
 
-semver@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
-  integrity sha1-myzl094C0XxgEq0yaqa00M9U+U8=
+samsam@~1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.3.tgz#9f5087419b4d091f232571e7fa52e90b0f552621"
+  integrity sha1-n1CHQZtNCR8jJXHn+lLpCw9VJiE=
 
-semver@~5.0.1:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.0.3.tgz#77466de589cd5d3c95f138aa78bc569a3cb5d27a"
-  integrity sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=
+sax@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
+semver@^5.3.0:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
+  integrity sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==
 
 sentence-case@^1.1.1, sentence-case@^1.1.2:
   version "1.1.3"
@@ -2941,20 +3217,35 @@ set-blocking@~2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
-set-immediate-shim@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
-  integrity sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=
+set-value@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
+  integrity sha1-fbCPnT0i3H945Trzw79GZuzfzPE=
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.1"
+    to-object-path "^0.3.0"
+
+set-value@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.0.tgz#71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
+  integrity sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.3"
+    split-string "^3.0.1"
 
 setimmediate@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
 
-setprototypeof@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
-  integrity sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=
+setprototypeof@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
+  integrity sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==
 
 sha.js@2.2.6:
   version "2.2.6"
@@ -3005,28 +3296,42 @@ snake-case@^1.1.0:
   dependencies:
     sentence-case "^1.1.2"
 
+snapdragon-node@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
+  integrity sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==
+  dependencies:
+    define-property "^1.0.0"
+    isobject "^3.0.0"
+    snapdragon-util "^3.0.1"
+
+snapdragon-util@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz#f956479486f2acd79700693f6f7b805e45ab56e2"
+  integrity sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==
+  dependencies:
+    kind-of "^3.2.0"
+
+snapdragon@^0.8.1:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/snapdragon/-/snapdragon-0.8.2.tgz#64922e7c565b0e14204ba1aa7d6964278d25182d"
+  integrity sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==
+  dependencies:
+    base "^0.11.1"
+    debug "^2.2.0"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    map-cache "^0.2.2"
+    source-map "^0.5.6"
+    source-map-resolve "^0.5.0"
+    use "^3.1.0"
+
 sntp@1.x.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
   integrity sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=
   dependencies:
     hoek "2.x.x"
-
-sntp@2.x.x:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/sntp/-/sntp-2.0.2.tgz#5064110f0af85f7cfdb7d6b67a40028ce52b4b2b"
-  integrity sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=
-  dependencies:
-    hoek "4.x.x"
-
-socks-proxy-agent@2:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-2.1.1.tgz#86ebb07193258637870e13b7bd99f26c663df3d3"
-  integrity sha512-sFtmYqdUK5dAMh85H0LEVFUCO7OhJJe1/z2x/Z6mxp3s7/QPf1RkZmpZy+BpuU0bEjcV9npqKjq9Y3kwFUjnxw==
-  dependencies:
-    agent-base "2"
-    extend "3"
-    socks "~1.1.5"
 
 socks-proxy-agent@^3.0.0:
   version "3.0.1"
@@ -3036,7 +3341,7 @@ socks-proxy-agent@^3.0.0:
     agent-base "^4.1.0"
     socks "^1.1.10"
 
-socks@^1.1.10, socks@~1.1.5:
+socks@^1.1.10:
   version "1.1.10"
   resolved "https://registry.yarnpkg.com/socks/-/socks-1.1.10.tgz#5b8b7fc7c8f341c53ed056e929b7bf4de8ba7b5a"
   integrity sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=
@@ -3049,12 +3354,31 @@ source-list-map@~0.1.7:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.8.tgz#c550b2ab5427f6b3f21f5afead88c4f5587b2106"
   integrity sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY=
 
-source-map@^0.4.4, source-map@~0.4.1:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
-  integrity sha1-66T12pwNyZneaAMti092FzZSA2s=
+source-map-resolve@^0.5.0:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
+  integrity sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==
   dependencies:
-    amdefine ">=0.0.4"
+    atob "^2.1.1"
+    decode-uri-component "^0.2.0"
+    resolve-url "^0.2.1"
+    source-map-url "^0.4.0"
+    urix "^0.1.0"
+
+source-map-url@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
+  integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
+
+source-map@^0.5.6, source-map@~0.5.1:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+  integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
+
+source-map@^0.6.1, source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 source-map@~0.1.38:
   version "0.1.43"
@@ -3070,15 +3394,19 @@ source-map@~0.2.0:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@~0.5.1:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
-  integrity sha1-dc449SvwczxafwwRjYEzSiu19BI=
+source-map@~0.4.1:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
+  integrity sha1-66T12pwNyZneaAMti092FzZSA2s=
+  dependencies:
+    amdefine ">=0.0.4"
 
-source-map@~0.5.6:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
-  integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
+split-string@^3.0.1, split-string@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
+  integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
+  dependencies:
+    extend-shallow "^3.0.0"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -3086,24 +3414,33 @@ sprintf-js@~1.0.2:
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
 sshpk@^1.7.0:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.13.1.tgz#512df6da6287144316dc4c18fe1cf1d940739be3"
-  integrity sha1-US322mKHFEMW3EwY/hzx2UBzm+M=
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.14.2.tgz#c6fc61648a3d9c4e764fd3fcdf4ea105e492ba98"
+  integrity sha1-xvxhZIo9nE52T9P8306hBeSSupg=
   dependencies:
     asn1 "~0.2.3"
     assert-plus "^1.0.0"
     dashdash "^1.12.0"
     getpass "^0.1.1"
+    safer-buffer "^2.0.2"
   optionalDependencies:
     bcrypt-pbkdf "^1.0.0"
     ecc-jsbn "~0.1.1"
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
-"statuses@>= 1.3.1 < 2":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
-  integrity sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==
+static-extend@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
+  integrity sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=
+  dependencies:
+    define-property "^0.2.5"
+    object-copy "^0.1.0"
+
+"statuses@>= 1.4.0 < 2":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
+  integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
 stream-browserify@^2.0.1:
   version "2.0.1"
@@ -3114,13 +3451,13 @@ stream-browserify@^2.0.1:
     readable-stream "^2.0.2"
 
 stream-http@^2.3.1:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.7.2.tgz#40a050ec8dc3b53b33d9909415c02c0bf1abfbad"
-  integrity sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.8.3.tgz#b2d242469288a5a27ec4fe8933acf623de6514fc"
+  integrity sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==
   dependencies:
     builtin-status-codes "^3.0.0"
     inherits "^2.0.1"
-    readable-stream "^2.2.6"
+    readable-stream "^2.3.6"
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
 
@@ -3135,7 +3472,7 @@ string-replace-webpack-plugin@0.0.3:
     loader-utils "~0.2.3"
     style-loader "^0.8.3"
 
-string-width@^1.0.1, string-width@^1.0.2:
+string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
   integrity sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=
@@ -3144,29 +3481,30 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
+"string-width@^1.0.2 || 2":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
+  integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^4.0.0"
+
 string_decoder@^0.10.25, string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
   integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
 
-string_decoder@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.2.tgz#b29e1f4e1125fa97a10382b8a533737b7491e179"
-  integrity sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=
-  dependencies:
-    safe-buffer "~5.0.1"
-
-string_decoder@~1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
-  integrity sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
 
-stringstream@~0.0.4, stringstream@~0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
-  integrity sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=
+stringstream@~0.0.4:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.6.tgz#7880225b0d4ad10e30927d167a1d6f2fd3b33a72"
+  integrity sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
@@ -3174,6 +3512,13 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
+  dependencies:
+    ansi-regex "^3.0.0"
 
 strip-eof@^1.0.0:
   version "1.0.0"
@@ -3198,28 +3543,28 @@ style-loader@^0.8.3:
     loader-utils "^0.2.5"
 
 superagent-proxy@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/superagent-proxy/-/superagent-proxy-1.0.2.tgz#92d3660578f618ed43a82cf8cac799fe2938ba2d"
-  integrity sha1-ktNmBXj2GO1DqCz4yseZ/ik4ui0=
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/superagent-proxy/-/superagent-proxy-1.0.3.tgz#acfa776672f11c24a90ad575e855def8be44f741"
+  integrity sha512-79Ujg1lRL2ICfuHUdX+H2MjIw73kB7bXsIkxLwHURz3j0XUmEEEoJ+u/wq+mKwna21Uejsm2cGR3OESA00TIjA==
   dependencies:
-    debug "2"
+    debug "^3.1.0"
     proxy-agent "2"
 
 superagent@^3.8.0:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.2.tgz#e4a11b9d047f7d3efeb3bbe536d9ec0021d16403"
-  integrity sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.3.tgz#460ea0dbdb7d5b11bc4f78deba565f86a178e128"
+  integrity sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==
   dependencies:
     component-emitter "^1.2.0"
     cookiejar "^2.1.0"
     debug "^3.1.0"
     extend "^3.0.0"
     form-data "^2.3.1"
-    formidable "^1.1.1"
+    formidable "^1.2.0"
     methods "^1.1.1"
     mime "^1.4.1"
     qs "^6.5.1"
-    readable-stream "^2.0.5"
+    readable-stream "^2.3.5"
 
 supports-color@1.2.0:
   version "1.2.0"
@@ -3239,9 +3584,9 @@ supports-color@^3.1.0:
     has-flag "^1.0.0"
 
 supports-color@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
-  integrity sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
 
@@ -3263,28 +3608,18 @@ tapable@^0.1.8, tapable@~0.1.8:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.1.10.tgz#29c35707c2b70e50d07482b5d202e8ed446dafd4"
   integrity sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=
 
-tar-pack@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.0.tgz#23be2d7f671a8339376cbdb0b8fe3fdebf317984"
-  integrity sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=
+tar@^4:
+  version "4.4.6"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.6.tgz#63110f09c00b4e60ac8bcfe1bf3c8660235fbc9b"
+  integrity sha512-tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==
   dependencies:
-    debug "^2.2.0"
-    fstream "^1.0.10"
-    fstream-ignore "^1.0.5"
-    once "^1.3.3"
-    readable-stream "^2.1.4"
-    rimraf "^2.5.1"
-    tar "^2.2.1"
-    uid-number "^0.0.6"
-
-tar@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
-  integrity sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=
-  dependencies:
-    block-stream "*"
-    fstream "^1.0.2"
-    inherits "2"
+    chownr "^1.0.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.3.3"
+    minizlib "^1.1.0"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.2"
 
 thunkify@^2.1.2:
   version "2.1.2"
@@ -3292,9 +3627,9 @@ thunkify@^2.1.2:
   integrity sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0=
 
 timers-browserify@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.2.tgz#ab4883cf597dcd50af211349a00fbca56ac86b86"
-  integrity sha1-q0iDz1l9zVCvIRNJoA+8pWrIa4Y=
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.10.tgz#1d28e3d2aadf1d5a5996c4e9f95601cd053480ae"
+  integrity sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==
   dependencies:
     setimmediate "^1.0.4"
 
@@ -3316,17 +3651,35 @@ to-iso-string@0.0.2:
   resolved "https://registry.yarnpkg.com/to-iso-string/-/to-iso-string-0.0.2.tgz#4dc19e664dfccbe25bd8db508b00c6da158255d1"
   integrity sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=
 
-tough-cookie@~2.3.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
-  integrity sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=
+to-object-path@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
+  integrity sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=
   dependencies:
-    punycode "^1.4.1"
+    kind-of "^3.0.2"
 
-tough-cookie@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
-  integrity sha1-C2GKVWW23qkL80JdBNVe3EdadWE=
+to-regex-range@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-2.1.1.tgz#7c80c17b9dfebe599e27367e0d4dd5590141db38"
+  integrity sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=
+  dependencies:
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+
+to-regex@^3.0.1, to-regex@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
+  integrity sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==
+  dependencies:
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    regex-not "^1.0.2"
+    safe-regex "^1.1.0"
+
+tough-cookie@~2.3.0:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
+  integrity sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==
   dependencies:
     punycode "^1.4.1"
 
@@ -3372,7 +3725,20 @@ type-detect@0.1.1:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-0.1.1.tgz#0ba5ec2a885640e470ea4e8505971900dac58822"
   integrity sha1-C6XsKohWQORw6k6FBZcZANrFiCI=
 
-uglify-js@^2.6, uglify-js@~2.7.3:
+type-detect@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
+  integrity sha1-diIXzAbbJY7EiQihKY6LlRIejqI=
+
+uglify-js@^3.1.4:
+  version "3.4.9"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.9.tgz#af02f180c1207d76432e473ed24a28f4a782bae3"
+  integrity sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==
+  dependencies:
+    commander "~2.17.1"
+    source-map "~0.6.1"
+
+uglify-js@~2.7.3:
   version "2.7.5"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.7.5.tgz#4612c0c7baaee2ba7c487de4904ae122079f2ca8"
   integrity sha1-RhLAx7qu4rp8SH3kkErhIgefLKg=
@@ -3386,11 +3752,6 @@ uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
   integrity sha1-bgkk1r2mta/jSeOabWMoUKD4grc=
-
-uid-number@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
-  integrity sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=
 
 underscore-contrib@~0.3.0:
   version "0.3.0"
@@ -3409,10 +3770,28 @@ underscore@~1.8.3:
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
   integrity sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=
 
+union-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
+  integrity sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=
+  dependencies:
+    arr-union "^3.1.0"
+    get-value "^2.0.6"
+    is-extendable "^0.1.1"
+    set-value "^0.4.3"
+
 unpipe@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
+
+unset-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
+  integrity sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=
+  dependencies:
+    has-value "^0.3.1"
+    isobject "^3.0.0"
 
 upper-case-first@^1.1.0:
   version "1.1.2"
@@ -3425,6 +3804,11 @@ upper-case@^1.0.3, upper-case@^1.1.0, upper-case@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
   integrity sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=
+
+urix@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
+  integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
 url@^0.11.0:
   version "0.11.0"
@@ -3439,34 +3823,50 @@ urlgrey@0.4.4:
   resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
   integrity sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=
 
+use@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
+  integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
+
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-util@0.10.3, "util@>=0.10.3 <1", util@^0.10.3:
+util@0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
   integrity sha1-evsa/lCAUkZInj23/g7TeTNqwPk=
   dependencies:
     inherits "2.0.1"
 
-uuid@^3.0.0, uuid@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
-  integrity sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==
+"util@>=0.10.3 <1":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.11.0.tgz#c5f391beb244103d799b21077a926fef8769e1fb"
+  integrity sha512-5n12uMzKCjvB2HPFHnbQSjaqAa98L5iIXmHrZCLavuZVe0qe/SJGbDGWlpaHk5lnBkWRDO+dRu1/PgmUYKPPTw==
+  dependencies:
+    inherits "2.0.3"
+
+util@^0.10.3:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
+  integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
+  dependencies:
+    inherits "2.0.3"
 
 uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-verror@1.3.6:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/verror/-/verror-1.3.6.tgz#cff5df12946d297d2baaefaa2689e25be01c005c"
-  integrity sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=
+verror@1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
+  integrity sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=
   dependencies:
-    extsprintf "1.0.2"
+    assert-plus "^1.0.0"
+    core-util-is "1.0.2"
+    extsprintf "^1.2.0"
 
 very-fast-args@^1.1.0:
   version "1.1.0"
@@ -3518,21 +3918,7 @@ webpack@^1.12.14:
     watchpack "^0.2.1"
     webpack-core "~0.6.9"
 
-which@^1.1.1:
-  version "1.2.14"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
-  integrity sha1-mofEN48D6CfOyvGs31bHNsAcFOU=
-  dependencies:
-    isexe "^2.0.0"
-
-which@^1.2.9:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
-  integrity sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==
-  dependencies:
-    isexe "^2.0.0"
-
-which@^1.3.1:
+which@^1.1.1, which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -3540,11 +3926,11 @@ which@^1.3.1:
     isexe "^2.0.0"
 
 wide-align@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710"
-  integrity sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
+  integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
   dependencies:
-    string-width "^1.0.2"
+    string-width "^1.0.2 || 2"
 
 window-size@0.1.0:
   version "0.1.0"
@@ -3595,6 +3981,11 @@ yallist@^2.0.0, yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
+
+yallist@^3.0.0, yallist@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
+  integrity sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=
 
 yargs@~3.10.0:
   version "3.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -338,6 +338,11 @@ bluebird@^2.10.2:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
   integrity sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=
 
+bluebird@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.2.tgz#1be0908e054a751754549c270489c1505d4ab15a"
+  integrity sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==
+
 bluebird@~3.5.0:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,7 @@
 "@types/body-parser@*":
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.17.0.tgz#9f5c9d9bd04bb54be32d5eb9fc0d8c974e6cf58c"
+  integrity sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==
   dependencies:
     "@types/connect" "*"
     "@types/node" "*"
@@ -12,16 +13,19 @@
 "@types/connect@*":
   version "3.4.32"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.32.tgz#aa0e9616b9435ccad02bc52b5b454ffc2c70ba28"
+  integrity sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==
   dependencies:
     "@types/node" "*"
 
 "@types/events@*":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
+  integrity sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==
 
 "@types/express-jwt@0.0.34":
   version "0.0.34"
   resolved "https://registry.yarnpkg.com/@types/express-jwt/-/express-jwt-0.0.34.tgz#fdbee4c6af5c0a246ef2a933f5519973c7717f02"
+  integrity sha1-/b7kxq9cCiRu8qkz9VGZc8dxfwI=
   dependencies:
     "@types/express" "*"
     "@types/express-unless" "*"
@@ -29,6 +33,7 @@
 "@types/express-serve-static-core@*":
   version "4.16.0"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.16.0.tgz#fdfe777594ddc1fe8eb8eccce52e261b496e43e7"
+  integrity sha512-lTeoCu5NxJU4OD9moCgm0ESZzweAx0YqsAcab6OB0EB3+As1OaHtKnaGJvcngQxYsi9UNv0abn4/DRavrRxt4w==
   dependencies:
     "@types/events" "*"
     "@types/node" "*"
@@ -37,12 +42,14 @@
 "@types/express-unless@*":
   version "0.0.32"
   resolved "https://registry.yarnpkg.com/@types/express-unless/-/express-unless-0.0.32.tgz#783f3cc1fa5e67cc2ed30000f3e1f22501f75d50"
+  integrity sha512-6YpJyFNlDDnPnRjMOvJCoDYlSDDmG/OEEUsPk7yhNkL4G9hUYtgab6vi1CcWsGSSSM0CsvNlWTG+ywAGnvF03g==
   dependencies:
     "@types/express" "*"
 
 "@types/express@*":
   version "4.16.0"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.16.0.tgz#6d8bc42ccaa6f35cf29a2b7c3333cb47b5a32a19"
+  integrity sha512-TtPEYumsmSTtTetAPXlJVf3kEqb6wZK0bZojpJQrnD/djV4q1oB6QQ8aKvKqwNPACoe02GNiy5zDzcYivR5Z2w==
   dependencies:
     "@types/body-parser" "*"
     "@types/express-serve-static-core" "*"
@@ -51,18 +58,22 @@
 "@types/mime@*":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.0.tgz#5a7306e367c539b9f6543499de8dd519fac37a8b"
+  integrity sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==
 
 "@types/node@*":
   version "10.7.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.7.1.tgz#b704d7c259aa40ee052eec678758a68d07132a2e"
+  integrity sha512-EGoI4ylB/lPOaqXqtzAyL8HcgOuCtH2hkEaLmkueOYufsTFWBn4VCvlCDC2HW8Q+9iF+QVC3sxjDKQYjHQeZ9w==
 
 "@types/range-parser@*":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.2.tgz#fa8e1ad1d474688a757140c91de6dace6f4abc8d"
+  integrity sha512-HtKGu+qG1NPvYe1z7ezLsyIaXYyi8SoAVqWDZgDQ8dLrsZvSzUNCwZyfX33uhWxL/SU0ZDQZ3nwZ0nimt507Kw==
 
 "@types/serve-static@*":
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.2.tgz#f5ac4d7a6420a99a6a45af4719f4dcd8cd907a48"
+  integrity sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==
   dependencies:
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
@@ -70,14 +81,17 @@
 abbrev@1, abbrev@1.0.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
+  integrity sha1-kbR5JYinc4wl813W9jdSovh3YTU=
 
 acorn@^3.0.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
+  integrity sha1-ReN/s56No/JbruP/U2niu18iAXo=
 
 agent-base@2, agent-base@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-2.1.1.tgz#d6de10d5af6132d5bd692427d46fc538539094c7"
+  integrity sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=
   dependencies:
     extend "~3.0.0"
     semver "~5.0.1"
@@ -85,12 +99,14 @@ agent-base@2, agent-base@^2.1.1:
 agent-base@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.1.1.tgz#92d8a4fc2524a3b09b3666a33b6c97960f23d6a4"
+  integrity sha512-yWGUUmCZD/33IRjG2It94PzixT8lX+47Uq8fjmd0cgQWITCMrJuXFaVIMnGDmDnZGGKAGdwTx8UGeU8lMR2urA==
   dependencies:
     es6-promisify "^5.0.0"
 
 ajv@^4.9.1:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
+  integrity sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=
   dependencies:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
@@ -98,6 +114,7 @@ ajv@^4.9.1:
 ajv@^5.1.0:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.3.tgz#c06f598778c44c6b161abafe3466b81ad1814ed2"
+  integrity sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=
   dependencies:
     co "^4.6.0"
     fast-deep-equal "^1.0.0"
@@ -107,6 +124,7 @@ ajv@^5.1.0:
 ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
+  integrity sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=
   dependencies:
     co "^4.6.0"
     fast-deep-equal "^1.0.0"
@@ -116,6 +134,7 @@ ajv@^5.3.0:
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
+  integrity sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=
   dependencies:
     kind-of "^3.0.2"
     longest "^1.0.1"
@@ -124,24 +143,29 @@ align-text@^0.1.1, align-text@^0.1.3:
 amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
+  integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
 
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
+  integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
 
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
 
 anymatch@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.0.tgz#a3e52fa39168c825ff57b0248126ce5a8ff95507"
+  integrity sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=
   dependencies:
     arrify "^1.0.0"
     micromatch "^2.1.5"
@@ -149,10 +173,12 @@ anymatch@^1.3.0:
 aproba@^1.0.3:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.1.2.tgz#45c6629094de4e96f693ef7eab74ae079c240fc1"
+  integrity sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==
 
 are-we-there-yet@~1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz#bb5dca382bb94f05e15194373d16fd3ba1ca110d"
+  integrity sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
@@ -160,154 +186,188 @@ are-we-there-yet@~1.1.2:
 argparse@^1.0.7:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
+  integrity sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=
   dependencies:
     sprintf-js "~1.0.2"
 
 argv@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
+  integrity sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=
 
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
+  integrity sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=
   dependencies:
     arr-flatten "^1.0.1"
 
 arr-flatten@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.0.3.tgz#a274ed85ac08849b6bd7847c4580745dc51adfb1"
+  integrity sha1-onTthawIhJtr14R8RYB0XcUa37E=
 
 array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
+  integrity sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=
 
 arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
+  integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
 asn1@~0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
+  integrity sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=
 
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
+  integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
 assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
+  integrity sha1-104bh+ev/A24qttwIfP+SBAasjQ=
 
 assert@^1.1.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
+  integrity sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=
   dependencies:
     util "0.10.3"
 
 assertion-error@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.0.tgz#c7f85438fdd466bc7ca16ab90c81513797a5d23b"
+  integrity sha1-x/hUOP3UZrx8oWq5DIFRN5el0js=
 
 ast-types@0.x.x:
   version "0.9.14"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.14.tgz#d34ba5dffb9d15a44351fd2a9d82e4ab2838b5ba"
+  integrity sha512-Ebvx7/0lLboCdyEmAw/4GqwBeKIijPveXNiVGhCGCNxc7z26T5he7DC6ARxu8ByKuzUZZcLog+VP8GMyZrBzJw==
 
 async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
+  integrity sha1-GdOGodntxufByF04iu28xW0zYC0=
 
 async@1.x, async@^1.3.0, async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
+  integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
 async@^0.9.0:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
+  integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
 
 async@~0.2.10, async@~0.2.6:
   version "0.2.10"
   resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
+  integrity sha1-trvgsGdLnXGXCMo43owjfLUmw9E=
 
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
 aws-sign2@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
+  integrity sha1-FDQt0428yU0OW4fXY81jYSwOeU8=
 
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
+  integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
 aws4@^1.2.1, aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
+  integrity sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=
 
 aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
+  integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
 babylon@7.0.0-beta.19:
   version "7.0.0-beta.19"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.19.tgz#e928c7e807e970e0536b078ab3e0c48f9e052503"
+  integrity sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==
 
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
 base64-js@^1.0.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.0.tgz#a39992d723584811982be5e290bb6a53d86700f1"
+  integrity sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
+  integrity sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=
   dependencies:
     tweetnacl "^0.14.3"
 
 big.js@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.1.3.tgz#4cada2193652eb3ca9ec8e55c9015669c9806978"
+  integrity sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg=
 
 binary-extensions@^1.0.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.8.0.tgz#48ec8d16df4377eae5fa5884682480af4d95c774"
+  integrity sha1-SOyNFt9Dd+rl+liEaCSAr02Vx3Q=
 
 block-stream@*:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
+  integrity sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=
   dependencies:
     inherits "~2.0.0"
 
 bluebird@^2.10.2:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
+  integrity sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=
 
 bluebird@~3.5.0:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
+  integrity sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==
 
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
+  integrity sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=
   dependencies:
     hoek "2.x.x"
 
 boom@4.x.x:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-4.3.1.tgz#4f8a3005cb4a7e3889f749030fd25b96e01d2e31"
+  integrity sha1-T4owBctKfjiJ90kDD9JbluAdLjE=
   dependencies:
     hoek "4.x.x"
 
 boom@5.x.x:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/boom/-/boom-5.2.0.tgz#5dd9da6ee3a5f302077436290cb717d3f4a54e02"
+  integrity sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==
   dependencies:
     hoek "4.x.x"
 
 brace-expansion@^1.1.7:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
+  integrity sha1-wHshHHyVLsH479Uad+8NHTmQopI=
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -315,6 +375,7 @@ brace-expansion@^1.1.7:
 braces@^1.8.2:
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/braces/-/braces-1.8.5.tgz#ba77962e12dff969d6b76711e914b737857bf6a7"
+  integrity sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=
   dependencies:
     expand-range "^1.8.1"
     preserve "^0.2.0"
@@ -323,22 +384,26 @@ braces@^1.8.2:
 browserify-aes@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-0.4.0.tgz#067149b668df31c4b58533e02d01e806d8608e2c"
+  integrity sha1-BnFJtmjfMcS1hTPgLQHoBthgjiw=
   dependencies:
     inherits "^2.0.1"
 
 browserify-zlib@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.1.4.tgz#bb35f8a519f600e0fa6b8485241c979d0141fb2d"
+  integrity sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=
   dependencies:
     pako "~0.2.0"
 
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
 
 buffer@^4.9.0:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
+  integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -347,14 +412,17 @@ buffer@^4.9.0:
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
+  integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
+  integrity sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
 
 camel-case@^1.1.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-1.2.2.tgz#1aca7c4d195359a2ce9955793433c6e5542511f2"
+  integrity sha1-Gsp8TRlTWaLOmVV5NDPG5VQlEfI=
   dependencies:
     sentence-case "^1.1.1"
     upper-case "^1.1.1"
@@ -362,24 +430,29 @@ camel-case@^1.1.1:
 camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
+  integrity sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=
 
 caseless@~0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.11.0.tgz#715b96ea9841593cc33067923f5ec60ebda4f7d7"
+  integrity sha1-cVuW6phBWTzDMGeSP17GDr2k99c=
 
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+  integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
 catharsis@~0.8.9:
   version "0.8.9"
   resolved "https://registry.yarnpkg.com/catharsis/-/catharsis-0.8.9.tgz#98cc890ca652dd2ef0e70b37925310ff9e90fc8b"
+  integrity sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=
   dependencies:
     underscore-contrib "~0.3.0"
 
 center-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/center-align/-/center-align-0.1.3.tgz#aa0d32629b6ee972200411cbd4461c907bc2b7ad"
+  integrity sha1-qg0yYptu6XIgBBHL1EYckHvCt60=
   dependencies:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
@@ -387,6 +460,7 @@ center-align@^0.1.1:
 "chai@>=1.9.2 <4.0.0", chai@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-2.3.0.tgz#8a2f6a34748da801090fd73287b2aa739a4e909a"
+  integrity sha1-ii9qNHSNqAEJD9cyh7Kqc5pOkJo=
   dependencies:
     assertion-error "1.0.0"
     deep-eql "0.1.3"
@@ -394,6 +468,7 @@ center-align@^0.1.1:
 chalk@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
+  integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
   dependencies:
     ansi-styles "^2.2.1"
     escape-string-regexp "^1.0.2"
@@ -404,6 +479,7 @@ chalk@^1.1.1:
 chalk@^2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
+  integrity sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==
   dependencies:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
@@ -412,6 +488,7 @@ chalk@^2.3.0:
 change-case@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/change-case/-/change-case-2.3.1.tgz#2c4fde3f063bb41d00cd68e0d5a09db61cbe894f"
+  integrity sha1-LE/ePwY7tB0AzWjg1aCdthy+iU8=
   dependencies:
     camel-case "^1.1.1"
     constant-case "^1.1.0"
@@ -433,10 +510,12 @@ change-case@^2.3.0:
 charenc@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+  integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
 
 chokidar@^1.0.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
+  integrity sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=
   dependencies:
     anymatch "^1.3.0"
     async-each "^1.0.0"
@@ -452,10 +531,12 @@ chokidar@^1.0.0:
 ci-info@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.3.tgz#710193264bb05c77b8c90d02f5aaf22216a667b2"
+  integrity sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==
 
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
+  integrity sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=
   dependencies:
     center-align "^0.1.1"
     right-align "^0.1.1"
@@ -464,18 +545,22 @@ cliui@^2.1.0:
 clone@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.2.tgz#260b7a99ebb1edfe247538175f783243cb19d149"
+  integrity sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=
 
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+  integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
 
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+  integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
 codecov@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/codecov/-/codecov-2.2.0.tgz#2d06817ceb8891eca6368836d4fb6bf6cc04ffd1"
+  integrity sha1-LQaBfOuIkeymNog21Ptr9swE/9E=
   dependencies:
     argv "0.0.2"
     request "2.79.0"
@@ -484,60 +569,72 @@ codecov@^2.2.0:
 color-convert@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
+  integrity sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==
   dependencies:
     color-name "^1.1.1"
 
 color-name@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
 combined-stream@1.0.6, combined-stream@~1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
+  integrity sha1-cj599ugBrFYTETp+RFqbactjKBg=
   dependencies:
     delayed-stream "~1.0.0"
 
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
+  integrity sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=
   dependencies:
     delayed-stream "~1.0.0"
 
 commander@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-0.6.1.tgz#fa68a14f6a945d54dbbe50d8cdb3320e9e3b1a06"
+  integrity sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=
 
 commander@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.3.0.tgz#fd430e889832ec353b9acd1de217c11cb3eef873"
+  integrity sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=
 
 commander@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
+  integrity sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
   dependencies:
     graceful-readlink ">= 1.0.0"
 
 component-emitter@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
+  integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
 
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
 console-browserify@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.1.0.tgz#f0241c45730a9fc6323b206dbf38edc741d0bb10"
+  integrity sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=
   dependencies:
     date-now "^0.1.4"
 
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
+  integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
 constant-case@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/constant-case/-/constant-case-1.1.2.tgz#8ec2ca5ba343e00aa38dbf4e200fd5ac907efd63"
+  integrity sha1-jsLKW6ND4Aqjjb9OIA/VrJB+/WM=
   dependencies:
     snake-case "^1.1.0"
     upper-case "^1.1.1"
@@ -545,18 +642,22 @@ constant-case@^1.1.0:
 constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
+  integrity sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
 
 cookiejar@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.1.tgz#41ad57b1b555951ec171412a81942b1e8200d34a"
+  integrity sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=
 
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+  integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
   dependencies:
     lru-cache "^4.0.1"
     shebang-command "^1.2.0"
@@ -565,22 +666,26 @@ cross-spawn@^5.0.1:
 crypt@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
+  integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
 cryptiles@2.x.x:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
+  integrity sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=
   dependencies:
     boom "2.x.x"
 
 cryptiles@3.x.x:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.2.tgz#a89fbb220f5ce25ec56e8c4aa8a4fd7b5b0d29fe"
+  integrity sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=
   dependencies:
     boom "5.x.x"
 
 crypto-browserify@3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.3.0.tgz#b9fc75bb4a0ed61dcf1cd5dae96eb30c9c3e506c"
+  integrity sha1-ufx1u0oO1h3PHNXa6W6zDJw+UGw=
   dependencies:
     browserify-aes "0.4.0"
     pbkdf2-compat "2.0.1"
@@ -590,6 +695,7 @@ crypto-browserify@3.3.0:
 css-loader@^0.9.1:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-0.9.1.tgz#2e1aa00ce7e30ef2c6a7a4b300a080a7c979e0dc"
+  integrity sha1-LhqgDOfjDvLGp6SzAKCAp8l54Nw=
   dependencies:
     csso "1.3.x"
     loader-utils "~0.2.2"
@@ -598,79 +704,87 @@ css-loader@^0.9.1:
 csso@1.3.x:
   version "1.3.12"
   resolved "https://registry.yarnpkg.com/csso/-/csso-1.3.12.tgz#fc628694a2d38938aaac4996753218fd311cdb9e"
+  integrity sha1-/GKGlKLTiTiqrEmWdTIY/TEc254=
 
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
+  integrity sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=
   dependencies:
     assert-plus "^1.0.0"
 
 data-uri-to-buffer@1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz#77163ea9c20d8641b4707e8f18abdf9a78f34835"
+  integrity sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ==
 
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
+  integrity sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=
 
 debug@2, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
 
 debug@2.2.0, debug@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
+  integrity sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=
   dependencies:
     ms "0.7.1"
 
 debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   dependencies:
     ms "2.0.0"
 
 debug@~0.7.4:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-0.7.4.tgz#06e1ea8082c2cb14e39806e22e2f6f757f92af39"
+  integrity sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=
 
 decamelize@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+  integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
 deep-eql@0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-0.1.3.tgz#ef558acab8de25206cd713906d74e56930eb69f2"
+  integrity sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=
   dependencies:
     type-detect "0.1.1"
 
 deep-equal@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
+  integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
 
 deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
+  integrity sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=
 
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+  integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
 deepmerge@^1.5.1:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"
-
-define-properties@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
-  dependencies:
-    foreach "^2.0.5"
-    object-keys "^1.0.8"
+  integrity sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ==
 
 degenerator@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/degenerator/-/degenerator-1.0.4.tgz#fcf490a37ece266464d9cc431ab98c5819ced095"
+  integrity sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=
   dependencies:
     ast-types "0.x.x"
     escodegen "1.x.x"
@@ -679,48 +793,58 @@ degenerator@^1.0.4:
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
+  integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
 depd@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
+  integrity sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=
 
 diff@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
+  integrity sha1-fyjS657nsVqX79ic5j3P2qPMur8=
 
 domain-browser@^1.1.1:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
+  integrity sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=
 
 dot-case@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/dot-case/-/dot-case-1.1.2.tgz#1e73826900de28d6de5480bc1de31d0842b06bec"
+  integrity sha1-HnOCaQDeKNbeVIC8HeMdCEKwa+w=
   dependencies:
     sentence-case "^1.1.2"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
+  integrity sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=
   dependencies:
     jsbn "~0.1.0"
 
 ecdsa-sig-formatter@1.0.10:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz#1c595000f04a8897dfb85000892a0f4c33af86c3"
+  integrity sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=
   dependencies:
     safe-buffer "^5.0.1"
 
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
+  integrity sha1-TapNnbAPmBmIDHn6RXrlsJof04k=
 
 enhanced-resolve@~0.9.0:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz#4d6e689b3725f86090927ccc86cd9f1635b89e2e"
+  integrity sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=
   dependencies:
     graceful-fs "^4.1.2"
     memory-fs "^0.2.0"
@@ -729,34 +853,41 @@ enhanced-resolve@~0.9.0:
 errno@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
+  integrity sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=
   dependencies:
     prr "~0.0.0"
 
 es6-promise@^4.0.3:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.1.1.tgz#8811e90915d9a0dba36274f0b242dbda78f9c92a"
+  integrity sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==
 
 es6-promisify@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
   dependencies:
     es6-promise "^4.0.3"
 
 es6-promisify@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-6.0.0.tgz#b526a75eaa5ca600e960bf3d5ad98c40d75c7203"
+  integrity sha512-8Tbqjrb8lC85dd81haajYwuRmiU2rkqNAFnlvQOJeeKqdUloIlI+JcUqeJruV4rCm5Y7oNU7jfs2FbmxhRR/2g==
 
 escape-string-regexp@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz#4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1"
+  integrity sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5, escape-string-regexp@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
 escodegen@1.8.x:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.8.1.tgz#5a5b53af4693110bebb0867aa3430dd3b70a1018"
+  integrity sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=
   dependencies:
     esprima "^2.7.1"
     estraverse "^1.9.1"
@@ -768,6 +899,7 @@ escodegen@1.8.x:
 escodegen@1.x.x:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.9.0.tgz#9811a2f265dc1cd3894420ee3717064b632b8852"
+  integrity sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==
   dependencies:
     esprima "^3.1.3"
     estraverse "^4.2.0"
@@ -779,30 +911,37 @@ escodegen@1.x.x:
 esprima@2.7.x, esprima@^2.6.0, esprima@^2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
+  integrity sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=
 
 esprima@3.x.x, esprima@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
+  integrity sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
 
 estraverse@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
+  integrity sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=
 
 estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
+  integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
 
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+  integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
 
 events@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
 
 execa@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
+  integrity sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=
   dependencies:
     cross-spawn "^5.0.1"
     get-stream "^3.0.0"
@@ -815,62 +954,75 @@ execa@^0.8.0:
 expand-brackets@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
+  integrity sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=
   dependencies:
     is-posix-bracket "^0.1.0"
 
 expand-range@^1.8.1:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337"
+  integrity sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=
   dependencies:
     fill-range "^2.1.0"
 
 extend@3, extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
+  integrity sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=
 
 extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
+  integrity sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=
   dependencies:
     is-extglob "^1.0.0"
 
 extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
+  integrity sha1-4QgOBljjALBilJkMxw4VAiNf1VA=
 
 fast-deep-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
+  integrity sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
+  integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+  integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
 file-loader@^0.8.1:
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-0.8.5.tgz#9275d031fe780f27d47f5f4af02bd43713cc151b"
+  integrity sha1-knXQMf54DyfUf19K8CvUNxPMFRs=
   dependencies:
     loader-utils "~0.2.5"
 
 file-uri-to-path@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
+  integrity sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=
 
 fill-keys@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/fill-keys/-/fill-keys-1.0.2.tgz#9a8fa36f4e8ad634e3bf6b4f3c8882551452eb20"
+  integrity sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=
   dependencies:
     is-object "~1.0.1"
     merge-descriptors "~1.0.0"
@@ -878,6 +1030,7 @@ fill-keys@^1.0.2:
 fill-range@^2.1.0:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.3.tgz#50b77dfd7e469bc7492470963699fe7a8485a723"
+  integrity sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=
   dependencies:
     is-number "^2.1.0"
     isobject "^2.0.0"
@@ -888,30 +1041,31 @@ fill-range@^2.1.0:
 find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
+  integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
   dependencies:
     locate-path "^2.0.0"
 
 for-in@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
+  integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
 
 for-own@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
+  integrity sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=
   dependencies:
     for-in "^1.0.1"
-
-foreach@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
 
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
+  integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
 form-data@^2.3.1, form-data@~2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.1.tgz#6fb94fbd71885306d73d15cc497fe4cc4ecd44bf"
+  integrity sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
@@ -920,6 +1074,7 @@ form-data@^2.3.1, form-data@~2.3.1:
 form-data@~2.1.1:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
+  integrity sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
@@ -928,6 +1083,7 @@ form-data@~2.1.1:
 form-data@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
+  integrity sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=
   dependencies:
     asynckit "^0.4.0"
     combined-stream "1.0.6"
@@ -936,20 +1092,24 @@ form-data@~2.3.2:
 formatio@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
+  integrity sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=
   dependencies:
     samsam "~1.1"
 
 formidable@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.1.1.tgz#96b8886f7c3c3508b932d6bd70c4d3a88f35f1a9"
+  integrity sha1-lriIb3w8NQi5Mta9cMTTqI818ak=
 
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
 fsevents@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.2.tgz#3282b713fb3ad80ede0e9fcf4611b5aa6fc033f4"
+  integrity sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==
   dependencies:
     nan "^2.3.0"
     node-pre-gyp "^0.6.36"
@@ -957,6 +1117,7 @@ fsevents@^1.0.0:
 fstream-ignore@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/fstream-ignore/-/fstream-ignore-1.0.5.tgz#9c31dae34767018fe1d249b24dada67d092da105"
+  integrity sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=
   dependencies:
     fstream "^1.0.0"
     inherits "2"
@@ -965,6 +1126,7 @@ fstream-ignore@^1.0.5:
 fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
+  integrity sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=
   dependencies:
     graceful-fs "^4.1.2"
     inherits "~2.0.0"
@@ -974,17 +1136,15 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
 ftp@~0.3.10:
   version "0.3.10"
   resolved "https://registry.yarnpkg.com/ftp/-/ftp-0.3.10.tgz#9197d861ad8142f3e63d5a83bfe4c59f7330885d"
+  integrity sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=
   dependencies:
     readable-stream "1.1.x"
     xregexp "2.0.0"
 
-function-bind@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
-
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
+  integrity sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=
   dependencies:
     aproba "^1.0.3"
     console-control-strings "^1.0.0"
@@ -998,20 +1158,24 @@ gauge@~2.7.3:
 generate-function@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.0.0.tgz#6858fe7c0969b7d4e9093337647ac79f60dfbe74"
+  integrity sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=
 
 generate-object-property@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
+  integrity sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=
   dependencies:
     is-property "^1.0.0"
 
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+  integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
 
 get-uri@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/get-uri/-/get-uri-2.0.1.tgz#dbdcacacd8c608a38316869368117697a1631c59"
+  integrity sha512-7aelVrYqCLuVjq2kEKRTH8fXPTC0xKTkM+G7UlFkEwCXY3sFbSxvY375JoFowOAYbkaU47SrBvOefUlLZZ+6QA==
   dependencies:
     data-uri-to-buffer "1"
     debug "2"
@@ -1023,12 +1187,14 @@ get-uri@^2.0.0:
 getpass@^0.1.1:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
+  integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
   dependencies:
     assert-plus "^1.0.0"
 
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
+  integrity sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=
   dependencies:
     glob-parent "^2.0.0"
     is-glob "^2.0.0"
@@ -1036,12 +1202,14 @@ glob-base@^0.3.0:
 glob-parent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-2.0.0.tgz#81383d72db054fcccf5336daa902f182f6edbb28"
+  integrity sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=
   dependencies:
     is-glob "^2.0.0"
 
 glob@3.2.11:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/glob/-/glob-3.2.11.tgz#4a973f635b9190f715d10987d5c00fd2815ebe3d"
+  integrity sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=
   dependencies:
     inherits "2"
     minimatch "0.3"
@@ -1049,6 +1217,7 @@ glob@3.2.11:
 glob@^5.0.15:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
+  integrity sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=
   dependencies:
     inflight "^1.0.4"
     inherits "2"
@@ -1059,6 +1228,7 @@ glob@^5.0.15:
 glob@^7.0.5:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+  integrity sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -1070,18 +1240,22 @@ glob@^7.0.5:
 graceful-fs@^4.1.2, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+  integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
 
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+  integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
 
 growl@1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
+  integrity sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=
 
 handlebars@^4.0.1:
   version "4.0.10"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.10.tgz#3d30c718b09a3d96f23ea4cc1f403c4d3ba9ff4f"
+  integrity sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=
   dependencies:
     async "^1.4.0"
     optimist "^0.6.1"
@@ -1092,14 +1266,17 @@ handlebars@^4.0.1:
 har-schema@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
+  integrity sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=
 
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
+  integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
 
 har-validator@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-2.0.6.tgz#cdcbc08188265ad119b6a5a7c8ab70eecfb5d27d"
+  integrity sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=
   dependencies:
     chalk "^1.1.1"
     commander "^2.9.0"
@@ -1109,6 +1286,7 @@ har-validator@~2.0.6:
 har-validator@~4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
+  integrity sha1-M0gdDxu/9gDdID11gSpqX7oALio=
   dependencies:
     ajv "^4.9.1"
     har-schema "^1.0.5"
@@ -1116,6 +1294,7 @@ har-validator@~4.2.1:
 har-validator@~5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd"
+  integrity sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=
   dependencies:
     ajv "^5.1.0"
     har-schema "^2.0.0"
@@ -1123,6 +1302,7 @@ har-validator@~5.0.3:
 har-validator@~5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.0.tgz#44657f5688a22cfd4b72486e81b3a3fb11742c29"
+  integrity sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==
   dependencies:
     ajv "^5.3.0"
     har-schema "^2.0.0"
@@ -1130,24 +1310,29 @@ har-validator@~5.1.0:
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
+  integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
   dependencies:
     ansi-regex "^2.0.0"
 
 has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
+  integrity sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=
 
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
+  integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
 
 hawk@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
+  integrity sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=
   dependencies:
     boom "2.x.x"
     cryptiles "2.x.x"
@@ -1157,6 +1342,7 @@ hawk@~3.1.3:
 hawk@~6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
+  integrity sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==
   dependencies:
     boom "4.x.x"
     cryptiles "3.x.x"
@@ -1166,14 +1352,17 @@ hawk@~6.0.2:
 hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
+  integrity sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=
 
 hoek@4.x.x:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
+  integrity sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==
 
 http-errors@1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736"
+  integrity sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=
   dependencies:
     depd "1.1.1"
     inherits "2.0.3"
@@ -1183,6 +1372,7 @@ http-errors@1.6.2:
 http-proxy-agent@1, http-proxy-agent@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-1.0.0.tgz#cc1ce38e453bf984a0f7702d2dd59c73d081284a"
+  integrity sha1-zBzjjkU7+YSg93AtLdWcc9CBKEo=
   dependencies:
     agent-base "2"
     debug "2"
@@ -1191,6 +1381,7 @@ http-proxy-agent@1, http-proxy-agent@^1.0.0:
 http-signature@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
+  integrity sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=
   dependencies:
     assert-plus "^0.2.0"
     jsprim "^1.2.2"
@@ -1199,6 +1390,7 @@ http-signature@~1.1.0:
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
+  integrity sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=
   dependencies:
     assert-plus "^1.0.0"
     jsprim "^1.2.2"
@@ -1207,10 +1399,12 @@ http-signature@~1.2.0:
 https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
+  integrity sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=
 
 https-proxy-agent@1, https-proxy-agent@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz#35f7da6c48ce4ddbfa264891ac593ee5ff8671e6"
+  integrity sha1-NffabEjOTdv6JkiRrFk+5f+GceY=
   dependencies:
     agent-base "2"
     debug "2"
@@ -1219,6 +1413,7 @@ https-proxy-agent@1, https-proxy-agent@^1.0.0:
 husky@^0.14.3:
   version "0.14.3"
   resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
+  integrity sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==
   dependencies:
     is-ci "^1.0.10"
     normalize-path "^1.0.0"
@@ -1227,22 +1422,27 @@ husky@^0.14.3:
 iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+  integrity sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==
 
 ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
+  integrity sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=
 
 ignore@^3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
+  integrity sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==
 
 indexof@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
+  integrity sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=
 
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
   dependencies:
     once "^1.3.0"
     wrappy "1"
@@ -1250,78 +1450,94 @@ inflight@^1.0.4:
 inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+  integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
 inherits@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
+  integrity sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=
 
 ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
+  integrity sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=
 
 interpret@^0.6.4:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-0.6.6.tgz#fecd7a18e7ce5ca6abfb953e1f86213a49f1625b"
+  integrity sha1-/s16GOfOXKar+5U+H4YhOknxYls=
 
 ip@^1.1.4, ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
+  integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
 
 is-binary-path@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898"
+  integrity sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=
   dependencies:
     binary-extensions "^1.0.0"
 
 is-buffer@^1.1.5, is-buffer@~1.1.1:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.5.tgz#1f3b26ef613b214b88cbca23cc6c01d87961eecc"
+  integrity sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=
 
 is-ci@^1.0.10:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.1.0.tgz#247e4162e7860cebbdaf30b774d6b0ac7dcfe7a5"
+  integrity sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==
   dependencies:
     ci-info "^1.0.0"
 
 is-dotfile@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
+  integrity sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=
 
 is-equal-shallow@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz#2238098fc221de0bcfa5d9eac4c45d638aa1c534"
+  integrity sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=
   dependencies:
     is-primitive "^2.0.0"
 
 is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
+  integrity sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=
 
 is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
+  integrity sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=
 
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
+  integrity sha1-754xOG8DGn8NZDr4L95QxFfvAMs=
   dependencies:
     number-is-nan "^1.0.0"
 
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
+  integrity sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=
   dependencies:
     is-extglob "^1.0.0"
 
 is-lower-case@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-lower-case/-/is-lower-case-1.1.3.tgz#7e147be4768dc466db3bfb21cc60b31e6ad69393"
+  integrity sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=
   dependencies:
     lower-case "^1.1.0"
 
 is-my-json-valid@^2.12.4:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz#f079dd9bfdae65ee2038aae8acbc86ab109e3693"
+  integrity sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=
   dependencies:
     generate-function "^2.0.0"
     generate-object-property "^1.1.0"
@@ -1331,74 +1547,90 @@ is-my-json-valid@^2.12.4:
 is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
+  integrity sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=
   dependencies:
     kind-of "^3.0.2"
 
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
+  integrity sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=
   dependencies:
     kind-of "^3.0.2"
 
 is-object@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
+  integrity sha1-iVJojF7C/9awPsyF52ngKQMINHA=
 
 is-posix-bracket@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
+  integrity sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=
 
 is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
+  integrity sha1-IHurkWOEmcB7Kt8kCkGochADRXU=
 
 is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
+  integrity sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=
 
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+  integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
 
 is-string@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.4.tgz#cc3a9b69857d621e963725a24caeec873b826e64"
+  integrity sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=
 
 is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+  integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
 is-upper-case@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/is-upper-case/-/is-upper-case-1.1.2.tgz#8d0b1fa7e7933a1e58483600ec7d9661cbaf756f"
+  integrity sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=
   dependencies:
     upper-case "^1.1.0"
 
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
 isobject@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
+  integrity sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=
   dependencies:
     isarray "1.0.0"
 
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+  integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
 istanbul@^0.4.0:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/istanbul/-/istanbul-0.4.5.tgz#65c7d73d4c4da84d4f3ac310b918fb0b8033733b"
+  integrity sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=
   dependencies:
     abbrev "1.0.x"
     async "1.x"
@@ -1418,6 +1650,7 @@ istanbul@^0.4.0:
 jade@0.26.3:
   version "0.26.3"
   resolved "https://registry.yarnpkg.com/jade/-/jade-0.26.3.tgz#8f10d7977d8d79f2f6ff862a81b0513ccb25686c"
+  integrity sha1-jxDXl32NefL2/4YqgbBRPMslaGw=
   dependencies:
     commander "0.6.1"
     mkdirp "0.3.0"
@@ -1425,6 +1658,7 @@ jade@0.26.3:
 js-yaml@3.x:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
+  integrity sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=
   dependencies:
     argparse "^1.0.7"
     esprima "^2.6.0"
@@ -1432,16 +1666,19 @@ js-yaml@3.x:
 js2xmlparser@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/js2xmlparser/-/js2xmlparser-3.0.0.tgz#3fb60eaa089c5440f9319f51760ccd07e2499733"
+  integrity sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=
   dependencies:
     xmlcreate "^1.0.1"
 
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+  integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
 jsdoc@^3.5.5:
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/jsdoc/-/jsdoc-3.5.5.tgz#484521b126e81904d632ff83ec9aaa096708fa4d"
+  integrity sha512-6PxB65TAU4WO0Wzyr/4/YhlGovXl0EVYfpKbpSroSj0qBxT4/xod/l40Opkm38dRHRdQgdeY836M0uVnJQG7kg==
   dependencies:
     babylon "7.0.0-beta.19"
     bluebird "~3.5.0"
@@ -1459,40 +1696,49 @@ jsdoc@^3.5.5:
 json-loader@^0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.4.tgz#8baa1365a632f58a3c46d20175fc6002c96e37de"
+  integrity sha1-i6oTZaYy9Yo8RtIBdfxgAsluN94=
 
 json-schema-traverse@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
+  integrity sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=
 
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
+  integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
 
 json-stable-stringify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
+  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
   dependencies:
     jsonify "~0.0.0"
 
 json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+  integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
 json5@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+  integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
 
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
+  integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
 jsonpointer@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
+  integrity sha1-T9kss04OnbPInIYi7PUfm5eMbLk=
 
 jsonwebtoken@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.3.0.tgz#056c90eee9a65ed6e6c72ddb0a1d325109aaf643"
+  integrity sha512-oge/hvlmeJCH+iIz1DwcO7vKPkNGJHhgkspk8OH3VKlw+mbi42WtD4ig1+VXRln765vxptAv+xT26Fd3cteqag==
   dependencies:
     jws "^3.1.5"
     lodash.includes "^4.3.0"
@@ -1507,6 +1753,7 @@ jsonwebtoken@^8.3.0:
 jsprim@^1.2.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.0.tgz#a3b87e40298d8c380552d8cc7628a0bb95a22918"
+  integrity sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=
   dependencies:
     assert-plus "1.0.0"
     extsprintf "1.0.2"
@@ -1516,6 +1763,7 @@ jsprim@^1.2.2:
 jwa@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.1.6.tgz#87240e76c9808dbde18783cf2264ef4929ee50e6"
+  integrity sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==
   dependencies:
     buffer-equal-constant-time "1.0.1"
     ecdsa-sig-formatter "1.0.10"
@@ -1524,6 +1772,7 @@ jwa@^1.1.5:
 jwks-rsa@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jwks-rsa/-/jwks-rsa-1.3.0.tgz#f37d2a6815af17a3b2e5898ab2a41ad8c168b295"
+  integrity sha512-9q+d5VffK/FvFAjuXoddrq7zQybFSINV4mcwJJExGKXGyjWWpTt3vsn/aX33aB0heY02LK0qSyicdtRK0gVTig==
   dependencies:
     "@types/express-jwt" "0.0.34"
     debug "^2.2.0"
@@ -1535,6 +1784,7 @@ jwks-rsa@^1.3.0:
 jws@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/jws/-/jws-3.1.5.tgz#80d12d05b293d1e841e7cb8b4e69e561adcf834f"
+  integrity sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==
   dependencies:
     jwa "^1.1.5"
     safe-buffer "^5.0.1"
@@ -1542,28 +1792,33 @@ jws@^3.1.5:
 kind-of@^3.0.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
+  integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
   dependencies:
     is-buffer "^1.1.5"
 
 kind-of@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
+  integrity sha1-IIE989cSkosgc3hpGkUGb65y3Vc=
   dependencies:
     is-buffer "^1.1.5"
 
 klaw@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-2.0.0.tgz#59c128e0dc5ce410201151194eeb9cbf858650f6"
+  integrity sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=
   dependencies:
     graceful-fs "^4.1.9"
 
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
+  integrity sha1-odePw6UEdMuAhF07O24dpJpEbo4=
 
 levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+  integrity sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
@@ -1571,10 +1826,12 @@ levn@~0.3.0:
 limiter@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/limiter/-/limiter-1.1.3.tgz#32e2eb55b2324076943e5d04c1185ffb387968ef"
+  integrity sha512-zrycnIMsLw/3ZxTbW7HCez56rcFGecWTx5OZNplzcXUUmJLmoYArC6qdJzmAN5BWiNXGcpjhF9RQ1HSv5zebEw==
 
 loader-utils@^0.2.11, loader-utils@^0.2.5, loader-utils@~0.2.2, loader-utils@~0.2.3, loader-utils@~0.2.5:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
+  integrity sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=
   dependencies:
     big.js "^3.1.3"
     emojis-list "^2.0.0"
@@ -1584,6 +1841,7 @@ loader-utils@^0.2.11, loader-utils@^0.2.5, loader-utils@~0.2.2, loader-utils@~0.
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
+  integrity sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=
   dependencies:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
@@ -1591,72 +1849,89 @@ locate-path@^2.0.0:
 lock@~0.1.2:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/lock/-/lock-0.1.4.tgz#fec7deaef17e7c3a0a55e1da042803e25d91745d"
+  integrity sha1-/sfervF+fDoKVeHaBCgD4l2RdF0=
 
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
 
 lodash.isboolean@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
 
 lodash.isinteger@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=
 
 lodash.isnumber@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
 
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
 
 lodash.isstring@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
 
 lodash.once@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
 lodash@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.1.tgz#5b7723034dda4d262e5a46fb2c58d7cc22f71420"
+  integrity sha1-W3cjA03aTSYuWkb7LFjXzCL3FCA=
 
 lodash@^4.17.4:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+  integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
 
 lodash@~4.5.1:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.5.1.tgz#80e8a074ca5f3893a6b1c10b2a636492d710c316"
+  integrity sha1-gOigdMpfOJOmscELKmNkktcQwxY=
 
 lolex@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
+  integrity sha1-fD2mL/yzDw9agKJWbKJORdigHzE=
 
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
+  integrity sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=
 
 lower-case-first@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/lower-case-first/-/lower-case-first-1.0.2.tgz#e5da7c26f29a7073be02d52bac9980e5922adfa1"
+  integrity sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=
   dependencies:
     lower-case "^1.1.2"
 
 lower-case@^1.1.0, lower-case@^1.1.1, lower-case@^1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
+  integrity sha1-miyr0bno4K6ZOkv31YdcOcQujqw=
 
 lru-cache@2:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
+  integrity sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=
 
 lru-cache@^4.0.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.2.tgz#45234b2e6e2f2b33da125624c4664929a0224c3f"
+  integrity sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
@@ -1664,10 +1939,12 @@ lru-cache@^4.0.1:
 lru-cache@~2.6.5:
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.6.5.tgz#e56d6354148ede8d7707b58d143220fd08df0fd5"
+  integrity sha1-5W1jVBSO3o13B7WNFDIg/QjfD9U=
 
 lru-cache@~4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.0.2.tgz#1d17679c069cda5d040991a09dbc2c0db377e55e"
+  integrity sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=
   dependencies:
     pseudomap "^1.0.1"
     yallist "^2.0.0"
@@ -1675,6 +1952,7 @@ lru-cache@~4.0.0:
 lru-memoizer@^1.11.1:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/lru-memoizer/-/lru-memoizer-1.11.1.tgz#0693f6100593914c02e192bf9b8d93884cbf50d3"
+  integrity sha1-BpP2EAWTkUwC4ZK/m42TiEy/UNM=
   dependencies:
     lock "~0.1.2"
     lodash "~4.5.1"
@@ -1684,6 +1962,7 @@ lru-memoizer@^1.11.1:
 lru-memoizer@^1.6.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/lru-memoizer/-/lru-memoizer-1.12.0.tgz#efe65706cc8a9cc653f80f0d5a6ea38ad950e352"
+  integrity sha1-7+ZXBsyKnMZT+A8NWm6jitlQ41I=
   dependencies:
     lock "~0.1.2"
     lodash "^4.17.4"
@@ -1693,10 +1972,12 @@ lru-memoizer@^1.6.0:
 marked@~0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
+  integrity sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=
 
 md5@^2.1.0, md5@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
+  integrity sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=
   dependencies:
     charenc "~0.0.1"
     crypt "~0.0.1"
@@ -1705,10 +1986,12 @@ md5@^2.1.0, md5@^2.2.1:
 memory-fs@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.2.0.tgz#f2bb25368bc121e391c2520de92969caee0a0290"
+  integrity sha1-8rslNovBIeORwlIN6Slpyu4KApA=
 
 memory-fs@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.3.0.tgz#7bcc6b629e3a43e871d7e29aca6ae8a7f15cbb20"
+  integrity sha1-e8xrYp46Q+hx1+Kaymrop/FcuyA=
   dependencies:
     errno "^0.1.3"
     readable-stream "^2.0.1"
@@ -1716,14 +1999,17 @@ memory-fs@~0.3.0:
 merge-descriptors@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
+  integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
 
 methods@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
+  integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
 micromatch@^2.1.5:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
+  integrity sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=
   dependencies:
     arr-diff "^2.0.0"
     array-unique "^0.2.1"
@@ -1742,44 +2028,53 @@ micromatch@^2.1.5:
 mime-db@~1.27.0:
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.27.0.tgz#820f572296bbd20ec25ed55e5b5de869e5436eb1"
+  integrity sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=
 
 mime-db@~1.30.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
+  integrity sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=
 
 mime-db@~1.35.0:
   version "1.35.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.35.0.tgz#0569d657466491283709663ad379a99b90d9ab47"
+  integrity sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==
 
 mime-types@^2.1.12, mime-types@~2.1.7:
   version "2.1.15"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.15.tgz#a4ebf5064094569237b8cf70046776d09fc92aed"
+  integrity sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=
   dependencies:
     mime-db "~1.27.0"
 
 mime-types@~2.1.17:
   version "2.1.17"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
+  integrity sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=
   dependencies:
     mime-db "~1.30.0"
 
 mime-types@~2.1.19:
   version "2.1.19"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.19.tgz#71e464537a7ef81c15f2db9d97e913fc0ff606f0"
+  integrity sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==
   dependencies:
     mime-db "~1.35.0"
 
 mime@^1.4.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
 minami@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/minami/-/minami-1.2.3.tgz#99b6dcdfb2f0a54da1c9c8f7aa3a327787aaf9f8"
+  integrity sha1-mbbc37LwpU2hycj3qjoyd4eq+fg=
 
 minimatch@0.3:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-0.3.0.tgz#275d8edaac4f1bb3326472089e7949c8394699dd"
+  integrity sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=
   dependencies:
     lru-cache "2"
     sigmund "~1.0.0"
@@ -1787,30 +2082,36 @@ minimatch@0.3:
 "minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
 
 minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
 minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
 mkdirp@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.0.tgz#1bbf5ab1ba827af23575143490426455f481fe1e"
+  integrity sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=
 
 mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
 
 mocha-junit-reporter@^1.13.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/mocha-junit-reporter/-/mocha-junit-reporter-1.13.0.tgz#030db8c530b244667253b03861d4cd336f7e56c8"
+  integrity sha1-Aw24xTCyRGZyU7A4YdTNM29+Vsg=
   dependencies:
     debug "^2.2.0"
     md5 "^2.1.0"
@@ -1820,6 +2121,7 @@ mocha-junit-reporter@^1.13.0:
 mocha-multi@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/mocha-multi/-/mocha-multi-0.11.0.tgz#5cd48e04dbe7657d7e997880c4ccd021aaf51aa5"
+  integrity sha1-XNSOBNvnZX1+mXiAxMzQIar1GqU=
   dependencies:
     debug "~0.7.4"
     is-string "^1.0.4"
@@ -1829,6 +2131,7 @@ mocha-multi@^0.11.0:
 mocha@^2.2.4:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-2.5.3.tgz#161be5bdeb496771eb9b35745050b622b5aefc58"
+  integrity sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=
   dependencies:
     commander "2.3.0"
     debug "2.2.0"
@@ -1844,38 +2147,47 @@ mocha@^2.2.4:
 module-not-found-error@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"
+  integrity sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=
 
 moment@^2.18.1:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
+  integrity sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=
 
 mri@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.0.tgz#5c0a3f29c8ccffbbb1ec941dcec09d71fa32f36a"
+  integrity sha1-XAo/KcjM/7ux7JQdzsCdcfoy82o=
 
 ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
+  integrity sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=
 
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
 ms@^2.0.0, ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
 nan@^2.3.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
+  integrity sha1-5P805slf37WuzAjeZZb0NgWn20U=
 
 netmask@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/netmask/-/netmask-1.0.6.tgz#20297e89d86f6f6400f250d9f4f6b4c1945fcd35"
+  integrity sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=
 
 nock@^3.1.1:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/nock/-/nock-3.6.0.tgz#d26c40004b3449a655b91b74ae3c56fc02c84525"
+  integrity sha1-0mxAAEs0SaZVuRt0rjxW/ALIRSU=
   dependencies:
     chai ">=1.9.2 <4.0.0"
     debug "^2.2.0"
@@ -1888,6 +2200,7 @@ nock@^3.1.1:
 node-libs-browser@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-0.7.0.tgz#3e272c0819e308935e26674408d7af0e1491b83b"
+  integrity sha1-PicsCBnjCJNeJmdECNevDhSRuDs=
   dependencies:
     assert "^1.1.1"
     browserify-zlib "^0.1.4"
@@ -1916,6 +2229,7 @@ node-libs-browser@^0.7.0:
 node-pre-gyp@^0.6.36:
   version "0.6.36"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz#db604112cb74e0d477554e9b505b17abddfab786"
+  integrity sha1-22BBEst04NR3VU6bUFsXq936t4Y=
   dependencies:
     mkdirp "^0.5.1"
     nopt "^4.0.1"
@@ -1930,12 +2244,14 @@ node-pre-gyp@^0.6.36:
 nopt@3.x:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
+  integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
   dependencies:
     abbrev "1"
 
 nopt@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
+  integrity sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=
   dependencies:
     abbrev "1"
     osenv "^0.1.4"
@@ -1943,22 +2259,26 @@ nopt@^4.0.1:
 normalize-path@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
+  integrity sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=
 
 normalize-path@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
+  integrity sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=
   dependencies:
     remove-trailing-separator "^1.0.1"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
   dependencies:
     path-key "^2.0.0"
 
 npmlog@^4.0.2:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.0.tgz#dc59bee85f64f00ed424efb2af0783df25d1c0b5"
+  integrity sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==
   dependencies:
     are-we-there-yet "~1.1.2"
     console-control-strings "~1.1.0"
@@ -1968,34 +2288,27 @@ npmlog@^4.0.2:
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
+  integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
 oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
+  integrity sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=
 
 oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
+  integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
 object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-
-object-keys@^1.0.10, object-keys@^1.0.8:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
-
-object.assign@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.0.4.tgz#b1c9cc044ef1b9fe63606fc141abbb32e14730cc"
-  dependencies:
-    define-properties "^1.1.2"
-    function-bind "^1.1.0"
-    object-keys "^1.0.10"
+  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 object.omit@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
+  integrity sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=
   dependencies:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
@@ -2003,12 +2316,14 @@ object.omit@^2.0.0:
 once@1.x, once@^1.3.0, once@^1.3.3:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
 
 optimist@^0.6.1, optimist@~0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
+  integrity sha1-2j6nRob6IaGaERwybpDrFaAZZoY=
   dependencies:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
@@ -2016,6 +2331,7 @@ optimist@^0.6.1, optimist@~0.6.0:
 optionator@^0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
+  integrity sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=
   dependencies:
     deep-is "~0.1.3"
     fast-levenshtein "~2.0.4"
@@ -2027,18 +2343,22 @@ optionator@^0.8.1:
 os-browserify@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.2.1.tgz#63fc4ccee5d2d7763d26bbf8601078e6c2e0044f"
+  integrity sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8=
 
 os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
+  integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
 
 os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+  integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
 osenv@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.4.tgz#42fe6d5953df06c8064be6f176c3d05aaaa34644"
+  integrity sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
@@ -2046,26 +2366,31 @@ osenv@^0.1.4:
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+  integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
 
 p-limit@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.2.0.tgz#0e92b6bedcb59f022c13d0f1949dc82d15909f1c"
+  integrity sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==
   dependencies:
     p-try "^1.0.0"
 
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  integrity sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
   dependencies:
     p-limit "^1.1.0"
 
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+  integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
 
 pac-proxy-agent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/pac-proxy-agent/-/pac-proxy-agent-2.0.0.tgz#beb17cd2b06a20b379d57e1b2e2c29be0dfe5f9a"
+  integrity sha512-t57UiJpi5mFLTvjheC1SNSwIhml3+ElNOj69iRrydtQXZJr8VIFYSDtyPi/3ZysA62kD2dmww6pDlzk0VaONZg==
   dependencies:
     agent-base "^2.1.1"
     debug "^2.6.8"
@@ -2079,6 +2404,7 @@ pac-proxy-agent@^2.0.0:
 pac-resolver@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pac-resolver/-/pac-resolver-3.0.0.tgz#6aea30787db0a891704deb7800a722a7615a6f26"
+  integrity sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==
   dependencies:
     co "^4.6.0"
     degenerator "^1.0.4"
@@ -2089,16 +2415,19 @@ pac-resolver@^3.0.0:
 pako@~0.2.0:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
+  integrity sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=
 
 param-case@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/param-case/-/param-case-1.1.2.tgz#dcb091a43c259b9228f1c341e7b6a44ea0bf9743"
+  integrity sha1-3LCRpDwlm5Io8cNB57akTqC/l0M=
   dependencies:
     sentence-case "^1.1.2"
 
 parse-glob@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"
+  integrity sha1-ssN2z7EfNVE7rdFz7wu246OIORw=
   dependencies:
     glob-base "^0.3.0"
     is-dotfile "^1.0.0"
@@ -2108,6 +2437,7 @@ parse-glob@^3.0.4:
 pascal-case@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-1.1.2.tgz#3e5d64a20043830a7c49344c2d74b41be0c9c99b"
+  integrity sha1-Pl1kogBDgwp8STRMLXS0G+DJyZs=
   dependencies:
     camel-case "^1.1.1"
     upper-case-first "^1.1.0"
@@ -2115,36 +2445,44 @@ pascal-case@^1.1.0:
 path-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
+  integrity sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=
 
 path-case@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/path-case/-/path-case-1.1.2.tgz#50ce6ba0d3bed3dd0b5c2a9c4553697434409514"
+  integrity sha1-UM5roNO+090LXCqcRVNpdDRAlRQ=
   dependencies:
     sentence-case "^1.1.2"
 
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
+  integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
 path-key@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
+  integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
 path-parse@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
 pbkdf2-compat@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz#b6e0c8fa99494d94e0511575802a59a5c142f288"
+  integrity sha1-tuDI+plJTZTgURV1gCpZpcFC8og=
 
 pem@^1.13.1:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/pem/-/pem-1.13.1.tgz#57dd3e0c044fbcf709db026a737e1aad7dc8330f"
+  integrity sha512-gA/kl8/MWWBaVRRv8M4iRkaJXEbp0L9NyG5ggZlbvQxylZAq5K5wGesAZifs89kwL/m4EGdekXtBMOzXM9rv7w==
   dependencies:
     es6-promisify "^6.0.0"
     md5 "^2.2.1"
@@ -2154,36 +2492,44 @@ pem@^1.13.1:
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
+  integrity sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=
 
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+  integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
+  integrity sha1-ITXW36ejWMBprJsXh3YogihFD/o=
   dependencies:
     pinkie "^2.0.0"
 
 pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+  integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+  integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
+  integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
 prettier@^1.12.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.12.0.tgz#d26fc5894b9230de97629b39cae225b503724ce8"
+  integrity sha512-Wz0SMncgaglBzDcohH3ZIAi4nVpzOIEweFzCOmgVEoRSeO72b4dcKGfgxoRGVMaFlh1r7dlVaJ+f3CIHfeH6xg==
 
 pretty-quick@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/pretty-quick/-/pretty-quick-1.4.1.tgz#9d41f778d2d4d940ec603d1293a0998e84c4722c"
+  integrity sha512-Q4V2GAflSaM739kKH63utbfI2n4s2fCDCyjFC4ykxA9ueb7FknLcLAZSKa3DejHMt5q9Fq395eKTZ9wYwoILBw==
   dependencies:
     chalk "^2.3.0"
     execa "^0.8.0"
@@ -2194,18 +2540,22 @@ pretty-quick@^1.4.1:
 process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
+  integrity sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=
 
 process@^0.11.0:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
 propagate@0.3.x:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-0.3.1.tgz#e3a84404a7ece820dd6bbea9f6d924e3135ae09c"
+  integrity sha1-46hEBKfs6CDda76p9tkk4xNa4Jw=
 
 proxy-agent@2:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/proxy-agent/-/proxy-agent-2.1.0.tgz#a3a2b3866debfeb79bb791f345dc9bc876e7ff86"
+  integrity sha512-I23qaUnXmU/ItpXWQcMj9wMcZQTXnJNI7nakSR+q95Iht8H0+w3dCgTJdfnOQqOCX1FZwKLSgurCyEt11LM6OA==
   dependencies:
     agent-base "2"
     debug "2"
@@ -2219,6 +2569,7 @@ proxy-agent@2:
 proxyquire@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/proxyquire/-/proxyquire-2.1.0.tgz#c2263a38bf0725f2ae950facc130e27510edce8d"
+  integrity sha512-kptdFArCfGRtQFv3Qwjr10lwbEV0TBJYvfqzhwucyfEXqVgmnAkyEw/S3FYzR5HI9i5QOq4rcqQjZ6AlknlCDQ==
   dependencies:
     fill-keys "^1.0.2"
     module-not-found-error "^1.0.0"
@@ -2227,50 +2578,62 @@ proxyquire@^2.1.0:
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
+  integrity sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=
 
 pseudomap@^1.0.1, pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
 psl@^1.1.24:
   version "1.1.29"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
+  integrity sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==
 
 punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
 
 punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+  integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
 qs@^6.5.1, qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
+  integrity sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==
 
 qs@~6.3.0:
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
+  integrity sha1-51vV9uJoEioqDgvaYwslUMFmUCw=
 
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+  integrity sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=
 
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
+  integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
+  integrity sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=
 
 querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 randomatic@^1.1.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
+  integrity sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==
   dependencies:
     is-number "^3.0.0"
     kind-of "^4.0.0"
@@ -2278,6 +2641,7 @@ randomatic@^1.1.3:
 raw-body@^2.2.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.2.tgz#bcd60c77d3eb93cde0050295c3f379389bc88f89"
+  integrity sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=
   dependencies:
     bytes "3.0.0"
     http-errors "1.6.2"
@@ -2287,6 +2651,7 @@ raw-body@^2.2.0:
 rc@^1.1.7:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.1.tgz#2e03e8e42ee450b8cb3dce65be1bf8974e1dfd95"
+  integrity sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=
   dependencies:
     deep-extend "~0.4.0"
     ini "~1.3.0"
@@ -2296,6 +2661,7 @@ rc@^1.1.7:
 readable-stream@1.1.x:
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
+  integrity sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.1"
@@ -2305,6 +2671,7 @@ readable-stream@1.1.x:
 readable-stream@2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
+  integrity sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
@@ -2317,6 +2684,7 @@ readable-stream@2:
 readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.6:
   version "2.2.11"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.11.tgz#0796b31f8d7688007ff0b93a8088d34aa17c0f72"
+  integrity sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.1"
@@ -2329,6 +2697,7 @@ readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable
 readdirp@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.1.0.tgz#4ed0ad060df3073300c48440373f72d1cc642d78"
+  integrity sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=
   dependencies:
     graceful-fs "^4.1.2"
     minimatch "^3.0.2"
@@ -2338,6 +2707,7 @@ readdirp@^2.0.0:
 regex-cache@^0.4.2:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.3.tgz#9b1a6c35d4d0dfcef5711ae651e8e9d3d7114145"
+  integrity sha1-mxpsNdTQ3871cRrmUejp09cRQUU=
   dependencies:
     is-equal-shallow "^0.1.3"
     is-primitive "^2.0.0"
@@ -2345,18 +2715,22 @@ regex-cache@^0.4.2:
 remove-trailing-separator@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz#69b062d978727ad14dc6b56ba4ab772fd8d70511"
+  integrity sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=
 
 repeat-element@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
+  integrity sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=
 
 repeat-string@^1.5.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
+  integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
 request@2.79.0:
   version "2.79.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
+  integrity sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=
   dependencies:
     aws-sign2 "~0.6.0"
     aws4 "^1.2.1"
@@ -2382,6 +2756,7 @@ request@2.79.0:
 request@^2.73.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
+  integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"
@@ -2407,6 +2782,7 @@ request@^2.73.0:
 request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
+  integrity sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=
   dependencies:
     aws-sign2 "~0.6.0"
     aws4 "^1.2.1"
@@ -2434,6 +2810,7 @@ request@^2.81.0:
 request@^2.83.0:
   version "2.83.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
+  integrity sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.6.0"
@@ -2461,22 +2838,26 @@ request@^2.83.0:
 requizzle@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/requizzle/-/requizzle-0.2.1.tgz#6943c3530c4d9a7e46f1cddd51c158fc670cdbde"
+  integrity sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=
   dependencies:
     underscore "~1.6.0"
 
 resolve@1.1.x:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+  integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
 resolve@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
+  integrity sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==
   dependencies:
     path-parse "^1.0.5"
 
 rest-facade@^1.10.1:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/rest-facade/-/rest-facade-1.10.1.tgz#a9b030ff50df28c9ea1a2719f94e369c47167d20"
+  integrity sha512-MYHUAxNQYkD/ejvQX1CY8pvPseKX5G4dWDRNv1OFNBxn4b063rvDyqpWkjdtP8QouhtAcf91HIUrBdPq08puiA==
   dependencies:
     bluebird "^2.10.2"
     change-case "^2.3.0"
@@ -2487,98 +2868,120 @@ rest-facade@^1.10.1:
 retry@^0.10.1:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
+  integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
 
 right-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
+  integrity sha1-YTObci/mo1FWiSENJOFMlhSGE+8=
   dependencies:
     align-text "^0.1.1"
 
 rimraf@2, rimraf@^2.5.1, rimraf@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
+  integrity sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=
   dependencies:
     glob "^7.0.5"
 
 ripemd160@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-0.2.0.tgz#2bf198bde167cacfa51c0a928e84b68bbe171fce"
+  integrity sha1-K/GYveFnys+lHAqSjoS2i74XH84=
 
 safe-buffer@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.0.tgz#fe4c8460397f9eaaaa58e73be46273408a45e223"
+  integrity sha512-aSLEDudu6OoRr/2rU609gRmnYboRLxgDG1z9o2Q0os7236FwvcqIOO8r8U5JUEwivZOhDaKlFO4SbPTJYyBEyQ==
 
 safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+  integrity sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==
 
 safe-buffer@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 safe-buffer@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
+  integrity sha1-0mPKVGls2KMGtcplUekt5XkY++c=
 
 samsam@1.1.2, samsam@~1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
+  integrity sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=
 
 semver@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+  integrity sha1-myzl094C0XxgEq0yaqa00M9U+U8=
 
 semver@~5.0.1:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.0.3.tgz#77466de589cd5d3c95f138aa78bc569a3cb5d27a"
+  integrity sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=
 
 sentence-case@^1.1.1, sentence-case@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/sentence-case/-/sentence-case-1.1.3.tgz#8034aafc2145772d3abe1509aa42c9e1042dc139"
+  integrity sha1-gDSq/CFFdy06vhUJqkLJ4QQtwTk=
   dependencies:
     lower-case "^1.1.1"
 
 set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+  integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
 set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
+  integrity sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=
 
 setimmediate@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+  integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
 
 setprototypeof@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
+  integrity sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=
 
 sha.js@2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.2.6.tgz#17ddeddc5f722fb66501658895461977867315ba"
+  integrity sha1-F93t3F9yL7ZlAWWIlUYZd4ZzFbo=
 
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  integrity sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=
   dependencies:
     shebang-regex "^1.0.0"
 
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+  integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
 sigmund@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
+  integrity sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=
 
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+  integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
 sinon@^1.17.1:
   version "1.17.7"
   resolved "https://registry.yarnpkg.com/sinon/-/sinon-1.17.7.tgz#4542a4f49ba0c45c05eb2e9dd9d203e2b8efe0bf"
+  integrity sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=
   dependencies:
     formatio "1.1.1"
     lolex "1.3.2"
@@ -2588,28 +2991,33 @@ sinon@^1.17.1:
 smart-buffer@^1.0.13:
   version "1.1.15"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-1.1.15.tgz#7f114b5b65fab3e2a35aa775bb12f0d1c649bf16"
+  integrity sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=
 
 snake-case@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-1.1.2.tgz#0c2f25e305158d9a18d3d977066187fef8a5a66a"
+  integrity sha1-DC8l4wUVjZoY09l3BmGH/vilpmo=
   dependencies:
     sentence-case "^1.1.2"
 
 sntp@1.x.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
+  integrity sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=
   dependencies:
     hoek "2.x.x"
 
 sntp@2.x.x:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-2.0.2.tgz#5064110f0af85f7cfdb7d6b67a40028ce52b4b2b"
+  integrity sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=
   dependencies:
     hoek "4.x.x"
 
 socks-proxy-agent@2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-2.1.1.tgz#86ebb07193258637870e13b7bd99f26c663df3d3"
+  integrity sha512-sFtmYqdUK5dAMh85H0LEVFUCO7OhJJe1/z2x/Z6mxp3s7/QPf1RkZmpZy+BpuU0bEjcV9npqKjq9Y3kwFUjnxw==
   dependencies:
     agent-base "2"
     extend "3"
@@ -2618,6 +3026,7 @@ socks-proxy-agent@2:
 socks-proxy-agent@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz#2eae7cf8e2a82d34565761539a7f9718c5617659"
+  integrity sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==
   dependencies:
     agent-base "^4.1.0"
     socks "^1.1.10"
@@ -2625,6 +3034,7 @@ socks-proxy-agent@^3.0.0:
 socks@^1.1.10, socks@~1.1.5:
   version "1.1.10"
   resolved "https://registry.yarnpkg.com/socks/-/socks-1.1.10.tgz#5b8b7fc7c8f341c53ed056e929b7bf4de8ba7b5a"
+  integrity sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=
   dependencies:
     ip "^1.1.4"
     smart-buffer "^1.0.13"
@@ -2632,40 +3042,48 @@ socks@^1.1.10, socks@~1.1.5:
 source-list-map@~0.1.7:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.8.tgz#c550b2ab5427f6b3f21f5afead88c4f5587b2106"
+  integrity sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY=
 
 source-map@^0.4.4, source-map@~0.4.1:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
+  integrity sha1-66T12pwNyZneaAMti092FzZSA2s=
   dependencies:
     amdefine ">=0.0.4"
 
 source-map@~0.1.38:
   version "0.1.43"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
+  integrity sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=
   dependencies:
     amdefine ">=0.0.4"
 
 source-map@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.2.0.tgz#dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d"
+  integrity sha1-2rc/vPwrqBm03gO9b26qSBZLP50=
   dependencies:
     amdefine ">=0.0.4"
 
 source-map@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+  integrity sha1-dc449SvwczxafwwRjYEzSiu19BI=
 
 source-map@~0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+  integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
 sshpk@^1.7.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.13.1.tgz#512df6da6287144316dc4c18fe1cf1d940739be3"
+  integrity sha1-US322mKHFEMW3EwY/hzx2UBzm+M=
   dependencies:
     asn1 "~0.2.3"
     assert-plus "^1.0.0"
@@ -2680,10 +3098,12 @@ sshpk@^1.7.0:
 "statuses@>= 1.3.1 < 2":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
+  integrity sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==
 
 stream-browserify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.1.tgz#66266ee5f9bdb9940a4e4514cafb43bb71e5c9db"
+  integrity sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=
   dependencies:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
@@ -2691,6 +3111,7 @@ stream-browserify@^2.0.1:
 stream-http@^2.3.1:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.7.2.tgz#40a050ec8dc3b53b33d9909415c02c0bf1abfbad"
+  integrity sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==
   dependencies:
     builtin-status-codes "^3.0.0"
     inherits "^2.0.1"
@@ -2701,6 +3122,7 @@ stream-http@^2.3.1:
 string-replace-webpack-plugin@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/string-replace-webpack-plugin/-/string-replace-webpack-plugin-0.0.3.tgz#82c67448cea95ec002a1bfcfd2fb0195cd12bd24"
+  integrity sha1-gsZ0SM6pXsACob/P0vsBlc0SvSQ=
   dependencies:
     async "~0.2.10"
     css-loader "^0.9.1"
@@ -2711,6 +3133,7 @@ string-replace-webpack-plugin@0.0.3:
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
+  integrity sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=
   dependencies:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
@@ -2719,50 +3142,60 @@ string-width@^1.0.1, string-width@^1.0.2:
 string_decoder@^0.10.25, string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+  integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
 
 string_decoder@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.2.tgz#b29e1f4e1125fa97a10382b8a533737b7491e179"
+  integrity sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=
   dependencies:
     safe-buffer "~5.0.1"
 
 string_decoder@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
+  integrity sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==
   dependencies:
     safe-buffer "~5.1.0"
 
 stringstream@~0.0.4, stringstream@~0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
+  integrity sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
+  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
 
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
+  integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
 
 strip-indent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
+  integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
 
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
 style-loader@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.8.3.tgz#f4f92eb7db63768748f15065cd6700f5a1c85357"
+  integrity sha1-9Pkut9tjdodI8VBlzWcA9aHIU1c=
   dependencies:
     loader-utils "^0.2.5"
 
 superagent-proxy@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/superagent-proxy/-/superagent-proxy-1.0.2.tgz#92d3660578f618ed43a82cf8cac799fe2938ba2d"
+  integrity sha1-ktNmBXj2GO1DqCz4yseZ/ik4ui0=
   dependencies:
     debug "2"
     proxy-agent "2"
@@ -2770,6 +3203,7 @@ superagent-proxy@^1.0.2:
 superagent@^3.8.0:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.2.tgz#e4a11b9d047f7d3efeb3bbe536d9ec0021d16403"
+  integrity sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==
   dependencies:
     component-emitter "^1.2.0"
     cookiejar "^2.1.0"
@@ -2785,26 +3219,31 @@ superagent@^3.8.0:
 supports-color@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-1.2.0.tgz#ff1ed1e61169d06b3cf2d588e188b18d8847e17e"
+  integrity sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=
 
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+  integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
 supports-color@^3.1.0:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
+  integrity sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=
   dependencies:
     has-flag "^1.0.0"
 
 supports-color@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
+  integrity sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==
   dependencies:
     has-flag "^3.0.0"
 
 swap-case@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/swap-case/-/swap-case-1.1.2.tgz#c39203a4587385fad3c850a0bd1bcafa081974e3"
+  integrity sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=
   dependencies:
     lower-case "^1.1.1"
     upper-case "^1.1.1"
@@ -2812,14 +3251,17 @@ swap-case@^1.1.0:
 taffydb@2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/taffydb/-/taffydb-2.6.2.tgz#7cbcb64b5a141b6a2efc2c5d2c67b4e150b2a268"
+  integrity sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=
 
 tapable@^0.1.8, tapable@~0.1.8:
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.1.10.tgz#29c35707c2b70e50d07482b5d202e8ed446dafd4"
+  integrity sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=
 
 tar-pack@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.0.tgz#23be2d7f671a8339376cbdb0b8fe3fdebf317984"
+  integrity sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=
   dependencies:
     debug "^2.2.0"
     fstream "^1.0.10"
@@ -2833,6 +3275,7 @@ tar-pack@^3.4.0:
 tar@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
+  integrity sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=
   dependencies:
     block-stream "*"
     fstream "^1.0.2"
@@ -2841,16 +3284,19 @@ tar@^2.2.1:
 thunkify@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/thunkify/-/thunkify-2.1.2.tgz#faa0e9d230c51acc95ca13a361ac05ca7e04553d"
+  integrity sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0=
 
 timers-browserify@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.2.tgz#ab4883cf597dcd50af211349a00fbca56ac86b86"
+  integrity sha1-q0iDz1l9zVCvIRNJoA+8pWrIa4Y=
   dependencies:
     setimmediate "^1.0.4"
 
 title-case@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/title-case/-/title-case-1.1.2.tgz#fae4a6ae546bfa22d083a0eea910a40d12ed4f5a"
+  integrity sha1-+uSmrlRr+iLQg6DuqRCkDRLtT1o=
   dependencies:
     sentence-case "^1.1.1"
     upper-case "^1.0.3"
@@ -2858,26 +3304,31 @@ title-case@^1.1.0:
 to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
+  integrity sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=
 
 to-iso-string@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/to-iso-string/-/to-iso-string-0.0.2.tgz#4dc19e664dfccbe25bd8db508b00c6da158255d1"
+  integrity sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=
 
 tough-cookie@~2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
+  integrity sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=
   dependencies:
     punycode "^1.4.1"
 
 tough-cookie@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
+  integrity sha1-C2GKVWW23qkL80JdBNVe3EdadWE=
   dependencies:
     punycode "^1.4.1"
 
 tough-cookie@~2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
+  integrity sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==
   dependencies:
     psl "^1.1.24"
     punycode "^1.4.1"
@@ -2885,34 +3336,41 @@ tough-cookie@~2.4.3:
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
+  integrity sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
   dependencies:
     safe-buffer "^5.0.1"
 
 tunnel-agent@~0.4.1:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.4.3.tgz#6373db76909fe570e08d73583365ed828a74eeeb"
+  integrity sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
+  integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
+  integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
 
 type-detect@0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-0.1.1.tgz#0ba5ec2a885640e470ea4e8505971900dac58822"
+  integrity sha1-C6XsKohWQORw6k6FBZcZANrFiCI=
 
 uglify-js@^2.6, uglify-js@~2.7.3:
   version "2.7.5"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.7.5.tgz#4612c0c7baaee2ba7c487de4904ae122079f2ca8"
+  integrity sha1-RhLAx7qu4rp8SH3kkErhIgefLKg=
   dependencies:
     async "~0.2.6"
     source-map "~0.5.1"
@@ -2922,42 +3380,51 @@ uglify-js@^2.6, uglify-js@~2.7.3:
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
+  integrity sha1-bgkk1r2mta/jSeOabWMoUKD4grc=
 
 uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
+  integrity sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=
 
 underscore-contrib@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/underscore-contrib/-/underscore-contrib-0.3.0.tgz#665b66c24783f8fa2b18c9f8cbb0e2c7d48c26c7"
+  integrity sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=
   dependencies:
     underscore "1.6.0"
 
 underscore@1.6.0, underscore@~1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
+  integrity sha1-izixDKze9jM3uLJOT/htRa6lKag=
 
 underscore@~1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
+  integrity sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=
 
 unpipe@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+  integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
 
 upper-case-first@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/upper-case-first/-/upper-case-first-1.1.2.tgz#5d79bedcff14419518fd2edb0a0507c9b6859115"
+  integrity sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=
   dependencies:
     upper-case "^1.1.1"
 
 upper-case@^1.0.3, upper-case@^1.1.0, upper-case@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
+  integrity sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=
 
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
+  integrity sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
@@ -2965,44 +3432,53 @@ url@^0.11.0:
 urlgrey@0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
+  integrity sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=
 
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
 util@0.10.3, "util@>=0.10.3 <1", util@^0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
+  integrity sha1-evsa/lCAUkZInj23/g7TeTNqwPk=
   dependencies:
     inherits "2.0.1"
 
 uuid@^3.0.0, uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+  integrity sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==
 
 uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 verror@1.3.6:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.3.6.tgz#cff5df12946d297d2baaefaa2689e25be01c005c"
+  integrity sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=
   dependencies:
     extsprintf "1.0.2"
 
 very-fast-args@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/very-fast-args/-/very-fast-args-1.1.0.tgz#e16d1d1faf8a6e596a246421fd90a77963d0b396"
+  integrity sha1-4W0dH6+KbllqJGQh/ZCneWPQs5Y=
 
 vm-browserify@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
+  integrity sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=
   dependencies:
     indexof "0.0.1"
 
 watchpack@^0.2.1:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-0.2.9.tgz#62eaa4ab5e5ba35fdfc018275626e3c0f5e3fb0b"
+  integrity sha1-Yuqkq15bo1/fwBgnVibjwPXj+ws=
   dependencies:
     async "^0.9.0"
     chokidar "^1.0.0"
@@ -3011,6 +3487,7 @@ watchpack@^0.2.1:
 webpack-core@~0.6.9:
   version "0.6.9"
   resolved "https://registry.yarnpkg.com/webpack-core/-/webpack-core-0.6.9.tgz#fc571588c8558da77be9efb6debdc5a3b172bdc2"
+  integrity sha1-/FcViMhVjad76e+23r3Fo7FyvcI=
   dependencies:
     source-list-map "~0.1.7"
     source-map "~0.4.1"
@@ -3018,6 +3495,7 @@ webpack-core@~0.6.9:
 webpack@^1.12.14:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-1.15.0.tgz#4ff31f53db03339e55164a9d468ee0324968fe98"
+  integrity sha1-T/MfU9sDM55VFkqdRo7gMklo/pg=
   dependencies:
     acorn "^3.0.0"
     async "^1.3.0"
@@ -3038,70 +3516,85 @@ webpack@^1.12.14:
 which@^1.1.1:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
+  integrity sha1-mofEN48D6CfOyvGs31bHNsAcFOU=
   dependencies:
     isexe "^2.0.0"
 
 which@^1.2.9:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
+  integrity sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==
   dependencies:
     isexe "^2.0.0"
 
 which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
 
 wide-align@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710"
+  integrity sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==
   dependencies:
     string-width "^1.0.2"
 
 window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
+  integrity sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=
 
 wordwrap@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
+  integrity sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=
 
 wordwrap@^1.0.0, wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
 wordwrap@~0.0.2:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
+  integrity sha1-o9XabNXAvAAI03I0u68b7WMFkQc=
 
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
 xml@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
 xmlcreate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/xmlcreate/-/xmlcreate-1.0.2.tgz#fa6bf762a60a413fb3dd8f4b03c5b269238d308f"
+  integrity sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=
 
 xregexp@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-2.0.0.tgz#52a63e56ca0b84a7f3a5f3d61872f126ad7a5943"
+  integrity sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=
 
 xtend@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+  integrity sha1-pcbVMr5lbiPbgg77lDofBJmNY68=
 
 yallist@^2.0.0, yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
 yargs@~3.10.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.10.0.tgz#f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1"
+  integrity sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=
   dependencies:
     camelcase "^1.0.2"
     cliui "^2.1.0"


### PR DESCRIPTION
- Remove usage of object.assign (dep)
- Remove usage of util._extend (prefer native Object.assign)
- Require Node v6+
- var -> const / let
- Object destructuring
- Native ES6 Classes
- Template strings

Refs #303 

Todo
 - [x] Fix tests
 - [x] Migrate management folder