### PR TITLE
doc typo: Stinrg -> String

### DIFF
--- a/src/auth/DatabaseAuthenticator.js
+++ b/src/auth/DatabaseAuthenticator.js
@@ -123,7 +123,7 @@ DatabaseAuthenticator.prototype.signIn = function(userData, cb) {
  * @param   {Object}    data              User credentials object.
  * @param   {String}    data.email        User email address.
  * @param   {String}    data.password     User password.
- * @param   {Stinrg}    data.connection   Identity provider in use.
+ * @param   {String}    data.connection   Identity provider in use.
  * @param   {Function}  [cb]              Method callback.
  *
  * @return  {Promise|undefined}


### PR DESCRIPTION
I didn't regenerate the docs as running `scripts/jsdocs.js` seemed to touch them all and `yarn jsdocs:generate` didn't seem to update them.