### PR TITLE
feat(proxy): pass proxy option to RestClient

### DIFF
--- a/src/auth/DatabaseAuthenticator.js
+++ b/src/auth/DatabaseAuthenticator.js
@@ -13,6 +13,7 @@ var RestClient = require('rest-facade').Client;
  * @param  {Object}              options            Authenticator options.
  * @param  {String}              options.baseUrl    The auth0 account URL.
  * @param  {String}              [options.clientId] Default client ID.
+ * @param  {String}              [options.proxy]    Proxy server URI.
  * @param  {OAuthAuthenticator}  oauth              OAuthAuthenticator instance.
  */
 var DatabaseAuthenticator = function(options, oauth) {
@@ -32,6 +33,10 @@ var DatabaseAuthenticator = function(options, oauth) {
   var clientOptions = {
     errorFormatter: { message: 'message', name: 'error' }
   };
+
+  if (options.proxy !== undefined) {
+    clientOptions.proxy = options.proxy;
+  }
 
   this.oauth = oauth;
   this.dbConnections = new RestClient(options.baseUrl + '/dbconnections/:type', clientOptions);

--- a/src/auth/OAuthAuthenticator.js
+++ b/src/auth/OAuthAuthenticator.js
@@ -17,6 +17,7 @@ var OAUthWithIDTokenValidation = require('./OAUthWithIDTokenValidation');
  * @param  {String}              options.domain         AuthenticationClient server domain
  * @param  {String}              [options.clientId]     Default client ID.
  * @param  {String}              [options.clientSecret] Default client Secret.
+ * @param  {String}              [options.proxy]        Proxy server URI.
  */
 var OAuthAuthenticator = function(options) {
   if (!options) {
@@ -35,6 +36,10 @@ var OAuthAuthenticator = function(options) {
   var clientOptions = {
     errorFormatter: { message: 'message', name: 'error' }
   };
+
+  if (options.proxy !== undefined) {
+    clientOptions.proxy = options.proxy;
+  }
 
   this.oauth = new RestClient(options.baseUrl + '/oauth/:type', clientOptions);
   this.oauthWithIDTokenValidation = new OAUthWithIDTokenValidation(this.oauth, options);

--- a/src/auth/PasswordlessAuthenticator.js
+++ b/src/auth/PasswordlessAuthenticator.js
@@ -12,6 +12,7 @@ var RestClient = require('rest-facade').Client;
  * @param  {Object}              options            Authenticator options.
  * @param  {String}              options.baseUrl    The auth0 account URL.
  * @param  {String}              [options.clientId] Default client ID.
+ * @param  {String}              [options.proxy]    Proxy server URI.
  * @param  {OAuthAuthenticator}  oauth              OAuthAuthenticator instance.
  */
 var PasswordlessAuthenticator = function(options, oauth) {
@@ -31,6 +32,10 @@ var PasswordlessAuthenticator = function(options, oauth) {
   var clientOptions = {
     errorFormatter: { message: 'message', name: 'error' }
   };
+
+  if (options.proxy !== undefined) {
+    clientOptions.proxy = options.proxy;
+  }
 
   this.oauth = oauth;
   this.passwordless = new RestClient(options.baseUrl + '/passwordless/start', clientOptions);

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -43,7 +43,8 @@ var BASE_URL_FORMAT = 'https://%s';
  * @param   {String}  options.domain                  AuthenticationClient server domain.
  * @param   {String}  [options.clientId]              Default client ID.
  * @param   {String}  [options.clientSecret]          Default client Secret.
- * @param   {String}  [options.supportedAlgorithms]   Algorithms that your application expects to receive
+ * @param   {String}  [options.supportedAlgorithms]   Algorithms that your application expects to receive.
+ * @param   {String}  [options.proxy]                 Proxy server URI.
  */
 var AuthenticationClient = function(options) {
   if (!options || typeof options !== 'object') {
@@ -69,6 +70,10 @@ var AuthenticationClient = function(options) {
   if (options.telemetry !== false) {
     var telemetry = jsonToBase64(options.clientInfo || this.getClientInfo());
     managerOptions.headers['Auth0-Client'] = telemetry;
+  }
+
+  if (options.proxy !== undefined) {
+    managerOptions.proxy = options.proxy;
   }
 
   /**

--- a/src/management/BlacklistedTokensManager.js
+++ b/src/management/BlacklistedTokensManager.js
@@ -13,7 +13,8 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object} [options.retry]    Retry Policy Config.
+ * @param {String} [options.proxy]    Proxy server URI.
  */
 var BlacklistedTokensManager = function(options) {
   if (options === null || typeof options !== 'object') {
@@ -38,6 +39,10 @@ var BlacklistedTokensManager = function(options) {
     headers: options.headers,
     query: { repeatParams: false }
   };
+
+  if (options.proxy !== undefined) {
+    clientOptions.proxy = options.proxy;
+  }
 
   /**
    * Provides an abstraction layer for consuming the

--- a/src/management/ClientGrantsManager.js
+++ b/src/management/ClientGrantsManager.js
@@ -14,7 +14,8 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object} [options.retry]    Retry Policy Config.
+ * @param {String} [options.proxy]    Proxy server URI.
  */
 var ClientGrantsManager = function(options) {
   if (options === null || typeof options !== 'object') {
@@ -39,6 +40,10 @@ var ClientGrantsManager = function(options) {
     headers: options.headers,
     query: { repeatParams: false }
   };
+
+  if (options.proxy !== undefined) {
+    clientOptions.proxy = options.proxy;
+  }
 
   /**
    * Provides an abstraction layer for consuming the

--- a/src/management/ClientsManager.js
+++ b/src/management/ClientsManager.js
@@ -18,7 +18,8 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object} [options.retry]    Retry Policy Config.
+ * @param {String} [options.proxy]    Proxy server URI.
  */
 var ClientsManager = function(options) {
   if (options === null || typeof options !== 'object') {
@@ -43,6 +44,10 @@ var ClientsManager = function(options) {
     headers: options.headers,
     query: { repeatParams: false }
   };
+
+  if (options.proxy !== undefined) {
+    clientOptions.proxy = options.proxy;
+  }
 
   /**
    * Provides an abstraction layer for consuming the

--- a/src/management/ConnectionsManager.js
+++ b/src/management/ConnectionsManager.js
@@ -12,7 +12,8 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object} [options.retry]    Retry Policy Config.
+ * @param {String} [options.proxy]    Proxy server URI.
  */
 var ConnectionsManager = function(options) {
   if (options === null || typeof options !== 'object') {
@@ -36,6 +37,10 @@ var ConnectionsManager = function(options) {
     headers: options.headers,
     query: { repeatParams: false }
   };
+
+  if (options.proxy !== undefined) {
+    clientOptions.proxy = options.proxy;
+  }
 
   /**
    * Provides an abstraction layer for performing CRUD operations on

--- a/src/management/CustomDomainsManager.js
+++ b/src/management/CustomDomainsManager.js
@@ -18,7 +18,8 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object} [options.retry]    Retry Policy Config.
+ * @param {String} [options.proxy]    Proxy server URI.
  */
 var CustomDomainsManager = function(options) {
   if (options === null || typeof options !== 'object') {
@@ -43,6 +44,10 @@ var CustomDomainsManager = function(options) {
     headers: options.headers,
     query: { repeatParams: false }
   };
+
+  if (options.proxy !== undefined) {
+    clientOptions.proxy = options.proxy;
+  }
 
   /**
    * Provides an abstraction layer for consuming the

--- a/src/management/DeviceCredentialsManager.js
+++ b/src/management/DeviceCredentialsManager.js
@@ -18,7 +18,8 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object} [options.retry]    Retry Policy Config.
+ * @param {String} [options.proxy]    Proxy server URI.
  */
 var DeviceCredentialsManager = function(options) {
   if (options === null || typeof options !== 'object') {
@@ -43,6 +44,10 @@ var DeviceCredentialsManager = function(options) {
     headers: options.headers,
     query: { repeatParams: false }
   };
+
+  if (options.proxy !== undefined) {
+    clientOptions.proxy = options.proxy;
+  }
 
   /**
    * Provides an abstraction layer for consuming the

--- a/src/management/EmailProviderManager.js
+++ b/src/management/EmailProviderManager.js
@@ -18,7 +18,8 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object} [options.retry]    Retry Policy Config.
+ * @param {String} [options.proxy]    Proxy server URI.
  */
 var EmailProviderManager = function(options) {
   if (options === null || typeof options !== 'object') {
@@ -43,6 +44,10 @@ var EmailProviderManager = function(options) {
     headers: options.headers,
     query: { repeatParams: false }
   };
+
+  if (options.proxy !== undefined) {
+    clientOptions.proxy = options.proxy;
+  }
 
   /**
    * Provides an abstraction layer for consuming the

--- a/src/management/EmailTemplatesManager.js
+++ b/src/management/EmailTemplatesManager.js
@@ -19,7 +19,8 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object} [options.retry]    Retry Policy Config.
+ * @param {String} [options.proxy]    Proxy server URI.
  */
 var EmailTemplatesManager = function(options) {
   if (!options || 'object' !== typeof options) {
@@ -39,6 +40,10 @@ var EmailTemplatesManager = function(options) {
     headers: options.headers,
     query: { repeatParams: false }
   };
+
+  if (options.proxy !== undefined) {
+    clientOptions.proxy = options.proxy;
+  }
 
   /**
    * Provides an abstraction layer for performing CRUD operations on

--- a/src/management/GuardianManager.js
+++ b/src/management/GuardianManager.js
@@ -18,7 +18,8 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object} [options.retry]    Retry Policy Config.
+ * @param {String} [options.proxy]    Proxy server URI.
  */
 var GuardianManager = function(options) {
   if (options === null || typeof options !== 'object') {
@@ -38,6 +39,10 @@ var GuardianManager = function(options) {
     headers: options.headers,
     query: { repeatParams: false }
   };
+
+  if (options.proxy !== undefined) {
+    clientOptions.proxy = options.proxy;
+  }
 
   /**
    * Provides an abstraction layer for retrieving Guardian enrollments.

--- a/src/management/JobsManager.js
+++ b/src/management/JobsManager.js
@@ -22,7 +22,8 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object} [options.retry]    Retry Policy Config.
+ * @param {String} [options.proxy]    Proxy server URI.
  */
 var JobsManager = function(options) {
   if (options === null || typeof options !== 'object') {
@@ -42,6 +43,10 @@ var JobsManager = function(options) {
     headers: options.headers,
     query: { repeatParams: false }
   };
+
+  if (options.proxy !== undefined) {
+    clientOptions.proxy = options.proxy;
+  }
 
   this.options = options;
 

--- a/src/management/LogsManager.js
+++ b/src/management/LogsManager.js
@@ -12,7 +12,8 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object} [options.retry]    Retry Policy Config.
+ * @param {String} [options.proxy]    Proxy server URI.
  */
 var LogsManager = function(options) {
   if (options === null || typeof options !== 'object') {
@@ -36,6 +37,10 @@ var LogsManager = function(options) {
     headers: options.headers,
     query: { repeatParams: false }
   };
+
+  if (options.proxy !== undefined) {
+    clientOptions.proxy = options.proxy;
+  }
 
   /**
    * Provides an abstraction layer for performing CRUD operations on

--- a/src/management/ManagementTokenProvider.js
+++ b/src/management/ManagementTokenProvider.js
@@ -20,6 +20,7 @@ var DEFAULT_OPTIONS = { enableCache: true };
  * @param {String}  options.audience                Audience of the Management API.
  * @param {Boolean} [options.enableCache=true]      Enabled or Disable Cache
  * @param {Number}  [options.cacheTTLInSeconds]     By default the `expires_in` value will be used to determine the cached time of the token, this can be overridden.
+ * @param {String}  [options.proxy]                 Proxy server URI.
  */
 var ManagementTokenProvider = function(options) {
   if (!options || typeof options !== 'object') {
@@ -67,6 +68,7 @@ var ManagementTokenProvider = function(options) {
     domain: this.options.domain,
     clientId: this.options.clientId,
     clientSecret: this.options.clientSecret,
+    proxy: this.options.proxy,
     telemetry: this.options.telemetry
   };
   this.authenticationClient = new AuthenticationClient(authenticationClientOptions);

--- a/src/management/ResourceServersManager.js
+++ b/src/management/ResourceServersManager.js
@@ -18,7 +18,8 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object} [options.retry]    Retry Policy Config.
+ * @param {String} [options.proxy]    Proxy server URI.
  */
 
 var ResourceServersManager = function(options) {
@@ -43,6 +44,10 @@ var ResourceServersManager = function(options) {
     headers: options.headers,
     query: { repeatParams: false }
   };
+
+  if (options.proxy !== undefined) {
+    clientOptions.proxy = options.proxy;
+  }
 
   /**
    * Provides an abstraction layer for consuming the

--- a/src/management/RulesConfigsManager.js
+++ b/src/management/RulesConfigsManager.js
@@ -9,7 +9,6 @@ var RetryRestClient = require('../RetryRestClient');
  * @see https://github.com/ngonzalvez/rest-facade
  */
 
-
 /**
  * @class RulesConfigsManager
  * The rules configs manager class provides a simple abstraction for performing CRUD operations
@@ -20,9 +19,10 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object} [options.retry]    Retry Policy Config.
+ * @param {String} [options.proxy]    Proxy server URI.
  */
-var RulesConfigsManager = function (options) {
+var RulesConfigsManager = function(options) {
   if (options === null || typeof options !== 'object') {
     throw new ArgumentError('Must provide manager options');
   }
@@ -45,16 +45,23 @@ var RulesConfigsManager = function (options) {
     query: { repeatParams: false }
   };
 
+  if (options.proxy !== undefined) {
+    clientOptions.proxy = options.proxy;
+  }
+
   /**
    * Provides an abstraction layer for performing CRUD operations on
    * {@link https://auth0.com/docs/api/v2#!/RulesConfigsManager Auth0 RulesConfigsManager}.
    *
    * @type {external:RestClient}
    */
-  var auth0RestClient = new Auth0RestClient(options.baseUrl + '/rules-configs/:key', clientOptions, options.tokenProvider);
+  var auth0RestClient = new Auth0RestClient(
+    options.baseUrl + '/rules-configs/:key',
+    clientOptions,
+    options.tokenProvider
+  );
   this.resource = new RetryRestClient(auth0RestClient, options.retry);
 };
-
 
 /**
  * Set a new rules config.
@@ -65,7 +72,7 @@ var RulesConfigsManager = function (options) {
  * @example
  * var params = { key: RULE_CONFIG_KEY };
  * var data =   { value: RULES_CONFIG_VALUE };
- *  
+ *
  * management.rulesConfigs.set(params, data, function (err, rulesConfig) {
  *   if (err) {
  *     // Handle error.
@@ -84,7 +91,6 @@ var RulesConfigsManager = function (options) {
  */
 utils.wrapPropertyMethod(RulesConfigsManager, 'set', 'resource.update');
 
-
 /**
  * Get all rules configs.
  *
@@ -101,7 +107,6 @@ utils.wrapPropertyMethod(RulesConfigsManager, 'set', 'resource.update');
  * @return  {Promise|undefined}
  */
 utils.wrapPropertyMethod(RulesConfigsManager, 'getAll', 'resource.getAll');
-
 
 /**
  * Delete an existing rules config.

--- a/src/management/RulesManager.js
+++ b/src/management/RulesManager.js
@@ -19,7 +19,8 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object} [options.retry]    Retry Policy Config.
+ * @param {String} [options.proxy]    Proxy server URI.
  */
 var RulesManager = function(options) {
   if (options === null || typeof options !== 'object') {
@@ -43,6 +44,10 @@ var RulesManager = function(options) {
     headers: options.headers,
     query: { repeatParams: false }
   };
+
+  if (options.proxy !== undefined) {
+    clientOptions.proxy = options.proxy;
+  }
 
   /**
    * Provides an abstraction layer for performing CRUD operations on

--- a/src/management/StatsManager.js
+++ b/src/management/StatsManager.js
@@ -17,7 +17,8 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object} [options.retry]    Retry Policy Config.
+ * @param {String} [options.proxy]    Proxy server URI.
  */
 var StatsManager = function(options) {
   if (options === null || typeof options !== 'object') {
@@ -37,6 +38,10 @@ var StatsManager = function(options) {
     headers: options.headers,
     query: { repeatParams: false }
   };
+
+  if (options.proxy !== undefined) {
+    clientOptions.proxy = options.proxy;
+  }
 
   /**
    * Provides an abstraction layer for consuming the

--- a/src/management/TenantManager.js
+++ b/src/management/TenantManager.js
@@ -17,7 +17,8 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object} [options.retry]    Retry Policy Config.
+ * @param {String} [options.proxy]    Proxy server URI.
  */
 var TenantManager = function(options) {
   if (options === null || typeof options !== 'object') {
@@ -37,6 +38,10 @@ var TenantManager = function(options) {
     headers: options.headers,
     query: { repeatParams: false }
   };
+
+  if (options.proxy !== undefined) {
+    clientOptions.proxy = options.proxy;
+  }
 
   /**
    * Provides an abstraction layer for consuming the

--- a/src/management/TicketsManager.js
+++ b/src/management/TicketsManager.js
@@ -11,7 +11,8 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object} [options.retry]    Retry Policy Config.
+ * @param {String} [options.proxy]    Proxy server URI.
  */
 var TicketsManager = function(options) {
   if (options === null || typeof options !== 'object') {
@@ -31,6 +32,10 @@ var TicketsManager = function(options) {
     headers: options.headers,
     query: { repeatParams: false }
   };
+
+  if (options.proxy !== undefined) {
+    clientOptions.proxy = options.proxy;
+  }
 
   /**
    * Provides an abstraction layer for consuming the

--- a/src/management/UsersManager.js
+++ b/src/management/UsersManager.js
@@ -17,7 +17,8 @@ var RetryRestClient = require('../RetryRestClient');
  * @param {Object} options            The client options.
  * @param {String} options.baseUrl    The URL of the API.
  * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object} [options.retry]    Retry Policy Config.
+ * @param {String} [options.proxy]    Proxy server URI.
  */
 var UsersManager = function(options) {
   if (options === null || typeof options !== 'object') {
@@ -37,6 +38,10 @@ var UsersManager = function(options) {
     headers: options.headers,
     query: { repeatParams: false }
   };
+
+  if (options.proxy !== undefined) {
+    clientOptions.proxy = options.proxy;
+  }
 
   var usersAuth0RestClient = new Auth0RestClient(
     options.baseUrl + '/users/:id',

--- a/src/management/index.js
+++ b/src/management/index.js
@@ -86,7 +86,7 @@ var MANAGEMENT_API_AUD_FORMAT = 'https://%s/api/v2/';
  * @param   {Number}  [options.tokenProvider.cacheTTLInSeconds]   By default the `expires_in` value will be used to determine the cached time of the token, this can be overridden.
  * @param   {Boolean} [options.retry.enabled=true]                Enabled or Disable Retry Policy functionality.
  * @param   {Number}  [options.retry.maxRetries=10]               Retry failed requests X times.
- *
+ * @param   {String}  [options.proxy]                             Proxy server URI.
  */
 var ManagementClient = function(options) {
   if (!options || typeof options !== 'object') {
@@ -132,6 +132,10 @@ var ManagementClient = function(options) {
   }
 
   managerOptions.retry = options.retry;
+
+  if (options.proxy !== undefined) {
+    managerOptions.proxy = options.proxy;
+  }
 
   /**
    * Simple abstraction for performing CRUD operations on the

--- a/test/auth/database-auth.tests.js
+++ b/test/auth/database-auth.tests.js
@@ -7,6 +7,7 @@ var SRC_DIR = '../../src';
 var DOMAIN = 'tenant.auth0.com';
 var API_URL = 'https://' + DOMAIN;
 var CLIENT_ID = 'TEST_CLIENT_ID';
+var PROXY = 'http://test-proxy:3128';
 
 var ArgumentError = require('rest-facade').ArgumentError;
 var Authenticator = require(SRC_DIR + '/auth/DatabaseAuthenticator');
@@ -14,6 +15,7 @@ var OAuth = require(SRC_DIR + '/auth/OAuthAuthenticator');
 
 var validOptions = {
   baseUrl: API_URL,
+  proxy: PROXY,
   clientId: CLIENT_ID
 };
 

--- a/test/auth/oauth.tests.js
+++ b/test/auth/oauth.tests.js
@@ -10,6 +10,7 @@ var DOMAIN = 'tenant.auth0.com';
 var API_URL = 'https://' + DOMAIN;
 var CLIENT_ID = 'TEST_CLIENT_ID';
 var CLIENT_SECRET = 'TEST_CLIENT_SECRET';
+var PROXY = 'http://test-proxy:3128';
 
 var ArgumentError = require('rest-facade').ArgumentError;
 var Authenticator = require(SRC_DIR + '/auth/OAuthAuthenticator');
@@ -18,6 +19,7 @@ var OAUthWithIDTokenValidation = require('../../src/auth/OAUthWithIDTokenValidat
 var validOptions = {
   baseUrl: API_URL,
   clientId: CLIENT_ID,
+  proxy: PROXY,
   clientSecret: CLIENT_SECRET
 };
 

--- a/test/auth/passwordless.tests.js
+++ b/test/auth/passwordless.tests.js
@@ -7,6 +7,7 @@ var SRC_DIR = '../../src';
 var DOMAIN = 'tenant.auth0.com';
 var API_URL = 'https://' + DOMAIN;
 var CLIENT_ID = 'TEST_CLIENT_ID';
+var PROXY = 'http://test-proxy:3128';
 
 var ArgumentError = require('rest-facade').ArgumentError;
 var Authenticator = require(SRC_DIR + '/auth/PasswordlessAuthenticator');
@@ -14,6 +15,7 @@ var OAuth = require(SRC_DIR + '/auth/OAuthAuthenticator');
 
 var validOptions = {
   baseUrl: API_URL,
+  proxy: PROXY,
   clientId: CLIENT_ID
 };
 

--- a/test/management/blacklisted-tokens.tests.js
+++ b/test/management/blacklisted-tokens.tests.js
@@ -3,6 +3,7 @@ var nock = require('nock');
 
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
+var PROXY = 'http://test-proxy:3128';
 
 var BlacklistedTokensManager = require(SRC_DIR + '/management/BlacklistedTokensManager');
 var ArgumentError = require('rest-facade').ArgumentError;
@@ -12,6 +13,7 @@ describe('BlacklistedTokensManager', function() {
     this.token = 'TOKEN';
     this.blacklistedTokens = new BlacklistedTokensManager({
       headers: { authorization: 'Bearer ' + this.token },
+      proxy: PROXY,
       baseUrl: API_URL
     });
   });

--- a/test/management/client-grants.tests.js
+++ b/test/management/client-grants.tests.js
@@ -4,6 +4,7 @@ var Promise = require('bluebird');
 
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
+var PROXY = 'http://test-proxy:3128';
 
 var ClientGrantsManager = require(SRC_DIR + '/management/ClientGrantsManager');
 var ArgumentError = require('rest-facade').ArgumentError;
@@ -15,6 +16,7 @@ describe('ClientGrantsManager', function() {
       headers: {
         authorization: 'Bearer ' + this.token
       },
+      proxy: PROXY,
       baseUrl: API_URL
     });
   });

--- a/test/management/client.tests.js
+++ b/test/management/client.tests.js
@@ -4,6 +4,7 @@ var Promise = require('bluebird');
 
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
+var PROXY = 'http://test-proxy:3128';
 
 var ClientsManager = require(SRC_DIR + '/management/ClientsManager');
 var ArgumentError = require('rest-facade').ArgumentError;
@@ -15,6 +16,7 @@ describe('ClientsManager', function() {
       headers: {
         authorization: 'Bearer ' + this.token
       },
+      proxy: PROXY,
       baseUrl: API_URL
     });
   });

--- a/test/management/connections.tests.js
+++ b/test/management/connections.tests.js
@@ -3,6 +3,7 @@ var nock = require('nock');
 
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
+var PROXY = 'http://test-proxy:3128';
 
 var ConnectionsManager = require(SRC_DIR + '/management/ConnectionsManager');
 var ArgumentError = require('rest-facade').ArgumentError;
@@ -12,6 +13,7 @@ describe('ConnectionsManager', function() {
     this.token = 'TOKEN';
     this.connections = new ConnectionsManager({
       headers: { authorization: 'Bearer ' + this.token },
+      proxy: PROXY,
       baseUrl: API_URL
     });
   });

--- a/test/management/custom-domains.tests.js
+++ b/test/management/custom-domains.tests.js
@@ -3,6 +3,7 @@ var nock = require('nock');
 
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
+var PROXY = 'http://test-proxy:3128';
 
 var CustomDomainsManager = require(SRC_DIR + '/management/CustomDomainsManager');
 var ArgumentError = require('rest-facade').ArgumentError;
@@ -12,6 +13,7 @@ describe('CustomDomainsManager', function() {
     this.token = 'TOKEN';
     this.customDomains = new CustomDomainsManager({
       headers: { authorization: 'Bearer ' + this.token },
+      proxy: PROXY,
       baseUrl: API_URL
     });
   });

--- a/test/management/device-credentials.tests.js
+++ b/test/management/device-credentials.tests.js
@@ -3,6 +3,7 @@ var nock = require('nock');
 
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
+var PROXY = 'http://test-proxy:3128';
 
 var DeviceCredentialsManager = require(SRC_DIR + '/management/DeviceCredentialsManager');
 var ArgumentError = require('rest-facade').ArgumentError;
@@ -12,6 +13,7 @@ describe('DeviceCredentialsManager', function() {
     this.token = 'TOKEN';
     this.credentials = new DeviceCredentialsManager({
       headers: { authorization: 'Bearer ' + this.token },
+      proxy: PROXY,
       baseUrl: API_URL
     });
   });

--- a/test/management/email-provider.tests.js
+++ b/test/management/email-provider.tests.js
@@ -3,6 +3,7 @@ var nock = require('nock');
 
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
+var PROXY = 'http://test-proxy:3128';
 
 var EmailProviderManager = require(SRC_DIR + '/management/EmailProviderManager');
 var ArgumentError = require('rest-facade').ArgumentError;
@@ -12,6 +13,7 @@ describe('EmailProviderManager', function() {
     this.token = 'TOKEN';
     this.emailProvider = new EmailProviderManager({
       headers: { authorization: 'Bearer ' + this.token },
+      proxy: PROXY,
       baseUrl: API_URL
     });
   });

--- a/test/management/email-templates.tests.js
+++ b/test/management/email-templates.tests.js
@@ -4,6 +4,7 @@ var EmailTemplatesManager = require('../../src/management/EmailTemplatesManager'
 var ArgumentError = require('rest-facade').ArgumentError;
 
 var API_URL = 'https://tenant.auth0.com';
+var PROXY = 'http://test-proxy:3128';
 const TEMPLATE_NAME = 'foobar';
 const DEFAULT_PARAMS = { name: TEMPLATE_NAME };
 const DEFAULT_DATA = {
@@ -22,6 +23,7 @@ describe('EmailTemplatesManager', function() {
     this.token = 'TOKEN';
     this.emailTemplates = new EmailTemplatesManager({
       headers: { authorization: 'Bearer ' + this.token },
+      proxy: PROXY,
       baseUrl: API_URL
     });
   });

--- a/test/management/guardian.tests.js
+++ b/test/management/guardian.tests.js
@@ -3,6 +3,7 @@ var nock = require('nock');
 
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenants.auth0.com';
+var PROXY = 'http://test-proxy:3128';
 
 var GuardianManager = require(SRC_DIR + '/management/GuardianManager');
 var ArgumentError = require('rest-facade').ArgumentError;
@@ -12,6 +13,7 @@ describe('GuardianManager', function() {
     this.token = 'TOKEN';
     this.guardian = new GuardianManager({
       headers: { authorization: 'Bearer ' + this.token },
+      proxy: PROXY,
       baseUrl: API_URL
     });
   });

--- a/test/management/jobs.tests.js
+++ b/test/management/jobs.tests.js
@@ -6,6 +6,7 @@ var fs = require('fs');
 
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
+var PROXY = 'http://test-proxy:3128';
 
 var JobsManager = require(SRC_DIR + '/management/JobsManager');
 var ArgumentError = require('rest-facade').ArgumentError;
@@ -22,6 +23,7 @@ describe('JobsManager', function() {
         }
       },
       headers: {},
+      proxy: PROXY,
       baseUrl: API_URL
     });
   });

--- a/test/management/logs.tests.js
+++ b/test/management/logs.tests.js
@@ -3,6 +3,7 @@ var nock = require('nock');
 
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
+var PROXY = 'http://test-proxy:3128';
 
 var LogsManager = require(SRC_DIR + '/management/LogsManager');
 var ArgumentError = require('rest-facade').ArgumentError;
@@ -12,6 +13,7 @@ describe('LogsManager', function() {
     this.token = 'TOKEN';
     this.logs = new LogsManager({
       headers: { authorization: 'Bearer ' + this.token },
+      proxy: PROXY,
       baseUrl: API_URL
     });
   });

--- a/test/management/management-client.tests.js
+++ b/test/management/management-client.tests.js
@@ -45,6 +45,11 @@ describe('ManagementClient', function() {
     expect(new ManagementClient(config)).to.exist.to.be.an.instanceOf(ManagementClient);
   });
 
+  it('should expose an instance of ManagementClient when proxy is passed', function() {
+    var config = assign({ proxy: 'http://test-proxy:3128' }, withTokenConfig);
+    expect(new ManagementClient(config)).to.exist.to.be.an.instanceOf(ManagementClient);
+  });
+
   it('should raise an error when no options object is provided', function() {
     expect(ManagementClient).to.throw(
       ArgumentError,
@@ -139,10 +144,10 @@ describe('ManagementClient', function() {
         property: 'tenant',
         cls: TenantManager
       },
-      'RulesConfigsManager': {
+      RulesConfigsManager: {
         property: 'rulesConfigs',
         cls: RulesConfigsManager
-      },
+      }
     };
 
     before(function() {

--- a/test/management/resource-servers.tests.js
+++ b/test/management/resource-servers.tests.js
@@ -4,6 +4,7 @@ var Promise = require('bluebird');
 
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
+var PROXY = 'http://test-proxy:3128';
 
 var ResourceServersManager = require(SRC_DIR + '/management/ResourceServersManager');
 var ArgumentError = require('rest-facade').ArgumentError;
@@ -15,6 +16,7 @@ describe('ResourceServersManager', function() {
       headers: {
         authorization: 'Bearer ' + this.token
       },
+      proxy: PROXY,
       baseUrl: API_URL
     });
   });

--- a/test/management/rules-configs.tests.js
+++ b/test/management/rules-configs.tests.js
@@ -3,93 +3,77 @@ var nock = require('nock');
 
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
+var PROXY = 'http://test-proxy:3128';
 
 var RulesConfigsManager = require(SRC_DIR + '/management/RulesConfigsManager');
 var ArgumentError = require('rest-facade').ArgumentError;
 
-
-describe('RulesConfigsManager', function () {
-  before(function () {
+describe('RulesConfigsManager', function() {
+  before(function() {
     this.token = 'TOKEN';
     this.rulesConfigs = new RulesConfigsManager({
       headers: { authorization: 'Bearer ' + this.token },
+      proxy: PROXY,
       baseUrl: API_URL
     });
   });
 
-  describe('instance', function () {
+  describe('instance', function() {
     var methods = ['set', 'getAll', 'delete'];
 
-    methods.forEach(function (method) {
-      it('should have a ' + method + ' method', function () {
-        expect(this.rulesConfigs[method])
-          .to.exist
-          .to.be.an.instanceOf(Function);
-      })
+    methods.forEach(function(method) {
+      it('should have a ' + method + ' method', function() {
+        expect(this.rulesConfigs[method]).to.exist.to.be.an.instanceOf(Function);
+      });
     });
   });
 
-  describe('#constructor', function () {
-    it('should error when no options are provided', function () {
-      expect(RulesConfigsManager)
-        .to.throw(ArgumentError, 'Must provide manager options');
+  describe('#constructor', function() {
+    it('should error when no options are provided', function() {
+      expect(RulesConfigsManager).to.throw(ArgumentError, 'Must provide manager options');
     });
 
-
-    it('should throw an error when no base URL is provided', function () {
+    it('should throw an error when no base URL is provided', function() {
       var client = RulesConfigsManager.bind(null, {});
 
-      expect(client)
-        .to.throw(ArgumentError, 'Must provide a base URL for the API');
+      expect(client).to.throw(ArgumentError, 'Must provide a base URL for the API');
     });
 
-
-    it('should throw an error when the base URL is invalid', function () {
+    it('should throw an error when the base URL is invalid', function() {
       var client = RulesConfigsManager.bind(null, { baseUrl: '' });
 
-      expect(client)
-        .to.throw(ArgumentError, 'The provided base URL is invalid');
+      expect(client).to.throw(ArgumentError, 'The provided base URL is invalid');
     });
   });
 
-  describe('#getAll', function () {
-
-    it('should accept a callback', function (done) {
-      this
-        .rulesConfigs
-        .getAll(function () {
-          done();
-        });
+  describe('#getAll', function() {
+    it('should accept a callback', function(done) {
+      this.rulesConfigs.getAll(function() {
+        done();
+      });
     });
 
-
-    it('should return a promise if no callback is given', function (done) {
-      this
-        .rulesConfigs
+    it('should return a promise if no callback is given', function(done) {
+      this.rulesConfigs
         .getAll()
         .then(done.bind(null, null))
         .catch(done.bind(null, null));
     });
 
-
-    it('should pass any errors to the promise catch handler', function (done) {
+    it('should pass any errors to the promise catch handler', function(done) {
       nock.cleanAll();
 
       var request = nock(API_URL)
         .get('/rules-configs')
         .reply(500);
 
-      this
-        .rulesConfigs
-        .getAll()
-        .catch(function (err) {
-          expect(err).to.exist;
-          done();
-        });
+      this.rulesConfigs.getAll().catch(function(err) {
+        expect(err).to.exist;
+        done();
+      });
     });
 
-
-    it('should pass the body of the response to the "then" handler', function (done) {
+    it('should pass the body of the response to the "then" handler', function(done) {
       nock.cleanAll();
 
       var data = [{ key: 'dbconnectionstring' }];
@@ -97,60 +81,45 @@ describe('RulesConfigsManager', function () {
         .get('/rules-configs')
         .reply(200, data);
 
-      this
-        .rulesConfigs
-        .getAll()
-        .then(function (rulesConfigs) {
-          expect(rulesConfigs)
-            .to.be.an.instanceOf(Array);
+      this.rulesConfigs.getAll().then(function(rulesConfigs) {
+        expect(rulesConfigs).to.be.an.instanceOf(Array);
 
-          expect(rulesConfigs.length)
-            .to.equal(data.length);
+        expect(rulesConfigs.length).to.equal(data.length);
 
-          expect(rulesConfigs[0].key)
-            .to.equal(data[0].key);
+        expect(rulesConfigs[0].key).to.equal(data[0].key);
 
-          done();
-        });
+        done();
+      });
     });
 
-
-    it('should perform a GET request to rules-configs', function (done) {
+    it('should perform a GET request to rules-configs', function(done) {
       nock.cleanAll();
 
       var request = nock(API_URL)
         .get('/rules-configs')
         .reply(200);
 
-      this
-        .rulesConfigs
-        .getAll()
-        .then(function () {
-          expect(request.isDone()).to.be.true;
-          done();
-        });
+      this.rulesConfigs.getAll().then(function() {
+        expect(request.isDone()).to.be.true;
+        done();
+      });
     });
 
-
-    it('should include the token in the Authorization header', function (done) {
+    it('should include the token in the Authorization header', function(done) {
       nock.cleanAll();
 
       var request = nock(API_URL)
         .get('/rules-configs')
         .matchHeader('Authorization', 'Bearer ' + this.token)
-        .reply(200)
+        .reply(200);
 
-      this
-        .rulesConfigs
-        .getAll()
-        .then(function () {
-          expect(request.isDone()).to.be.true;
-          done();
-        });
+      this.rulesConfigs.getAll().then(function() {
+        expect(request.isDone()).to.be.true;
+        done();
+      });
     });
 
-
-    it('should pass the parameters in the query-string', function (done) {
+    it('should pass the parameters in the query-string', function(done) {
       nock.cleanAll();
 
       var params = {
@@ -160,198 +129,154 @@ describe('RulesConfigsManager', function () {
       var request = nock(API_URL)
         .get('/rules-configs')
         .query(params)
-        .reply(200)
+        .reply(200);
 
-      this
-        .rulesConfigs
-        .getAll(params)
-        .then(function () {
-          expect(request.isDone())
-            .to.be.true;
+      this.rulesConfigs.getAll(params).then(function() {
+        expect(request.isDone()).to.be.true;
 
-          done();
-        });
+        done();
+      });
     });
   });
 
-  describe('#set', function () {
-
-    beforeEach(function () {
+  describe('#set', function() {
+    beforeEach(function() {
       this.data = { value: 'foobar' };
       this.params = { key: 'KEY' };
     });
 
-    it('should accept a callback', function (done) {
-      this
-        .rulesConfigs
-        .set(this.params, this.data, function () {
-          done();
-        });
+    it('should accept a callback', function(done) {
+      this.rulesConfigs.set(this.params, this.data, function() {
+        done();
+      });
     });
 
-    it('should return a promise if no callback is given', function (done) {
-      this
-        .rulesConfigs
+    it('should return a promise if no callback is given', function(done) {
+      this.rulesConfigs
         .set(this.params, this.data)
         .then(done.bind(null, null))
         .catch(done.bind(null, null));
     });
 
-    it('should pass any errors to the promise catch handler', function (done) {
+    it('should pass any errors to the promise catch handler', function(done) {
       nock.cleanAll();
 
       var request = nock(API_URL)
         .put('/rules-configs/' + this.params.key)
         .reply(500);
 
-      this
-        .rulesConfigs
-        .set(this.params, this.data)
-        .catch(function (err) {
-          expect(err)
-            .to.exist;
+      this.rulesConfigs.set(this.params, this.data).catch(function(err) {
+        expect(err).to.exist;
 
-          done();
-        });
+        done();
+      });
     });
 
-    it('should perform a PUT request to /rules-configs/{KEY}', function (done) {
+    it('should perform a PUT request to /rules-configs/{KEY}', function(done) {
       nock.cleanAll();
 
       var request = nock(API_URL)
         .put('/rules-configs/' + this.params.key, this.data)
         .reply(200);
 
-      this
-        .rulesConfigs
+      this.rulesConfigs
         .set(this.params, this.data)
-        .then(function () {
-          expect(request.isDone())
-            .to.be.true;
+        .then(function() {
+          expect(request.isDone()).to.be.true;
 
           done();
         })
-        .catch(function (err) {
+        .catch(function(err) {
           console.error(err);
           expect.fail();
           done();
         });
     });
 
-    it('should pass the data in the body of the request', function (done) {
+    it('should pass the data in the body of the request', function(done) {
       nock.cleanAll();
 
       var request = nock(API_URL)
         .put('/rules-configs/' + this.params.key, this.data)
         .reply(200);
 
-      this
-        .rulesConfigs
-        .set(this.params, this.data)
-        .then(function () {
-          expect(request.isDone())
-            .to.be.true;
+      this.rulesConfigs.set(this.params, this.data).then(function() {
+        expect(request.isDone()).to.be.true;
 
-          done();
-        });
+        done();
+      });
     });
 
-    it('should include the token in the Authorization header', function (done) {
+    it('should include the token in the Authorization header', function(done) {
       nock.cleanAll();
 
       var request = nock(API_URL)
         .put('/rules-configs/' + this.params.key, this.data)
         .matchHeader('Authorization', 'Bearer ' + this.token)
-        .reply(200)
+        .reply(200);
 
-      this
-        .rulesConfigs
-        .set(this.params, this.data)
-        .then(function () {
-          expect(request.isDone())
-            .to.be.true;
+      this.rulesConfigs.set(this.params, this.data).then(function() {
+        expect(request.isDone()).to.be.true;
 
-          done();
-        });
+        done();
+      });
     });
   });
 
-  describe('#delete', function () {
+  describe('#delete', function() {
     var key = 'KEY';
 
-    beforeEach(function () {
+    beforeEach(function() {
       this.request = nock(API_URL)
         .delete('/rules-configs/' + key)
         .reply(200);
     });
 
-
-    it('should accept a callback', function (done) {
-      this
-        .rulesConfigs
-        .delete({ key: key }, done.bind(null, null));
+    it('should accept a callback', function(done) {
+      this.rulesConfigs.delete({ key: key }, done.bind(null, null));
     });
 
-
-    it('should return a promise when no callback is given', function (done) {
-      this
-        .rulesConfigs
-        .delete({ key: key })
-        .then(done.bind(null, null));
+    it('should return a promise when no callback is given', function(done) {
+      this.rulesConfigs.delete({ key: key }).then(done.bind(null, null));
     });
 
-
-    it('should perform a delete request to /rules-configs/' + key, function (done) {
+    it('should perform a delete request to /rules-configs/' + key, function(done) {
       var request = this.request;
- 
-      this
-        .rulesConfigs
-        .delete({ key: key })
-        .then(function () {
-          expect(request.isDone())
-            .to.be.true;
 
-          done();
-        });
+      this.rulesConfigs.delete({ key: key }).then(function() {
+        expect(request.isDone()).to.be.true;
+
+        done();
+      });
     });
 
-
-    it('should pass any errors to the promise catch handler', function (done) {
+    it('should pass any errors to the promise catch handler', function(done) {
       nock.cleanAll();
 
       var request = nock(API_URL)
         .delete('/rules-configs/' + key)
         .reply(500);
 
-      this
-        .rulesConfigs
-        .delete({ key: key })
-        .catch(function (err) {
-          expect(err)
-            .to.exist;
+      this.rulesConfigs.delete({ key: key }).catch(function(err) {
+        expect(err).to.exist;
 
-          done();
-        });
+        done();
+      });
     });
 
-
-    it('should include the token in the authorization header', function (done) {
+    it('should include the token in the authorization header', function(done) {
       nock.cleanAll();
 
       var request = nock(API_URL)
         .delete('/rules-configs/' + key)
         .matchHeader('authorization', 'Bearer ' + this.token)
-        .reply(200)
+        .reply(200);
 
-      this
-        .rulesConfigs
-        .delete({ key: key })
-        .then(function () {
-          expect(request.isDone())
-            .to.be.true;
+      this.rulesConfigs.delete({ key: key }).then(function() {
+        expect(request.isDone()).to.be.true;
 
-          done();
-        });
+        done();
+      });
     });
   });
 });

--- a/test/management/rules.tests.js
+++ b/test/management/rules.tests.js
@@ -3,6 +3,7 @@ var nock = require('nock');
 
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
+var PROXY = 'http://test-proxy:3128';
 
 var RulesManager = require(SRC_DIR + '/management/RulesManager');
 var ArgumentError = require('rest-facade').ArgumentError;
@@ -12,6 +13,7 @@ describe('RulesManager', function() {
     this.token = 'TOKEN';
     this.rules = new RulesManager({
       headers: { authorization: 'Bearer ' + this.token },
+      proxy: PROXY,
       baseUrl: API_URL
     });
   });

--- a/test/management/stats.tests.js
+++ b/test/management/stats.tests.js
@@ -3,6 +3,7 @@ var nock = require('nock');
 
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';
+var PROXY = 'http://test-proxy:3128';
 
 var StatsManager = require(SRC_DIR + '/management/StatsManager');
 var ArgumentError = require('rest-facade').ArgumentError;
@@ -12,6 +13,7 @@ describe('StatsManager', function() {
     this.token = 'TOKEN';
     this.stats = new StatsManager({
       headers: { authorization: 'Bearer ' + this.token },
+      proxy: PROXY,
       baseUrl: API_URL
     });
   });

--- a/test/management/tenant.tests.js
+++ b/test/management/tenant.tests.js
@@ -3,6 +3,7 @@ var nock = require('nock');
 
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenants.auth0.com';
+var PROXY = 'http://test-proxy:3128';
 
 var TenantManager = require(SRC_DIR + '/management/TenantManager');
 var ArgumentError = require('rest-facade').ArgumentError;
@@ -12,6 +13,7 @@ describe('TenantManager', function() {
     this.token = 'TOKEN';
     this.tenant = new TenantManager({
       headers: { authorization: 'Bearer ' + this.token },
+      proxy: PROXY,
       baseUrl: API_URL
     });
   });

--- a/test/management/tickets.tests.js
+++ b/test/management/tickets.tests.js
@@ -3,6 +3,7 @@ var nock = require('nock');
 
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenants.auth0.com';
+var PROXY = 'http://test-proxy:3128';
 
 var TicketsManager = require(SRC_DIR + '/management/TicketsManager');
 var ArgumentError = require('rest-facade').ArgumentError;
@@ -12,6 +13,7 @@ describe('TicketsManager', function() {
     this.token = 'TOKEN';
     this.tickets = new TicketsManager({
       headers: { authorization: 'Bearer ' + this.token },
+      proxy: PROXY,
       baseUrl: API_URL
     });
   });

--- a/test/management/users.tests.js
+++ b/test/management/users.tests.js
@@ -3,6 +3,7 @@ var nock = require('nock');
 
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenants.auth0.com';
+var PROXY = 'http://test-proxy:3128';
 
 var UsersManager = require(SRC_DIR + '/management/UsersManager');
 var ArgumentError = require('rest-facade').ArgumentError;
@@ -12,6 +13,7 @@ describe('UsersManager', function() {
     this.token = 'TOKEN';
     this.users = new UsersManager({
       headers: { authorization: 'Bearer ' + this.token },
+      proxy: PROXY,
       baseUrl: API_URL
     });
   });


### PR DESCRIPTION
### Changes

- Allow `proxy` option to be passed to underlying `rest-facade` package

### References

- Fixes issue #197 

### Testing

The input `proxy` option is passed to `rest-facade`

* [x] This change adds unit test coverage

* [ ] This change adds integration test coverage

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

* [x] All existing and new tests complete without errors
