### PR TITLE
Added docs for parameter client_id on requestChangePasswordEmail

### DIFF
--- a/src/auth/DatabaseAuthenticator.js
+++ b/src/auth/DatabaseAuthenticator.js
@@ -246,7 +246,8 @@ DatabaseAuthenticator.prototype.changePassword = function(userData, cb) {
  *
  * var data = {
  *   email: '{EMAIL}',
- *   connection: 'Username-Password-Authentication'
+ *   connection: 'Username-Password-Authentication',
+ *   client_id: 'OS1VzKTVjizL0VCc9Hx2ae2aTPXWy6BD
  * };
  *
  * auth0.database.requestChangePasswordEmail(data, function (err, message) {
@@ -260,6 +261,7 @@ DatabaseAuthenticator.prototype.changePassword = function(userData, cb) {
  * @param   {Object}    data              User credentials object.
  * @param   {String}    data.email        User email address.
  * @param   {String}    data.connection   Identity provider in use.
+ * @param   {String}    data.client_id    Client ID of the App the user should be returned to.
  * @param   {Function}  [cb]              Method callback.
  *
  * @return  {Promise|undefined}

--- a/src/auth/DatabaseAuthenticator.js
+++ b/src/auth/DatabaseAuthenticator.js
@@ -247,7 +247,7 @@ DatabaseAuthenticator.prototype.changePassword = function(userData, cb) {
  * var data = {
  *   email: '{EMAIL}',
  *   connection: 'Username-Password-Authentication',
- *   client_id: 'OS1VzKTVjizL0VCc9Hx2ae2aTPXWy6BD
+ *   client_id: 'OS1VzKTVjizL0VCc9Hx2ae2aTPXWy6BD'
  * };
  *
  * auth0.database.requestChangePasswordEmail(data, function (err, message) {
@@ -261,7 +261,7 @@ DatabaseAuthenticator.prototype.changePassword = function(userData, cb) {
  * @param   {Object}    data              User credentials object.
  * @param   {String}    data.email        User email address.
  * @param   {String}    data.connection   Identity provider in use.
- * @param   {String}    data.client_id    Client ID of the App the user should be returned to.
+ * @param   {String}    data.client_id    Client ID of the Application requesting the password change, to be included in the email template.
  * @param   {Function}  [cb]              Method callback.
  *
  * @return  {Promise|undefined}

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -407,6 +407,7 @@ AuthenticationClient.prototype.changePassword = function(data, cb) {
  * @param   {String}    data.email      User email.
  * @param   {String}    data.connection Identity provider for the user.
  * @param   {String}    data.client_id  Client ID of the App the user should be returned to.
+ * @param   {Function}  [cb]            Method callback.
  *
  * @return  {Promise|undefined}
  */

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -391,7 +391,8 @@ AuthenticationClient.prototype.changePassword = function(data, cb) {
  *
  * var data = {
  *   email: '{EMAIL}',
- *   connection: 'Username-Password-Authentication'
+ *   connection: 'Username-Password-Authentication',
+ *   client_id: 'OS1VzKTVjizL0VCc9Hx2ae2aTPXWy6BD
  * };
  *
  * auth0.requestChangePasswordEmail(data, function (err, message) {
@@ -405,6 +406,7 @@ AuthenticationClient.prototype.changePassword = function(data, cb) {
  * @param   {Object}    data            User data object.
  * @param   {String}    data.email      User email.
  * @param   {String}    data.connection Identity provider for the user.
+ * @param   {String}    data.client_id  Client ID of the App the user should be returned to.
  *
  * @return  {Promise|undefined}
  */

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -142,9 +142,10 @@ var AuthenticationClient = function(options) {
  *   }
  * };
  *
- * @param   {Object}  data              User data object.
- * @param   {String}  data.email        User email address.
- * @param   {Object}  [data.authParams] Authentication parameters.
+ * @param   {Object}    data              User data object.
+ * @param   {String}    data.email        User email address.
+ * @param   {Object}    [data.authParams] Authentication parameters.
+ * @param   {Function}  [cb]              Method callback.
  *
  * @return  {Promise|undefined}
  */
@@ -180,9 +181,10 @@ AuthenticationClient.prototype.requestMagicLink = function(data, cb) {
  *   }
  * };
  *
- * @param   {Object}  data              User data object.
- * @param   {String}  data.email        User email address.
- * @param   {Object}  [data.authParams] Authentication parameters.
+ * @param   {Object}    data              User data object.
+ * @param   {String}    data.email        User email address.
+ * @param   {Object}    [data.authParams] Authentication parameters.
+ * @param   {Function}  [cb]              Method callback.
  *
  * @return  {Promise|undefined}
  */
@@ -216,8 +218,9 @@ AuthenticationClient.prototype.requestEmailCode = function(data, cb) {
  *
  * });
  *
- * @param   {Object}  data                User data object.
- * @param   {String}  data.phone_number   The user phone number.
+ * @param   {Object}    data                User data object.
+ * @param   {String}    data.phone_number   The user phone number.
+ * @param   {Function}  [cb]                Method callback.
  *
  * @return  {Promise|undefined}
  */
@@ -262,11 +265,12 @@ AuthenticationClient.prototype.requestSMSCode = function(data, cb) {
  *   token_type: String
  * }
  *
- * @param   {Object}  data              Credentials object.
- * @param   {String}  data.username     Phone number.
- * @param   {String}  data.password     Verification code.
- * @param   {String}  data.target       Target client ID.
- * @param   {String}  data.grant_type   Grant type.
+ * @param   {Object}    data              Credentials object.
+ * @param   {String}    data.username     Phone number.
+ * @param   {String}    data.password     Verification code.
+ * @param   {String}    data.target       Target client ID.
+ * @param   {String}    data.grant_type   Grant type.
+ * @param   {Function}  [cb]              Method callback.
  *
  * @return  {Promise|undefined}
  */
@@ -309,11 +313,12 @@ AuthenticationClient.prototype.verifySMSCode = function(data, cb) {
  *   console.log(token);
  * });
  *
- * @param   {Object}  data              Token data object.
- * @param   {String}  data.id_token     The user ID token.
- * @param   {String}  data.api_type     The API type (aws, firebase, etc).
- * @param   {String}  data.target       The target client ID.
- * @param   {String}  data.grant_type   The grant type.
+ * @param   {Object}    data              Token data object.
+ * @param   {String}    data.id_token     The user ID token.
+ * @param   {String}    data.api_type     The API type (aws, firebase, etc).
+ * @param   {String}    data.target       The target client ID.
+ * @param   {String}    data.grant_type   The grant type.
+ * @param   {Function}  [cb]              Method callback.
  *
  * @return  {Promise|undefined}
  */
@@ -362,6 +367,7 @@ AuthenticationClient.prototype.getDelegationToken = function(data, cb) {
  * @param   {String}    data.email      User email.
  * @param   {String}    data.password   User password.
  * @param   {String}    data.connection Identity provider for the user.
+ * @param   {Function}  [cb]            Method callback.
  *
  * @return  {Promise|undefined}
  */

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -392,7 +392,7 @@ AuthenticationClient.prototype.changePassword = function(data, cb) {
  * var data = {
  *   email: '{EMAIL}',
  *   connection: 'Username-Password-Authentication',
- *   client_id: 'OS1VzKTVjizL0VCc9Hx2ae2aTPXWy6BD
+ *   client_id: 'OS1VzKTVjizL0VCc9Hx2ae2aTPXWy6BD'
  * };
  *
  * auth0.requestChangePasswordEmail(data, function (err, message) {
@@ -406,7 +406,7 @@ AuthenticationClient.prototype.changePassword = function(data, cb) {
  * @param   {Object}    data            User data object.
  * @param   {String}    data.email      User email.
  * @param   {String}    data.connection Identity provider for the user.
- * @param   {String}    data.client_id  Client ID of the App the user should be returned to.
+ * @param   {String}    data.client_id  Client ID of the Application requesting the password change, to be included in the email template.
  * @param   {Function}  [cb]            Method callback.
  *
  * @return  {Promise|undefined}


### PR DESCRIPTION
### Changes

The parameter `client_id` which can be actually passed to `requestChangePasswordEmail` is not documented. I think it should be added though.

Since it's my first PR here: docs are generated on release altogether, right? So my changes should be sufficient?

### References

I made this PR in response to this post from the community since I ran into that issue not knowing I could configure it.

https://community.auth0.com/t/password-reset-form-no-back-to-app-button/42948/6?u=vui

### Testing

No tests needed

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
