### PR TITLE
Added client secret to default fields

### DIFF
--- a/src/auth/OAuthAuthenticator.js
+++ b/src/auth/OAuthAuthenticator.js
@@ -218,6 +218,7 @@ OAuthAuthenticator.prototype.refreshToken = function(userData, cb) {
   };
   var defaultFields = {
     client_id: this.clientId,
+    client_secret: this.clientSecret,
     grant_type: 'refresh_token'
   };
   var data = extend(defaultFields, userData);


### PR DESCRIPTION
oauth.refreshToken: Added client secret to default fields

Refresh token didn't work for me until I added the client_secret to default fields.