### PR TITLE
Update getRulesConfigs docs to include callback

### DIFF
--- a/src/management/index.js
+++ b/src/management/index.js
@@ -2394,6 +2394,7 @@ utils.wrapPropertyMethod(ManagementClient, 'setRulesConfig', 'rulesConfigs.set')
  *
  * @method    getRulesConfigs
  * @memberOf  module:management.ManagementClient.prototype
+ * @param     {Function}  [cb]  Callback function.
  *
  * @example
  *


### PR DESCRIPTION
Hi,

I have submitted a TypeScript PR a few days ago to include types for rules configs functions and with a reviewer we detected a mismatch in a library docs:
https://auth0.github.io/node-auth0/module-management.ManagementClient.html#getRulesConfigs that define `getRulesConfigs()` without a callback argument, however in example and the source code itself the callback is expected.

We would appreciate it if we could have the updated docs with a `getRulesConfigs(cb)`. 

This is a tiny PR, however let me know if I am wrong in my understanding or if I can help  you any further.

Kind regards :)