### PR TITLE
fix: guardian-related code examples

### DIFF
--- a/src/management/GuardianManager.js
+++ b/src/management/GuardianManager.js
@@ -76,7 +76,7 @@ var GuardianManager = function(options) {
   this.factors = new RetryRestClient(guardianFactorsAuth0RestClient, options.retry);
 
   /**
-   * Provides an abstraction layer for retrieving Guardian factors.
+   * Provides an abstraction layer for retrieving Guardian factor templates.
    *
    * @type {external:RestClient}
    */
@@ -167,6 +167,7 @@ utils.wrapPropertyMethod(GuardianManager, 'createEnrollmentTicket', 'tickets.cre
  * @method    getFactors
  * @memberOf  module:management.GuardianManager.prototype
  *
+ * @example
  * management.guardian.getFactors(function (err, factors) {
  *   console.log(factors.length);
  * });
@@ -183,6 +184,7 @@ utils.wrapPropertyMethod(GuardianManager, 'getFactors', 'factors.getAll');
  * @method    getFactorProvider
  * @memberOf  module:management.GuardianManager.prototype
  *
+ * @example
  * management.guardian.getFactorProvider({ name: 'sms', provider: 'twilio'}, function (err, provider) {
  *   console.log(provider);
  * });
@@ -200,12 +202,13 @@ utils.wrapPropertyMethod(GuardianManager, 'getFactorProvider', 'factorsProviders
  * @method    updateFactorProvider
  * @memberOf  module:management.GuardianManager.prototype
  *
+ * @example
  * management.guardian.updateFactorProvider({ name: 'sms', provider: 'twilio' }, {
- *  messaging_service_sid: 'XXXXXXXXXXXXXX',
- *  auth_token: 'XXXXXXXXXXXXXX',
- *  sid: 'XXXXXXXXXXXXXX'
- * }, function(err, provider) {
- *  console.log(provider);
+ *   messaging_service_sid: 'XXXXXXXXXXXXXX',
+ *   auth_token: 'XXXXXXXXXXXXXX',
+ *   sid: 'XXXXXXXXXXXXXX'
+ * }, function (err, provider) {
+ *   console.log(provider);
  * });
  *
  * @param   {Object}    params            Factor provider parameters.
@@ -222,6 +225,7 @@ utils.wrapPropertyMethod(GuardianManager, 'updateFactorProvider', 'factorsProvid
  * @method    getFactorTemplates
  * @memberOf  module:management.GuardianManager.prototype
  *
+ * @example
  * management.guardian.getFactorTemplates({ name: 'sms' }, function (err, templates) {
  *   console.log(templates);
  * });
@@ -239,11 +243,12 @@ utils.wrapPropertyMethod(GuardianManager, 'getFactorTemplates', 'factorsTemplate
  * @method    updateFactorTemplates
  * @memberOf  module:management.GuardianManager.prototype
  *
+ * @example
  * management.guardian.updateFactorProvider({ name: 'sms' }, {
- *  enrollment_message: "{{code}} is your verification code for {{tenant.friendly_name}}. Please enter this code to verify your enrollment.",
- *  verification_message: "{{code}} is your verification code for {{tenant.friendly_name}}"
- * }, function(err, templates) {
- *  console.log(templates);
+ *   enrollment_message: "{{code}} is your verification code for {{tenant.friendly_name}}. Please enter this code to verify your enrollment.",
+ *   verification_message: "{{code}} is your verification code for {{tenant.friendly_name}}"
+ * }, function (err, templates) {
+ *   console.log(templates);
  * });
  *
  * @param   {Object}    params            Factor parameters.
@@ -260,10 +265,11 @@ utils.wrapPropertyMethod(GuardianManager, 'updateFactorTemplates', 'factorsTempl
  * @method    updateFactor
  * @memberOf  module:management.GuardianManager.prototype
  *
+ * @example
  * management.guardian.updateFactor({ name: 'sms' }, {
- *  enabled: true
- * }, function(err, factor) {
- *  console.log(factor);
+ *   enabled: true
+ * }, function (err, factor) {
+ *   console.log(factor);
  * });
  *
  * @param   {Object}    params            Factor parameters.

--- a/src/management/index.js
+++ b/src/management/index.js
@@ -2567,6 +2567,7 @@ utils.wrapPropertyMethod(
  * @method    getGuardianFactors
  * @memberOf  module:management.ManagementClient.prototype
  *
+ * @example
  * management.getGuardianFactors(function (err, factors) {
  *   console.log(factors.length);
  * });
@@ -2583,6 +2584,7 @@ utils.wrapPropertyMethod(ManagementClient, 'getGuardianFactors', 'guardian.facto
  * @method    getGuardianFactorProvider
  * @memberOf  module:management.ManagementClient.prototype
  *
+ * @example
  * management.getFactorProvider({ name: 'sms', provider: 'twilio'}, function (err, provider) {
  *   console.log(provider);
  * });
@@ -2604,12 +2606,13 @@ utils.wrapPropertyMethod(
  * @method    updateFactorProvider
  * @memberOf  module:management.ManagementClient.prototype
  *
+ * @example
  * management.updateGuardianFactorProvider({ name: 'sms', provider: 'twilio' }, {
- *  messaging_service_sid: 'XXXXXXXXXXXXXX',
- *  auth_token: 'XXXXXXXXXXXXXX',
- *  sid: 'XXXXXXXXXXXXXX'
- * }, function(err, provider) {
- *  console.log(provider);
+ *   messaging_service_sid: 'XXXXXXXXXXXXXX',
+ *   auth_token: 'XXXXXXXXXXXXXX',
+ *   sid: 'XXXXXXXXXXXXXX'
+ * }, function (err, provider) {
+ *   console.log(provider);
  * });
  *
  * @param   {Object}    params            Factor provider parameters.
@@ -2630,6 +2633,7 @@ utils.wrapPropertyMethod(
  * @method    getGuardianFactorTemplates
  * @memberOf  module:management.ManagementClient.prototype
  *
+ * @example
  * management.getGuardianFactorTemplates({ name: 'sms' }, function (err, templates) {
  *   console.log(templates);
  * });
@@ -2651,11 +2655,12 @@ utils.wrapPropertyMethod(
  * @method    updateGuardianFactorTemplates
  * @memberOf  module:management.ManagementClient.prototype
  *
+ * @example
  * management.updateGuardianFactorTemplates({ name: 'sms' }, {
- *  enrollment_message: "{{code}} is your verification code for {{tenant.friendly_name}}. Please enter this code to verify your enrollment.",
- *  verification_message: "{{code}} is your verification code for {{tenant.friendly_name}}"
- * }, function(err, templates) {
- *  console.log(templates);
+ *   enrollment_message: "{{code}} is your verification code for {{tenant.friendly_name}}. Please enter this code to verify your enrollment.",
+ *   verification_message: "{{code}} is your verification code for {{tenant.friendly_name}}"
+ * }, function (err, templates) {
+ *   console.log(templates);
  * });
  *
  * @param   {Object}    params            Factor parameters.
@@ -2676,10 +2681,11 @@ utils.wrapPropertyMethod(
  * @method    updateGuardianFactor
  * @memberOf  module:management.ManagementClient.prototype
  *
+ * @example
  * management.updateGuardianFactor({ name: 'sms' }, {
- *  enabled: true
- * }, function(err, factor) {
- *  console.log(factor);
+ *   enabled: true
+ * }, function (err, factor) {
+ *   console.log(factor);
  * });
  *
  * @param   {Object}    params            Factor parameters.


### PR DESCRIPTION
### Changes

Our public docs do not render properly for some of the guardian endpoints/methods. Some methods are missing:

![image](https://user-images.githubusercontent.com/1411117/85165651-265e9e00-b234-11ea-9cbb-e2b4bd117905.png)

By adding the missing `@example` tokens, the methods are all documented properly:
![image](https://user-images.githubusercontent.com/1411117/85165842-6b82d000-b234-11ea-9cfe-a583b3f9f4a9.png)

I also made the indentation uniform across example snippets.

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

You can generate the documentation locally using `npm run jsdoc:generate` and browsing the resulting docs.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
