### PR TITLE
Don't validate id_token when alg is HS256 and there is no clientSecret

### DIFF
--- a/src/auth/OAUthWithIDTokenValidation.js
+++ b/src/auth/OAUthWithIDTokenValidation.js
@@ -86,7 +86,7 @@ OAUthWithIDTokenValidation.prototype.create = function(params, data, cb) {
           },
           function(err) {
             if (!err || err.ignoreValidation) {
-              if (err.ignoreReason) {
+              if (err && err.ignoreReason) {
                 console.warn(err.ignoreReason);
               }
               return res(r);

--- a/src/auth/OAUthWithIDTokenValidation.js
+++ b/src/auth/OAUthWithIDTokenValidation.js
@@ -86,9 +86,11 @@ OAUthWithIDTokenValidation.prototype.create = function(params, data, cb) {
           },
           function(err) {
             if (!err || err.ignoreValidation) {
+              if (err.ignoreReason) {
+                console.warn(err.ignoreReason);
+              }
               return res(r);
             }
-            console.warn(err.ignoreReason);
             return rej(err);
           }
         );

--- a/src/auth/OAUthWithIDTokenValidation.js
+++ b/src/auth/OAUthWithIDTokenValidation.js
@@ -86,9 +86,9 @@ OAUthWithIDTokenValidation.prototype.create = function(params, data, cb) {
           },
           function(err) {
             if (!err || err.ignoreValidation) {
-              console.warn(err.ignoreReason);
               return res(r);
             }
+            console.warn(err.ignoreReason);
             return rej(err);
           }
         );

--- a/test/auth/oauth-with-idtoken-validation.tests.js
+++ b/test/auth/oauth-with-idtoken-validation.tests.js
@@ -153,11 +153,9 @@ describe('OAUthWithIDTokenValidation', function() {
       };
       sinon.stub(jwt, 'verify', function(idtoken, getKey, options, callback) {
         getKey({ alg: 'HS256' }, function(err, key) {
-          expect(err).to.be.eql({
-            ignoreValidation: true,
-            ignoreReason:
-              'The `id_token` was not validated because a `clientSecret` was not provided. To ensure tokens are validated, please provide a `clientSecret` in the constructor.'
-          });
+          expect(err.message).to.contain(
+            'Validation of `id_token` requires a `clientSecret` when using the HS256 algorithm. To ensure tokens are validated, please switch the signing algorithm to RS256 or provide a `clientSecret` in the constructor.'
+          );
           callback(err, key);
         });
       });


### PR DESCRIPTION
fix https://github.com/auth0/node-auth0/issues/329

### Changes

In 2.13.0 we added ID token validation, but there are old tenants that return HS256 id_tokens. Since this library doesn't require the `clientSecret` param and the client secret is needed to validate HS256 id_tokens, the validation fails with an exception. This PR bypasses the validation when the id_token is HS256 and there is no client secret (it will emit a console.warn).

### References

#295 

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

[x] This change adds unit test coverage

[ ] This change adds integration test coverage

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[x] All existing and new tests complete without errors
