### PR TITLE
- Fix issue when a client uses the Issuer URL passed back from other …

### DIFF
--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -61,7 +61,10 @@ var AuthenticationClient = function(options) {
       'User-agent': 'node.js/' + process.version.replace('v', ''),
       'Content-Type': 'application/json'
     },
-    baseUrl: util.format(BASE_URL_FORMAT, options.domain),
+    baseUrl:
+      options.domain.length >= 8 && options.domain.substring(0, 8) === 'https://'
+        ? options.domain
+        : util.format(BASE_URL_FORMAT, options.domain),
     supportedAlgorithms: options.supportedAlgorithms,
     __bypassIdTokenValidation: options.__bypassIdTokenValidation
   };


### PR DESCRIPTION
…Auth0 Libraries.

- The issue is that you don't check if a string starts with https:// before trying to prepend https://.
- If it's a precondition, check it before trying to resolve it

### Changes

Please describe both what is changing and why this is important. Include:
I am checking if a passed in domain starts with "https://" before trying to prepend it. 
This is important because if a client is using the issuer sent back by Auth0's APIs as input to this library then this library will fail whenever trying to do requests. All requests will try to access a url of the form "https://https://%s"

### References

### Testing

Create an express app.
Add the express-jwt library as a middleware.
Create a new express middleware that creates an AuthenticationClient from this library and sets the domain option to be the req.user.iss from the express-jwt middleware.
Watch every request fail. 

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
