### PR TITLE
Implement auth0-forwarded-for header passing in Authentication Client

### DIFF
--- a/src/auth/OAuthAuthenticator.js
+++ b/src/auth/OAuthAuthenticator.js
@@ -233,17 +233,13 @@ OAuthAuthenticator.prototype.passwordGrant = function(userData, options, cb) {
  *
  * @param   {Object}    userData                User credentials object.
  * @param   {String}    userData.refresh_token  Refresh token.
- * @param   {Object}    [options]               Additional options.
- * @param   {String}    [options.forwardedFor]  Value to be used for auth0-forwarded-for header
  *
  * @return  {Promise|undefined}
  */
-OAuthAuthenticator.prototype.refreshToken = function(userData, options, cb) {
-  var { options, cb } = sanitizeArguments(options, cb);
-  var defaultParams = {
+OAuthAuthenticator.prototype.refreshToken = function(userData, cb) {
+  var params = {
     type: 'token'
   };
-  var params = extend(defaultParams, getParamsFromOptions(options));
   var defaultFields = {
     client_id: this.clientId,
     grant_type: 'refresh_token'
@@ -267,20 +263,16 @@ OAuthAuthenticator.prototype.refreshToken = function(userData, options, cb) {
  * @method    socialSignIn
  * @memberOf  module:auth.OAuthAuthenticator.prototype
  *
- * @param   {Object}    data                   User credentials object.
- * @param   {String}    data.access_token      User access token.
- * @param   {String}    data.connection        Identity provider.
- * @param   {Object}    [options]              Additional options.
- * @param   {String}    [options.forwardedFor] Value to be used for auth0-forwarded-for header
+ * @param   {Object}    data                User credentials object.
+ * @param   {String}    data.access_token   User access token.
+ * @param   {String}    data.connection     Identity provider.
  *
  * @return  {Promise|undefined}
  */
-OAuthAuthenticator.prototype.socialSignIn = function(data, options, cb) {
-  var { options, cb } = sanitizeArguments(options, cb);
-  var defaultParams = {
+OAuthAuthenticator.prototype.socialSignIn = function(data, cb) {
+  var params = {
     type: 'access_token'
   };
-  var params = extend(defaultParams, getParamsFromOptions(options));
 
   if (typeof data !== 'object') {
     throw new ArgumentError('Missing user credential objects');
@@ -302,10 +294,9 @@ OAuthAuthenticator.prototype.socialSignIn = function(data, options, cb) {
 };
 
 OAuthAuthenticator.prototype.clientCredentialsGrant = function(options, cb) {
-  var defaultParams = {
+  var params = {
     type: 'token'
   };
-  var params = extend(defaultParams, getParamsFromOptions(options));
 
   var defaultFields = {
     grant_type: 'client_credentials',
@@ -365,18 +356,16 @@ OAuthAuthenticator.prototype.clientCredentialsGrant = function(options, cb) {
  *   console.log(userData);
  * });
  *
- * @param   {Object}    options                  Authorization code payload
- * @param   {String}    options.code             Code in URL returned after authentication
- * @param   {String}    option.redirect_uri      The URL to which Auth0 will redirect the browser after authorization has been granted by the user.
- * @param   {String}    [options.forwardedFor]   Value to be used for auth0-forwarded-for header
+ * @param   {Object}    data                  Authorization code payload
+ * @param   {String}    userData.code         Code in URL returned after authentication
+ * @param   {String}    userData.redirect_uri The URL to which Auth0 will redirect the browser after authorization has been granted by the user.
  *
  * @return  {Promise|undefined}
  */
 OAuthAuthenticator.prototype.authorizationCodeGrant = function(options, cb) {
-  var defaultParams = {
+  var params = {
     type: 'token'
   };
-  var params = extend(defaultParams, getParamsFromOptions(options));
 
   var defaultFields = {
     grant_type: 'authorization_code',

--- a/src/auth/OAuthAuthenticator.js
+++ b/src/auth/OAuthAuthenticator.js
@@ -1,9 +1,23 @@
 var extend = require('util')._extend;
+var sanitizeArguments = require('../utils').sanitizeArguments;
 
 var ArgumentError = require('rest-facade').ArgumentError;
 var RestClient = require('rest-facade').Client;
 
 var OAUthWithIDTokenValidation = require('./OAUthWithIDTokenValidation');
+
+function getParamsFromOptions(options) {
+  const params = {};
+  if (!options || typeof options !== 'object') {
+    return params;
+  }
+  if (options.forwardedFor) {
+    params._requestCustomizer = function(req) {
+      req.set('auth0-forwarded-for', options.forwardedFor);
+    };
+  }
+  return params;
+}
 
 /**
  * @class
@@ -75,17 +89,21 @@ var OAuthAuthenticator = function(options) {
  *   console.log(userData);
  * });
  *
- * @param   {Object}    userData              User credentials object.
- * @param   {String}    userData.username     Username.
- * @param   {String}    userData.password     User password.
- * @param   {String}    userData.connection   The identity provider in use.
+ * @param   {Object}    userData               User credentials object.
+ * @param   {String}    userData.username      Username.
+ * @param   {String}    userData.password      User password.
+ * @param   {String}    userData.connection    The identity provider in use.
+ * @param   {Object}    [options]              Additional options.
+ * @param   {String}    [options.forwardedFor] Value to be used for auth0-forwarded-for header
  *
  * @return  {Promise|undefined}
  */
-OAuthAuthenticator.prototype.signIn = function(userData, cb) {
-  var params = {
+OAuthAuthenticator.prototype.signIn = function(userData, options, cb) {
+  var { options, cb } = sanitizeArguments(options, cb);
+  var defaultParams = {
     type: 'ro'
   };
+  var params = extend(defaultParams, getParamsFromOptions(options));
   var defaultFields = {
     client_id: this.clientId,
     grant_type: 'password',
@@ -140,17 +158,21 @@ OAuthAuthenticator.prototype.signIn = function(userData, cb) {
  *   console.log(userData);
  * });
  *
- * @param   {Object}    userData              User credentials object.
- * @param   {String}    userData.username     Username.
- * @param   {String}    userData.password     User password.
- * @param   {String}    [userData.realm]      Name of the realm to use to authenticate or the connection name
+ * @param   {Object}    userData               User credentials object.
+ * @param   {String}    userData.username      Username.
+ * @param   {String}    userData.password      User password.
+ * @param   {String}    [userData.realm]       Name of the realm to use to authenticate or the connection name
+ * @param   {Object}    [options]              Additional options.
+ * @param   {String}    [options.forwardedFor] Value to be used for auth0-forwarded-for header
  *
  * @return  {Promise|undefined}
  */
-OAuthAuthenticator.prototype.passwordGrant = function(userData, cb) {
-  var params = {
+OAuthAuthenticator.prototype.passwordGrant = function(userData, options, cb) {
+  var { options, cb } = sanitizeArguments(options, cb);
+  var defaultParams = {
     type: 'token'
   };
+  var params = extend(defaultParams, getParamsFromOptions(options));
   var defaultFields = {
     client_id: this.clientId,
     client_secret: this.clientSecret,
@@ -211,13 +233,17 @@ OAuthAuthenticator.prototype.passwordGrant = function(userData, cb) {
  *
  * @param   {Object}    userData                User credentials object.
  * @param   {String}    userData.refresh_token  Refresh token.
+ * @param   {Object}    [options]               Additional options.
+ * @param   {String}    [options.forwardedFor]  Value to be used for auth0-forwarded-for header
  *
  * @return  {Promise|undefined}
  */
-OAuthAuthenticator.prototype.refreshToken = function(userData, cb) {
-  var params = {
+OAuthAuthenticator.prototype.refreshToken = function(userData, options, cb) {
+  var { options, cb } = sanitizeArguments(options, cb);
+  var defaultParams = {
     type: 'token'
   };
+  var params = extend(defaultParams, getParamsFromOptions(options));
   var defaultFields = {
     client_id: this.clientId,
     grant_type: 'refresh_token'
@@ -241,16 +267,20 @@ OAuthAuthenticator.prototype.refreshToken = function(userData, cb) {
  * @method    socialSignIn
  * @memberOf  module:auth.OAuthAuthenticator.prototype
  *
- * @param   {Object}    data                User credentials object.
- * @param   {String}    data.access_token   User access token.
- * @param   {String}    data.connection     Identity provider.
+ * @param   {Object}    data                   User credentials object.
+ * @param   {String}    data.access_token      User access token.
+ * @param   {String}    data.connection        Identity provider.
+ * @param   {Object}    [options]              Additional options.
+ * @param   {String}    [options.forwardedFor] Value to be used for auth0-forwarded-for header
  *
  * @return  {Promise|undefined}
  */
-OAuthAuthenticator.prototype.socialSignIn = function(data, cb) {
-  var params = {
+OAuthAuthenticator.prototype.socialSignIn = function(data, options, cb) {
+  var { options, cb } = sanitizeArguments(options, cb);
+  var defaultParams = {
     type: 'access_token'
   };
+  var params = extend(defaultParams, getParamsFromOptions(options));
 
   if (typeof data !== 'object') {
     throw new ArgumentError('Missing user credential objects');
@@ -272,9 +302,10 @@ OAuthAuthenticator.prototype.socialSignIn = function(data, cb) {
 };
 
 OAuthAuthenticator.prototype.clientCredentialsGrant = function(options, cb) {
-  var params = {
+  var defaultParams = {
     type: 'token'
   };
+  var params = extend(defaultParams, getParamsFromOptions(options));
 
   var defaultFields = {
     grant_type: 'client_credentials',
@@ -334,16 +365,18 @@ OAuthAuthenticator.prototype.clientCredentialsGrant = function(options, cb) {
  *   console.log(userData);
  * });
  *
- * @param   {Object}    data                  Authorization code payload
- * @param   {String}    userData.code         Code in URL returned after authentication
- * @param   {String}    userData.redirect_uri The URL to which Auth0 will redirect the browser after authorization has been granted by the user.
+ * @param   {Object}    options                  Authorization code payload
+ * @param   {String}    options.code             Code in URL returned after authentication
+ * @param   {String}    option.redirect_uri      The URL to which Auth0 will redirect the browser after authorization has been granted by the user.
+ * @param   {String}    [options.forwardedFor]   Value to be used for auth0-forwarded-for header
  *
  * @return  {Promise|undefined}
  */
 OAuthAuthenticator.prototype.authorizationCodeGrant = function(options, cb) {
-  var params = {
+  var defaultParams = {
     type: 'token'
   };
+  var params = extend(defaultParams, getParamsFromOptions(options));
 
   var defaultFields = {
     grant_type: 'authorization_code',

--- a/src/utils.js
+++ b/src/utils.js
@@ -102,3 +102,16 @@ utils.maybeDecode = url => {
   }
   return url;
 };
+
+utils.sanitizeArguments = function(optionsCandidate, cbCandidate) {
+  if (optionsCandidate instanceof Function) {
+    return {
+      cb: optionsCandidate,
+      options: undefined
+    };
+  }
+  return {
+    cb: cbCandidate,
+    options: optionsCandidate
+  };
+};

--- a/test/auth/oauth.tests.js
+++ b/test/auth/oauth.tests.js
@@ -462,9 +462,6 @@ describe('OAuthAuthenticator', function() {
     var userData = {
       refresh_token: 'refresh_token'
     };
-    var options = {
-      forwardedFor: '0.0.0.0'
-    };
 
     beforeEach(function() {
       this.authenticator = new Authenticator(validOptions);
@@ -534,26 +531,6 @@ describe('OAuthAuthenticator', function() {
         })
         .catch(done);
     });
-
-    it('should make it possible to pass auth0-forwarded-for header', function(done) {
-      nock.cleanAll();
-
-      var request = nock(API_URL)
-        .post(path, function() {
-          return this.getHeader('auth0-forwarded-for') === options.forwardedFor;
-        })
-        .reply(200);
-
-      this.authenticator
-        .refreshToken(userData, options)
-        .then(function() {
-          expect(request.isDone()).to.be.true;
-
-          done();
-        })
-        .catch(done);
-    });
-
     it('should use refresh_token as default grant type', function(done) {
       nock.cleanAll();
       var request = nock(API_URL)
@@ -576,9 +553,6 @@ describe('OAuthAuthenticator', function() {
     var userData = {
       access_token: 'TEST_ACCESS_TOKEN',
       connection: 'facebook'
-    };
-    var options = {
-      forwardedFor: '0.0.0.0'
     };
 
     beforeEach(function() {
@@ -686,25 +660,6 @@ describe('OAuthAuthenticator', function() {
 
         done();
       });
-    });
-
-    it('should make it possible to pass auth0-forwarded-for header', function(done) {
-      nock.cleanAll();
-
-      var request = nock(API_URL)
-        .post(path, function() {
-          return this.getHeader('auth0-forwarded-for') === options.forwardedFor;
-        })
-        .reply(200);
-
-      this.authenticator
-        .socialSignIn(userData, options)
-        .then(function() {
-          expect(request.isDone()).to.be.true;
-
-          done();
-        })
-        .catch(done);
     });
 
     it('should use application/json as Content-Type', function(done) {
@@ -852,32 +807,11 @@ describe('OAuthAuthenticator', function() {
         expect(request.isDone()).to.be.true;
       });
     });
-
-    it('should make it possible to pass auth0-forwarded-for header', function(done) {
-      nock.cleanAll();
-
-      const extension = { forwardedFor: '0.0.0.0' };
-      var data = extend(extension, options);
-      var request = nock(API_URL)
-        .post(path, function() {
-          return this.getHeader('auth0-forwarded-for') === extension.forwardedFor;
-        })
-        .reply(200);
-
-      this.authenticator
-        .clientCredentialsGrant(data)
-        .then(function() {
-          expect(request.isDone()).to.be.true;
-
-          done();
-        })
-        .catch(done);
-    });
   });
 
   describe('#authorizationCodeGrant', function() {
     var path = '/oauth/token';
-    var options = {
+    var data = {
       code: 'auth_code',
       redirect_uri: API_URL
     };
@@ -911,12 +845,12 @@ describe('OAuthAuthenticator', function() {
     });
 
     it('should accept a callback', function(done) {
-      this.authenticator.authorizationCodeGrant(options, done.bind(null, null));
+      this.authenticator.authorizationCodeGrant(data, done.bind(null, null));
     });
 
     it('should return a promise when no callback is provided', function(done) {
       this.authenticator
-        .authorizationCodeGrant(options)
+        .authorizationCodeGrant(data)
         .then(done.bind(null, null))
         .catch(done.bind(null, null));
     });
@@ -925,7 +859,7 @@ describe('OAuthAuthenticator', function() {
       var request = this.request;
 
       this.authenticator
-        .authorizationCodeGrant(options)
+        .authorizationCodeGrant(data)
         .then(function() {
           expect(request.isDone()).to.be.true;
 
@@ -939,8 +873,8 @@ describe('OAuthAuthenticator', function() {
 
       var request = nock(API_URL)
         .post(path, function(body) {
-          for (var property in options) {
-            if (options[property] !== body[property]) {
+          for (var property in data) {
+            if (data[property] !== body[property]) {
               return false;
             }
           }
@@ -950,7 +884,7 @@ describe('OAuthAuthenticator', function() {
         .reply(200);
 
       this.authenticator
-        .authorizationCodeGrant(options)
+        .authorizationCodeGrant(data)
         .then(function() {
           expect(request.isDone()).to.be.true;
 
@@ -969,7 +903,7 @@ describe('OAuthAuthenticator', function() {
         .reply(200);
 
       this.authenticator
-        .authorizationCodeGrant(options)
+        .authorizationCodeGrant(data)
         .then(function() {
           expect(request.isDone()).to.be.true;
 
@@ -988,7 +922,7 @@ describe('OAuthAuthenticator', function() {
         .reply(200);
 
       this.authenticator
-        .authorizationCodeGrant(options)
+        .authorizationCodeGrant(data)
         .then(function() {
           expect(request.isDone()).to.be.true;
 
@@ -1007,27 +941,6 @@ describe('OAuthAuthenticator', function() {
         .reply(200);
 
       this.authenticator
-        .authorizationCodeGrant(options)
-        .then(function() {
-          expect(request.isDone()).to.be.true;
-
-          done();
-        })
-        .catch(done);
-    });
-
-    it('should make it possible to pass auth0-forwarded-for header', function(done) {
-      nock.cleanAll();
-
-      const extension = { forwardedFor: '0.0.0.0' };
-      var data = extend(extension, options);
-      var request = nock(API_URL)
-        .post(path, function() {
-          return this.getHeader('auth0-forwarded-for') === extension.forwardedFor;
-        })
-        .reply(200);
-
-      this.authenticator
         .authorizationCodeGrant(data)
         .then(function() {
           expect(request.isDone()).to.be.true;
@@ -1039,7 +952,7 @@ describe('OAuthAuthenticator', function() {
 
     it('should use OAUthWithIDTokenValidation', function(done) {
       this.authenticator
-        .authorizationCodeGrant(options)
+        .authorizationCodeGrant(data)
         .then(function() {
           expect(OAUthWithIDTokenValidation.prototype.create.calledOnce).to.be.true;
           done();

--- a/test/auth/oauth.tests.js
+++ b/test/auth/oauth.tests.js
@@ -67,6 +67,9 @@ describe('OAuthAuthenticator', function() {
       password: 'pwd',
       connection: 'Username-Password-Authentication'
     };
+    var options = {
+      forwardedFor: '0.0.0.0'
+    };
 
     beforeEach(function() {
       this.authenticator = new Authenticator(validOptions);
@@ -230,6 +233,26 @@ describe('OAuthAuthenticator', function() {
         })
         .catch(done);
     });
+
+    it('should make it possible to pass auth0-forwarded-for header', function(done) {
+      nock.cleanAll();
+
+      var request = nock(API_URL)
+        .post(path, function() {
+          return this.getHeader('auth0-forwarded-for') === options.forwardedFor;
+        })
+        .reply(200);
+
+      this.authenticator
+        .signIn(userData, options)
+        .then(function() {
+          expect(request.isDone()).to.be.true;
+
+          done();
+        })
+        .catch(done);
+    });
+
     it('should use OAUthWithIDTokenValidation', function(done) {
       this.authenticator
         .signIn(userData)
@@ -246,6 +269,9 @@ describe('OAuthAuthenticator', function() {
     var userData = {
       username: 'username',
       password: 'pwd'
+    };
+    var options = {
+      forwardedFor: '0.0.0.0'
     };
 
     beforeEach(function() {
@@ -400,6 +426,26 @@ describe('OAuthAuthenticator', function() {
         })
         .catch(done);
     });
+
+    it('should make it possible to pass auth0-forwarded-for header', function(done) {
+      nock.cleanAll();
+
+      var request = nock(API_URL)
+        .post(path, function() {
+          return this.getHeader('auth0-forwarded-for') === options.forwardedFor;
+        })
+        .reply(200);
+
+      this.authenticator
+        .passwordGrant(userData, options)
+        .then(function() {
+          expect(request.isDone()).to.be.true;
+
+          done();
+        })
+        .catch(done);
+    });
+
     it('should use OAUthWithIDTokenValidation', function(done) {
       this.authenticator
         .passwordGrant(userData)
@@ -416,6 +462,10 @@ describe('OAuthAuthenticator', function() {
     var userData = {
       refresh_token: 'refresh_token'
     };
+    var options = {
+      forwardedFor: '0.0.0.0'
+    };
+
     beforeEach(function() {
       this.authenticator = new Authenticator(validOptions);
       this.request = nock(API_URL)
@@ -484,6 +534,26 @@ describe('OAuthAuthenticator', function() {
         })
         .catch(done);
     });
+
+    it('should make it possible to pass auth0-forwarded-for header', function(done) {
+      nock.cleanAll();
+
+      var request = nock(API_URL)
+        .post(path, function() {
+          return this.getHeader('auth0-forwarded-for') === options.forwardedFor;
+        })
+        .reply(200);
+
+      this.authenticator
+        .refreshToken(userData, options)
+        .then(function() {
+          expect(request.isDone()).to.be.true;
+
+          done();
+        })
+        .catch(done);
+    });
+
     it('should use refresh_token as default grant type', function(done) {
       nock.cleanAll();
       var request = nock(API_URL)
@@ -506,6 +576,9 @@ describe('OAuthAuthenticator', function() {
     var userData = {
       access_token: 'TEST_ACCESS_TOKEN',
       connection: 'facebook'
+    };
+    var options = {
+      forwardedFor: '0.0.0.0'
     };
 
     beforeEach(function() {
@@ -613,6 +686,25 @@ describe('OAuthAuthenticator', function() {
 
         done();
       });
+    });
+
+    it('should make it possible to pass auth0-forwarded-for header', function(done) {
+      nock.cleanAll();
+
+      var request = nock(API_URL)
+        .post(path, function() {
+          return this.getHeader('auth0-forwarded-for') === options.forwardedFor;
+        })
+        .reply(200);
+
+      this.authenticator
+        .socialSignIn(userData, options)
+        .then(function() {
+          expect(request.isDone()).to.be.true;
+
+          done();
+        })
+        .catch(done);
     });
 
     it('should use application/json as Content-Type', function(done) {
@@ -760,11 +852,32 @@ describe('OAuthAuthenticator', function() {
         expect(request.isDone()).to.be.true;
       });
     });
+
+    it('should make it possible to pass auth0-forwarded-for header', function(done) {
+      nock.cleanAll();
+
+      const extension = { forwardedFor: '0.0.0.0' };
+      var data = extend(extension, options);
+      var request = nock(API_URL)
+        .post(path, function() {
+          return this.getHeader('auth0-forwarded-for') === extension.forwardedFor;
+        })
+        .reply(200);
+
+      this.authenticator
+        .clientCredentialsGrant(data)
+        .then(function() {
+          expect(request.isDone()).to.be.true;
+
+          done();
+        })
+        .catch(done);
+    });
   });
 
   describe('#authorizationCodeGrant', function() {
     var path = '/oauth/token';
-    var data = {
+    var options = {
       code: 'auth_code',
       redirect_uri: API_URL
     };
@@ -798,12 +911,12 @@ describe('OAuthAuthenticator', function() {
     });
 
     it('should accept a callback', function(done) {
-      this.authenticator.authorizationCodeGrant(data, done.bind(null, null));
+      this.authenticator.authorizationCodeGrant(options, done.bind(null, null));
     });
 
     it('should return a promise when no callback is provided', function(done) {
       this.authenticator
-        .authorizationCodeGrant(data)
+        .authorizationCodeGrant(options)
         .then(done.bind(null, null))
         .catch(done.bind(null, null));
     });
@@ -812,7 +925,7 @@ describe('OAuthAuthenticator', function() {
       var request = this.request;
 
       this.authenticator
-        .authorizationCodeGrant(data)
+        .authorizationCodeGrant(options)
         .then(function() {
           expect(request.isDone()).to.be.true;
 
@@ -826,8 +939,8 @@ describe('OAuthAuthenticator', function() {
 
       var request = nock(API_URL)
         .post(path, function(body) {
-          for (var property in data) {
-            if (data[property] !== body[property]) {
+          for (var property in options) {
+            if (options[property] !== body[property]) {
               return false;
             }
           }
@@ -837,7 +950,7 @@ describe('OAuthAuthenticator', function() {
         .reply(200);
 
       this.authenticator
-        .authorizationCodeGrant(data)
+        .authorizationCodeGrant(options)
         .then(function() {
           expect(request.isDone()).to.be.true;
 
@@ -856,7 +969,7 @@ describe('OAuthAuthenticator', function() {
         .reply(200);
 
       this.authenticator
-        .authorizationCodeGrant(data)
+        .authorizationCodeGrant(options)
         .then(function() {
           expect(request.isDone()).to.be.true;
 
@@ -875,7 +988,7 @@ describe('OAuthAuthenticator', function() {
         .reply(200);
 
       this.authenticator
-        .authorizationCodeGrant(data)
+        .authorizationCodeGrant(options)
         .then(function() {
           expect(request.isDone()).to.be.true;
 
@@ -894,6 +1007,27 @@ describe('OAuthAuthenticator', function() {
         .reply(200);
 
       this.authenticator
+        .authorizationCodeGrant(options)
+        .then(function() {
+          expect(request.isDone()).to.be.true;
+
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should make it possible to pass auth0-forwarded-for header', function(done) {
+      nock.cleanAll();
+
+      const extension = { forwardedFor: '0.0.0.0' };
+      var data = extend(extension, options);
+      var request = nock(API_URL)
+        .post(path, function() {
+          return this.getHeader('auth0-forwarded-for') === extension.forwardedFor;
+        })
+        .reply(200);
+
+      this.authenticator
         .authorizationCodeGrant(data)
         .then(function() {
           expect(request.isDone()).to.be.true;
@@ -902,9 +1036,10 @@ describe('OAuthAuthenticator', function() {
         })
         .catch(done);
     });
+
     it('should use OAUthWithIDTokenValidation', function(done) {
       this.authenticator
-        .authorizationCodeGrant(data)
+        .authorizationCodeGrant(options)
         .then(function() {
           expect(OAUthWithIDTokenValidation.prototype.create.calledOnce).to.be.true;
           done();


### PR DESCRIPTION
### Changes

This PR implements [auth0-forwarded-for](https://auth0.com/docs/api-auth/tutorials/using-resource-owner-password-from-server-side#sending-the-end-user-ip-from-your-server) header passing in the Authentication Client.
User-facing methods now accept an additional argument `options`, right before callback, for example:
```js
client.passwordGrant(userData, {forwardFor: '1.2.3.4'}, callback);
```
This change is non-breaking. If there is no options object, the callback as a second argument will still work.

### References

#191 

### Testing

- [x] This change adds unit test coverage

I have also npm linked the module to my existing project and it seemed to do it's job.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
