### PR TITLE
Update lru-memoizer dependency to avoid DeprecationWarning Buffer()

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "bluebird": "^3.5.5",
     "jsonwebtoken": "^8.5.1",
     "jwks-rsa": "^1.6.0",
-    "lru-memoizer": "^2.0.1",
+    "lru-memoizer": "^2.1.0",
     "object.assign": "^4.1.0",
     "request": "^2.88.0",
     "rest-facade": "^1.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2992,10 +2992,10 @@ lru-memoizer@^1.12.0:
     lru-cache "~4.0.0"
     very-fast-args "^1.1.0"
 
-lru-memoizer@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/lru-memoizer/-/lru-memoizer-2.0.1.tgz#f21e015bb6856483f574070be11ca16b0c010693"
-  integrity sha512-kGl+zlIqdQL24f0Q9IUSUZeSvA7nqXPFLA7suFh00v4KVqfXkZJtkPfTfXV/oQMSPfNr6VT4xGkRAUPhFnGyxQ==
+lru-memoizer@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/lru-memoizer/-/lru-memoizer-2.1.0.tgz#2551b29d5181188695d30f12f6a56fad5b418b61"
+  integrity sha512-oKjxgJhL+m1wfEkez7/a6iyRZUdohej+2u04qCaAQ7BBfx/qD4RH3jOQhPsd8Y3pcm7IhcNtE3kCEIDCMPiJFQ==
   dependencies:
     lodash.clonedeep "^4.5.0"
     lru-cache "~4.0.0"


### PR DESCRIPTION
### Changes

- updated lru-memoizer to latest version 2.1.0 to fix DeprecationWarning about Buffer()

### References

The newest lru-memoizer version is using the recommended porting from Buffer:
https://github.com/jfromaniello/lru-memoizer/compare/v2.0.1...v2.1.0

About the Buffer porting in general:
https://nodejs.org/fr/docs/guides/buffer-constructor-deprecation/

### Testing

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
