### PR TITLE
JobsManager handling importUsers response payload

### DIFF
--- a/src/management/JobsManager.js
+++ b/src/management/JobsManager.js
@@ -200,6 +200,49 @@ JobsManager.prototype.importUsers = function(data, cb) {
 };
 
 /**
+ * Given a path to a file and a connection id, create a new job that imports the
+ * users contained in the file or JSON string and associate them with the given
+ * connection.
+ *
+ * @method   importUsersJob
+ * @memberOf module:management.JobsManager.prototype
+ *
+ * @example
+ * var params = {
+ *   connection_id: '{CONNECTION_ID}',
+ *   users: '{PATH_TO_USERS_FILE}' // or users_json: '{USERS_JSON_STRING}'
+ * };
+ *
+ * management.jobs.importUsers(params, function (err) {
+ *   if (err) {
+ *     // Handle error.
+ *   }
+ * });
+ *
+ * @param   {Object}    data                          Users import data.
+ * @param   {String}    data.connection_id            connection_id of the connection to which users will be imported.
+ * @param   {String}    [data.users]                  Path to the users data file. Either users or users_json is mandatory.
+ * @param   {String}    [data.users_json]             JSON data for the users.
+ * @param   {Boolean}   [data.upsert]                 Whether to update users if they already exist (true) or to ignore them (false).
+ * @param   {Boolean}   [data.send_completion_email]  Whether to send a completion email to all tenant owners when the job is finished (true) or not (false).
+ * @param   {Function}  [cb]                          Callback function.
+ *
+ * @return  {Promise|undefined}
+ */
+JobsManager.prototype.importUsersJob = function(data, cb) {
+  var promise = this.importUsers(data).then(response => response.data);
+
+  // Don't return a promise if a callback was given.
+  if (cb && cb instanceof Function) {
+    promise.then(cb.bind(null, null)).catch(cb);
+
+    return;
+  }
+
+  return promise;
+};
+
+/**
  * Export all users to a file using a long running job.
  *
  * @method   exportUsers

--- a/test/management/jobs.tests.js
+++ b/test/management/jobs.tests.js
@@ -288,6 +288,31 @@ describe('JobsManager', function() {
         .catch(done.bind(null, null));
     });
 
+    it('should have the payload in response.data', function(done) {
+      nock.cleanAll();
+      var payload = {
+        status: 'pending',
+        type: 'users_import',
+        created_at: '',
+        id: 'job_0000000000000001',
+        connection_id: 'con_0000000000000001',
+        upsert: false,
+        external_id: '',
+        send_completion_email: true
+      };
+      var request = nock(API_URL)
+        .post('/jobs/users-imports')
+        .reply(200, payload);
+
+      this.jobs
+        .importUsers(data)
+        .then(response => {
+          expect(response.data).to.deep.equal(payload);
+          done();
+        })
+        .catch(err => done(err));
+    });
+
     it('should pass request errors to the promise catch handler', function(done) {
       nock.cleanAll();
 
@@ -535,6 +560,58 @@ describe('JobsManager', function() {
 
         done();
       });
+    });
+  });
+
+  describe('#importUsersJob', function() {
+    var data = {
+      users: usersFilePath,
+      connection_id: 'con_test'
+    };
+
+    beforeEach(function() {
+      this.request = nock(API_URL)
+        .post('/jobs/users-imports')
+        .reply(200);
+    });
+
+    it('should accept a callback', function(done) {
+      this.jobs.importUsersJob(data, function() {
+        done();
+      });
+    });
+
+    it('should return a promise if no callback is given', function(done) {
+      this.jobs
+        .importUsersJob(data)
+        .then(done.bind(null, null))
+        .catch(done.bind(null, null));
+    });
+
+    it('should extract data from the response', function(done) {
+      nock.cleanAll();
+
+      var payload = {
+        status: 'pending',
+        type: 'users_import',
+        created_at: '',
+        id: 'job_0000000000000001',
+        connection_id: 'con_0000000000000001',
+        upsert: false,
+        external_id: '',
+        send_completion_email: true
+      };
+      var request = nock(API_URL)
+        .post('/jobs/users-imports')
+        .reply(200, payload);
+
+      this.jobs
+        .importUsersJob(data)
+        .then(response => {
+          expect(response).to.deep.equal(payload);
+          done();
+        })
+        .catch(err => done(err));
     });
   });
 


### PR DESCRIPTION
Currently TokensManager and UserManager return response data, while Jobs is returning the whole response.  To avoid a breaking change, and make the experience consistent with the Jobs manager, we are adding a new function `importUsersJob` that will extract the data from the response

Follow up to #491 
Closes #467