### PR TITLE
update OAuthAuthenticator.prototype.refreshToken

### DIFF
--- a/src/auth/OAuthAuthenticator.js
+++ b/src/auth/OAuthAuthenticator.js
@@ -218,6 +218,7 @@ OAuthAuthenticator.prototype.refreshToken = function(userData, cb) {
   };
   var defaultFields = {
     client_id: this.clientId,
+    client_secret: this.clientSecret,
     grant_type: 'refresh_token'
   };
   var data = extend(defaultFields, userData);


### PR DESCRIPTION
### Changes

- In OAuthAuthenticator.prototype.refreshToken, "client_secret" is a required. and I added "client_secret".

### References

- https://auth0.com/docs/api/authentication#refresh-token

### Testing

- [ ] This change adds unit test coverage

- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [ ] All existing and new tests complete without errors
