### PR TITLE
missing params in sendEmailVerification

### DIFF
--- a/src/management/index.js
+++ b/src/management/index.js
@@ -1923,7 +1923,7 @@ utils.wrapPropertyMethod(ManagementClient, 'exportUsers', 'jobs.exportUsers');
  * 	user_id: '{USER_ID}'
  * };
  *
- * management.sendEmailVerification(function (err) {
+ * management.sendEmailVerification(params, function (err) {
  *   if (err) {
  *     // Handle error.
  *   }


### PR DESCRIPTION
Added params to sendEmailVerification.

Error was noticed in community topic here:
https://community.auth0.com/t/resend-confirmation-email-rule-button/23734/6

### Changes

Please describe both what is changing and why this is important. Include:

- Endpoints added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
- Any alternative designs or approaches considered

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

[ ] This change adds unit test coverage

[ ] This change adds integration test coverage

### Checklist

[ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[ ] All existing and new tests complete without errors
