### PR TITLE
Return response.data where Axios is used

### DIFF
--- a/src/auth/TokensManager.js
+++ b/src/auth/TokensManager.js
@@ -71,7 +71,7 @@ TokensManager.prototype.getInfo = function(idToken, cb) {
     url: this.baseUrl + '/tokeninfo',
     data: { id_token: idToken },
     headers: headers
-  });
+  }).then(({ data }) => data);
 
   // Use callback if given.
   if (cb instanceof Function) {
@@ -161,7 +161,7 @@ TokensManager.prototype.getDelegationToken = function(data, cb) {
     url: this.baseUrl + '/delegation',
     data: body,
     headers: headers
-  });
+  }).then(({ data }) => data);
 
   // Use callback if given.
   if (cb instanceof Function) {

--- a/src/auth/UsersManager.js
+++ b/src/auth/UsersManager.js
@@ -73,7 +73,7 @@ UsersManager.prototype.getInfo = function(accessToken, cb) {
     method: 'GET',
     url: url,
     headers: headers
-  });
+  }).then(({ data }) => data);
 
   // Use callback if given.
   if (cb instanceof Function) {
@@ -158,7 +158,7 @@ UsersManager.prototype.impersonate = function(userId, settings, cb) {
     headers: headers,
     data: data,
     url: url
-  });
+  }).then(({ data }) => data);
 
   // Use callback if given.
   if (cb instanceof Function) {

--- a/src/management/JobsManager.js
+++ b/src/management/JobsManager.js
@@ -173,6 +173,7 @@ JobsManager.prototype.importUsers = function(data, cb) {
   var promise = options.tokenProvider.getAccessToken().then(function(access_token) {
     return axios
       .post(url, form, { headers: { ...headers, Authorization: `Bearer ${access_token}` } })
+      .then(({ data }) => data)
       .catch(function(err) {
         if (!err.response) {
           return Promise.reject(err);

--- a/src/management/JobsManager.js
+++ b/src/management/JobsManager.js
@@ -173,7 +173,6 @@ JobsManager.prototype.importUsers = function(data, cb) {
   var promise = options.tokenProvider.getAccessToken().then(function(access_token) {
     return axios
       .post(url, form, { headers: { ...headers, Authorization: `Bearer ${access_token}` } })
-      .then(({ data }) => data)
       .catch(function(err) {
         if (!err.response) {
           return Promise.reject(err);


### PR DESCRIPTION
### Changes

In https://github.com/auth0/node-auth0/pull/475, the request library was removed in favor of Axios. This introduced [a bug that causes the full HTTP response to be returned instead of just the `data` property from the response](https://github.com/auth0/node-auth0/issues/483).

This PR updates anywhere Axios is used to explicitly grab the `data` property from the response.

### References

Closes #483

### Testing

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
