### PR TITLE
JSDoc update in assignRolestoUser() from ManagementClient

### DIFF
--- a/src/management/index.js
+++ b/src/management/index.js
@@ -1349,7 +1349,7 @@ utils.wrapPropertyMethod(ManagementClient, 'getUserRoles', 'users.getRoles');
  *
  * @param   {Object}    params       params object
  * @param   {String}    params.id    user_id
- * @param   {String}    data         data object containing list of role IDs
+ * @param   {Object}    data         data object containing list of role IDs
  * @param   {String}    data.roles  Array of role IDs
  * @param   {Function}  [cb]                  Callback function.
  *


### PR DESCRIPTION
Correction of a parameter in `assignRolestoUser` method definition.

### Changes

Changed JSDoc parameter in method `assignRolestoUser`.

It's has to define parameter `data` as an `Object` (example: `{roles: [<role_id>]}`) instead of a `string`.
Because it's defined on [UsersManager](https://github.com/auth0/node-auth0/blob/master/src/management/UsersManager.js#L679) `assignRoles`.

### References

None

### Testing

None

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
