### PR TITLE
Update JobsManager to return response data

### DIFF
--- a/src/management/JobsManager.js
+++ b/src/management/JobsManager.js
@@ -173,6 +173,7 @@ JobsManager.prototype.importUsers = function(data, cb) {
   var promise = options.tokenProvider.getAccessToken().then(function(access_token) {
     return axios
       .post(url, form, { headers: { ...headers, Authorization: `Bearer ${access_token}` } })
+      .then(({ data }) => data)
       .catch(function(err) {
         if (!err.response) {
           return Promise.reject(err);

--- a/test/management/jobs.tests.js
+++ b/test/management/jobs.tests.js
@@ -268,11 +268,21 @@ describe('JobsManager', function() {
       users: usersFilePath,
       connection_id: 'con_test'
     };
+    var payload = {
+      status: 'pending',
+      type: 'users_import',
+      created_at: '',
+      id: 'job_0000000000000001',
+      connection_id: 'con_0000000000000001',
+      upsert: false,
+      external_id: '',
+      send_completion_email: true
+    };
 
     beforeEach(function() {
       this.request = nock(API_URL)
         .post('/jobs/users-imports')
-        .reply(200);
+        .reply(200, payload);
     });
 
     it('should accept a callback', function(done) {
@@ -285,6 +295,16 @@ describe('JobsManager', function() {
       this.jobs
         .importUsers(data)
         .then(done.bind(null, null))
+        .catch(done.bind(null, null));
+    });
+
+    it('should return a promise with the api response as the value passed back', function(done) {
+      this.jobs
+        .importUsers(data)
+        .then(data => {
+          expect(data).to.eql(payload);
+          done();
+        })
         .catch(done.bind(null, null));
     });
 


### PR DESCRIPTION
Currently Tokens and User manager return response data, while Jobs is returning the request.  To make the experience consistent updating the Jobs manager to return data

closes #467 