### PR TITLE
fix: management methods throwing error on access

### DIFF
--- a/src/management/index.js
+++ b/src/management/index.js
@@ -2558,7 +2558,7 @@ utils.wrapPropertyMethod(ManagementClient, 'deleteCustomDomain', 'customDomains.
 utils.wrapPropertyMethod(
   ManagementClient,
   'createGuardianEnrollmentTicket',
-  'guardian.tickets.create'
+  'guardian.createEnrollmentTicket'
 );
 
 /**
@@ -2576,7 +2576,7 @@ utils.wrapPropertyMethod(
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(ManagementClient, 'getGuardianFactors', 'guardian.factors.getAll');
+utils.wrapPropertyMethod(ManagementClient, 'getGuardianFactors', 'guardian.getFactors');
 
 /**
  * Get Guardian factor provider configuration
@@ -2597,7 +2597,7 @@ utils.wrapPropertyMethod(ManagementClient, 'getGuardianFactors', 'guardian.facto
 utils.wrapPropertyMethod(
   ManagementClient,
   'getGuardianFactorProvider',
-  'guardian.factorsProviders.get'
+  'guardian.getFactorProvider'
 );
 
 /**
@@ -2624,7 +2624,7 @@ utils.wrapPropertyMethod(
 utils.wrapPropertyMethod(
   ManagementClient,
   'updateGuardianFactorProvider',
-  'guardian.factorsProviders.update'
+  'guardian.updateFactorProvider'
 );
 
 /**
@@ -2646,7 +2646,7 @@ utils.wrapPropertyMethod(
 utils.wrapPropertyMethod(
   ManagementClient,
   'getGuardianFactorTemplates',
-  'guardian.factorsTemplates.get'
+  'guardian.getFactorTemplates'
 );
 
 /**
@@ -2672,7 +2672,7 @@ utils.wrapPropertyMethod(
 utils.wrapPropertyMethod(
   ManagementClient,
   'updateGuardianFactorTemplates',
-  'guardian.factorsTemplates.update'
+  'guardian.updateFactorTemplates'
 );
 
 /**
@@ -2694,7 +2694,7 @@ utils.wrapPropertyMethod(
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(ManagementClient, 'updateGuardianFactor', 'guardian.factors.update');
+utils.wrapPropertyMethod(ManagementClient, 'updateGuardianFactor', 'guardian.updateFactor');
 
 /**
  * Get all roles.

--- a/src/utils.js
+++ b/src/utils.js
@@ -50,6 +50,9 @@ utils.generateClientInfo = function() {
  */
 utils.wrapPropertyMethod = function(Parent, name, propertyMethod) {
   var path = propertyMethod.split('.');
+  if (path.length > 2) {
+    throw new Error('wrapPropertyMethod() only supports one level of nesting for propertyMethod');
+  }
   var property = path.shift();
   var method = path.pop();
 

--- a/test/management/management-client.tests.js
+++ b/test/management/management-client.tests.js
@@ -810,7 +810,6 @@ describe('ManagementClient', function() {
   });
 
   describe('instance methods', function() {
-    var method;
     var methods = [
       'getConnections',
       'createConnection',
@@ -839,7 +838,7 @@ describe('ManagementClient', function() {
       'getUsers',
       'getUser',
       'deleteAllUsers',
-      'deleteUsers',
+      'deleteUser',
       'createUser',
       'updateUser',
       'getBlacklistedTokens',
@@ -860,6 +859,13 @@ describe('ManagementClient', function() {
       'setRulesConfig',
       'getRulesConfigs',
       'deleteRulesConfig',
+      'createGuardianEnrollmentTicket',
+      'getGuardianFactors',
+      'getGuardianFactorProvider',
+      'updateGuardianFactorProvider',
+      'getGuardianFactorTemplates',
+      'updateGuardianFactorTemplates',
+      'updateGuardianFactor',
       'getUserBlocks',
       'unblockUser',
       'getUserBlocksByIdentifier',
@@ -872,12 +878,10 @@ describe('ManagementClient', function() {
       this.client = new ManagementClient(config);
     });
 
-    for (var i = 0, l = methods.length; i < l; i++) {
-      method = methods[i];
-
+    methods.forEach(function (method) {
       it('should have a ' + method + ' method', function() {
         expect(this.client[method]).to.exist.to.be.an.instanceOf(Function);
       });
-    }
+    });
   });
 });


### PR DESCRIPTION
### Changes

A few of the methods defined directly on the ManagementClient are throwing errors when accessed:
```
var ManagementClient = require('auth0').ManagementClient;
var management = new ManagementClient({
  token: '{YOUR_API_V2_TOKEN}',
  domain: '{YOUR_ACCOUNT}.auth0.com'
});
management.updateGuardianFactor
```
Throws:
```
TypeError: Cannot read property 'bind' of undefined
    at ManagementClient.get (./node-auth0/src/utils.js:59:37)
```
After debugging, I found that the error comes from the `utils.wrapPropertyMethod()` method that only supports a single level of nesting for `propertyMethod` (ex. `a.b` works, but not `a.b.c`).

In this PR, I review all methods defined on `ManagementClient` and ensure they all use one level of nesting instead of 2.

I also fixed the unit test that was supposed to catch this.

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
