### PR TITLE
Fix base url double slash bug and https:// double pre-prending

### DIFF
--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -61,7 +61,10 @@ var AuthenticationClient = function(options) {
       'User-agent': 'node.js/' + process.version.replace('v', ''),
       'Content-Type': 'application/json'
     },
-    baseUrl: util.format(BASE_URL_FORMAT, options.domain),
+    baseUrl:
+      options.domain.length >= 8 && options.domain.substring(0, 8) === 'https://'
+        ? options.domain
+        : util.format(BASE_URL_FORMAT, options.domain),
     supportedAlgorithms: options.supportedAlgorithms,
     __bypassIdTokenValidation: options.__bypassIdTokenValidation
   };

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -63,8 +63,8 @@ var AuthenticationClient = function(options) {
     },
     baseUrl:
       options.domain.length >= 8 && options.domain.substring(0, 8) === 'https://'
-        ? options.domain
-        : util.format(BASE_URL_FORMAT, options.domain),
+        ? options.domain.replace(/\/$/, '')
+        : util.format(BASE_URL_FORMAT, options.domain).replace(/\/$/, ''),
     supportedAlgorithms: options.supportedAlgorithms,
     __bypassIdTokenValidation: options.__bypassIdTokenValidation
   };

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -61,10 +61,9 @@ var AuthenticationClient = function(options) {
       'User-agent': 'node.js/' + process.version.replace('v', ''),
       'Content-Type': 'application/json'
     },
-    baseUrl:
-      options.domain.length >= 8 && options.domain.substring(0, 8) === 'https://'
-        ? options.domain.replace(/\/$/, '')
-        : util.format(BASE_URL_FORMAT, options.domain).replace(/\/$/, ''),
+    baseUrl: options.domain.startsWith('https://')
+      ? util.format(BASE_URL_FORMAT, options.domain).replace(/\/$/, '')
+      : options.domain.replace(/\/$/, ''),
     supportedAlgorithms: options.supportedAlgorithms,
     __bypassIdTokenValidation: options.__bypassIdTokenValidation
   };


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

Currently if you pass in a URL for the domain option that ends in a slash then all request urls will take the form 
"https://%s//%s"

This is wrong. A better solution than mine would be to redo this whole library and construct URLs the proper way with: https://nodejs.org/api/url.html#url_the_whatwg_url_api

Not by concatenating strings together...

As well, 
I am checking if a passed in domain starts with "https://" before trying to prepend it.
If a client is using the issuer sent back by Auth0's APIs as input to this library (for example from the issuer returned by ( https://github.com/auth0/express-jwt ) then this library will fail whenever trying to do requests. All requests will try to access a url of the form "https://https://%s"

### References


### Testing

Create *any* client and pass in a domain that ends with a slash and starts with https://. Then log the output of your request url. It will have a form like "https://https://<base_url>//<endpoint>"


- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
