### PR TITLE
Implement users exports endpoint

### DIFF
--- a/src/management/JobsManager.js
+++ b/src/management/JobsManager.js
@@ -57,6 +57,19 @@ var JobsManager = function(options) {
     options.tokenProvider
   );
   this.jobs = new RetryRestClient(auth0RestClient, options.retry);
+
+  /**
+   * Provides an abstraction layer for consuming the
+   * {@link https://auth0.com/docs/api/v2#!/Jobs/post_users_exports Create job to export users endpoint}
+   *
+   * @type {external:RestClient}
+   */
+  const usersExportsRestClient = new Auth0RestClient(
+    options.baseUrl + '/jobs/users-exports',
+    clientOptions,
+    options.tokenProvider
+  );
+  this.usersExports = new RetryRestClient(usersExportsRestClient, options.retry);
 };
 
 /**
@@ -192,6 +205,63 @@ JobsManager.prototype.importUsers = function(data, cb) {
   }
 
   return promise;
+};
+
+/**
+ * Export all users to a file using a long running job.
+ *
+ * @method   exportUsers
+ * @memberOf module:management.JobsManager.prototype
+ *
+ * @example
+ * var data = {
+ *   connection_id: 'con_0000000000000001',
+ *   format: 'csv',
+ *   limit: 5,
+ *   fields: [
+ *     {
+ *       "name": "user_id"
+ *     },
+ *     {
+ *       "name": "name"
+ *     },
+ *     {
+ *       "name": "email"
+ *     },
+ *     {
+ *       "name": "identities[0].connection",
+ *       "export_as": "provider"
+ *     },
+ *     {
+ *       "name": "user_metadata.some_field"
+ *     }
+ *   ]
+ * }
+ *
+ * management.jobs.exportUsers(data, function (err, results) {
+ *   if (err) {
+ *     // Handle error.
+ *   }
+ *
+ *   // Retrieved job.
+ *   console.log(results);
+ * });
+ *
+ * @param   {Object}    data                  Users export data.
+ * @param   {String}    [data.connection_id]  The connection id of the connection from which users will be exported
+ * @param   {String}    [data.format]         The format of the file. Valid values are: "json" and "csv".
+ * @param   {Number}    [data.limit]          Limit the number of records.
+ * @param   {Object[]}  [data.fields]         A list of fields to be included in the CSV. If omitted, a set of predefined fields will be exported.
+ * @param   {Function}  [cb]                  Callback function.
+ *
+ * @return  {Promise|undefined}
+ */
+JobsManager.prototype.exportUsers = function(data, cb) {
+  if (cb && cb instanceof Function) {
+    return this.usersExports.create(data, cb);
+  }
+
+  return this.usersExports.create(data);
 };
 
 /**

--- a/src/management/index.js
+++ b/src/management/index.js
@@ -1612,6 +1612,57 @@ utils.wrapPropertyMethod(ManagementClient, 'getJob', 'jobs.get');
 utils.wrapPropertyMethod(ManagementClient, 'importUsers', 'jobs.importUsers');
 
 /**
+ * Export all users to a file using a long running job.
+ *
+ * @method   exportUsers
+ * @memberOf module:management.ManagementClient.prototype
+ *
+ * @example
+ * var data = {
+ *   connection_id: 'con_0000000000000001',
+ *   format: 'csv',
+ *   limit: 5,
+ *   fields: [
+ *     {
+ *       "name": "user_id"
+ *     },
+ *     {
+ *       "name": "name"
+ *     },
+ *     {
+ *       "name": "email"
+ *     },
+ *     {
+ *       "name": "identities[0].connection",
+ *       "export_as": "provider"
+ *     },
+ *     {
+ *       "name": "user_metadata.some_field"
+ *     }
+ *   ]
+ * }
+ *
+ * management.exportUsers(data, function (err, results) {
+ *   if (err) {
+ *     // Handle error.
+ *   }
+ *
+ *   // Retrieved job.
+ *   console.log(results);
+ * });
+ *
+ * @param   {Object}    data                  Users export data.
+ * @param   {String}    [data.connection_id]  The connection id of the connection from which users will be exported
+ * @param   {String}    [data.format]         The format of the file. Valid values are: "json" and "csv".
+ * @param   {Number}    [data.limit]          Limit the number of records.
+ * @param   {Object[]}  [data.fields]         A list of fields to be included in the CSV. If omitted, a set of predefined fields will be exported.
+ * @param   {Function}  [cb]                  Callback function.
+ *
+ * @return  {Promise|undefined}
+ */
+utils.wrapPropertyMethod(ManagementClient, 'exportUsers', 'jobs.exportUsers');
+
+/**
  * Send a verification email to a user.
  *
  * @method    sendEmailVerification


### PR DESCRIPTION
### Changes
This PR implements the `/api/v2/jobs/users-exports` endpoint.

Instead of the approach in #319 this PR uses `Auth0RestClient` and `RetryRestClient` which results in a much shorter implementation (i.e. with retry if the rate limit is hit and the management API returns a HTTP 429 response).

### References
Fixes #318 

### Testing
To test the changes in this PR:

- Checkout this branch
- Create file `test.js` in the root directory of this branch with the following contents:
    ```javascript
    const src = require("./src");
    const auth0 = new src.ManagementClient({
      "domain": "<domain>",
      "clientId": "<clientId>",
      "clientSecret": "<clientSecret>",
      "scope": "read:users"
    });
    return auth0.exportUsers({ format: "csv", })
      .then(console.log)
      .catch(console.error);
    ```
    Make sure to fill out the `domain`, `clientId` and `clientSecret`.
- Run `node test.js`
- Verify that the console output shows a JSON response of a created export job.

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
