### PR TITLE
install dependencies with --frozen-lockfile option in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
             - yarn-packages-{{ checksum "yarn.lock" }}
       - run:
           name: Install Dependencies
-          command: yarn install --pure-lockfile
+          command: yarn install --frozen-lockfile
       - save-cache:
           name: Save Yarn Package Cache
           key: yarn-packages-{{ checksum "yarn.lock" }}


### PR DESCRIPTION
ci is supposed to install dependencies exactly what are in lockfile

example project:
**facebook/react**
https://github.com/facebook/react/blob/cbc22402880a6f55ed3d127b6ea2a4398a25e649/.circleci/config.yml#L29-L33
**webpack/webpack**
https://github.com/webpack/webpack/blob/4d3fe000b5f173a186c918eb1a9b0486e0fc3f5c/.travis.yml#L50-L55