### PR TITLE
feat(guardian): support policies, selected-provider, message-types methods [MFA-310]

### DIFF
--- a/src/management/GuardianManager.js
+++ b/src/management/GuardianManager.js
@@ -123,7 +123,7 @@ var GuardianManager = function(options) {
    * @type {external:RestClient}
    */
   var guardianFactorsPhoneSelectedProviderAuth0RestClient = new Auth0RestClient(
-    options.baseUrl + '/guardian/factors/phone/selected-provider',
+    options.baseUrl + '/guardian/factors/sms/selected-provider',
     clientOptions,
     options.tokenProvider
   );

--- a/src/management/GuardianManager.js
+++ b/src/management/GuardianManager.js
@@ -118,32 +118,32 @@ var GuardianManager = function(options) {
   this.policies = new RetryRestClient(guardianPoliciesAuth0RestClient, options.retry);
 
   /**
-   * Provides an abstraction layer for retrieving a Guardian factor selected provider.
+   * Provides an abstraction layer for retrieving Guardian phone factor selected provider.
    *
    * @type {external:RestClient}
    */
-  var guardianFactorsSelectedProviderAuth0RestClient = new Auth0RestClient(
-    options.baseUrl + '/guardian/factors/:name/selected-provider',
+  var guardianFactorsPhoneSelectedProviderAuth0RestClient = new Auth0RestClient(
+    options.baseUrl + '/guardian/factors/phone/selected-provider',
     clientOptions,
     options.tokenProvider
   );
-  this.factorsSelectedProvider = new RetryRestClient(
-    guardianFactorsSelectedProviderAuth0RestClient,
+  this.factorsPhoneSelectedProvider = new RetryRestClient(
+    guardianFactorsPhoneSelectedProviderAuth0RestClient,
     options.retry
   );
 
   /**
-   * Provides an abstraction layer for retrieving Guardian factor message types.
+   * Provides an abstraction layer for retrieving Guardian phone factor message types.
    *
    * @type {external:RestClient}
    */
-  var guardianFactorsMessageTypesAuth0RestClient = new Auth0RestClient(
-    options.baseUrl + '/guardian/factors/:name/message-types',
+  var guardianFactorsPhoneMessageTypesAuth0RestClient = new Auth0RestClient(
+    options.baseUrl + '/guardian/factors/phone/message-types',
     clientOptions,
     options.tokenProvider
   );
-  this.factorsMessageTypes = new RetryRestClient(
-    guardianFactorsMessageTypesAuth0RestClient,
+  this.factorsPhoneMessageTypes = new RetryRestClient(
+    guardianFactorsPhoneMessageTypesAuth0RestClient,
     options.retry
   );
 };
@@ -361,43 +361,40 @@ utils.wrapPropertyMethod(GuardianManager, 'getPolicies', 'policies.get');
 utils.wrapPropertyMethod(GuardianManager, 'updatePolicies', 'policies.update');
 
 /**
- * Get the Guardian factor's selected provider
+ * Get the Guardian phone factor's selected provider
  *
- * @method    getFactorSelectedProvider
+ * @method    getPhoneFactorSelectedProvider
  * @memberOf  module:management.GuardianManager.prototype
  *
  * @example
- * management.guardian.getFactorSelectedProvider({ name: 'phone' }, function (err, selectedProvider) {
+ * management.guardian.getPhoneFactorSelectedProvider(function (err, selectedProvider) {
  *   console.log(selectedProvider);
  * });
  *
- * @param   {Object}    params            Factor provider parameters.
- * @param   {String}    params.name       Factor name (only `"phone"` is supported).
  * @param   {Function}  [cb]              Callback function.
  *
  * @return  {Promise|undefined}
  */
 utils.wrapPropertyMethod(
   GuardianManager,
-  'getFactorSelectedProvider',
-  'factorsSelectedProvider.get'
+  'getPhoneFactorSelectedProvider',
+  'factorsPhoneSelectedProvider.get'
 );
 
 /**
- * Update the Guardian factor's selected provider
+ * Update the Guardian phone factor's selected provider
  *
- * @method    updateFactorSelectedProvider
+ * @method    updatePhoneFactorSelectedProvider
  * @memberOf  module:management.GuardianManager.prototype
  *
  * @example
- * management.guardian.updateFactorSelectedProvider({ name: 'phone' }, {
+ * management.guardian.updatePhoneFactorSelectedProvider({}, {
  *   provider: 'twilio'
  * }, function (err, factor) {
  *   console.log(factor);
  * });
  *
- * @param   {Object}    params            Factor provider parameters.
- * @param   {String}    params.name       Factor name (only `"phone"` is supported).
+ * @param   {Object}    params            Parameters.
  * @param   {Object}    data              Updated selected provider data.
  * @param   {String}    data.provider     Name of the selected provider
  * @param   {Function}  [cb]              Callback function.
@@ -406,50 +403,55 @@ utils.wrapPropertyMethod(
  */
 utils.wrapPropertyMethod(
   GuardianManager,
-  'updateFactorSelectedProvider',
-  'factorsSelectedProvider.update'
+  'updatePhoneFactorSelectedProvider',
+  'factorsPhoneSelectedProvider.update'
 );
 
 /**
- * Get the Guardian factor's message types
+ * Get the Guardian phone factor's message types
  *
- * @method    getFactorMessageTypes
+ * @method    getPhoneFactorMessageTypes
  * @memberOf  module:management.GuardianManager.prototype
  *
  * @example
- * management.guardian.getFactorMessageTypes({ name: 'phone' }, function (err, messageTypes) {
+ * management.guardian.getPhoneFactorMessageTypes(function (err, messageTypes) {
  *   console.log(messageTypes);
  * });
  *
- * @param   {Object}    params            Factor provider parameters.
- * @param   {String}    params.name       Factor name (only `"phone"` is supported).
  * @param   {Function}  [cb]              Callback function.
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(GuardianManager, 'getFactorMessageTypes', 'factorsMessageTypes.get');
+utils.wrapPropertyMethod(
+  GuardianManager,
+  'getPhoneFactorMessageTypes',
+  'factorsPhoneMessageTypes.get'
+);
 
 /**
- * Update the Guardian factor's message types
+ * Update the Guardian phone factor's message types
  *
- * @method    updateFactorMessageTypes
+ * @method    updatePhoneFactorMessageTypes
  * @memberOf  module:management.GuardianManager.prototype
  *
  * @example
- * management.guardian.updateFactorMessageTypes({ name: 'phone' }, {
+ * management.guardian.updatePhoneFactorMessageTypes({}, {
  *   message_types: ['sms', 'voice']
  * }, function (err, factor) {
  *   console.log(factor);
  * });
  *
- * @param   {Object}    params                Factor provider parameters.
- * @param   {String}    params.name           Factor name (only `"phone"` is supported).
+ * @param   {Object}    params                Parameters.
  * @param   {Object}    data                  Updated selected provider data.
  * @param   {String[]}  data.message_types    Message types (only `"sms"` and `"voice"` are supported).
  * @param   {Function}  [cb]                  Callback function.
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(GuardianManager, 'updateFactorMessageTypes', 'factorsMessageTypes.update');
+utils.wrapPropertyMethod(
+  GuardianManager,
+  'updatePhoneFactorMessageTypes',
+  'factorsPhoneMessageTypes.update'
+);
 
 module.exports = GuardianManager;

--- a/src/management/GuardianManager.js
+++ b/src/management/GuardianManager.js
@@ -104,6 +104,48 @@ var GuardianManager = function(options) {
     guardianFactorsProvidersAuth0RestClient,
     options.retry
   );
+
+  /**
+   * Provides an abstraction layer for retrieving Guardian policies.
+   *
+   * @type {external:RestClient}
+   */
+  var guardianPoliciesAuth0RestClient = new Auth0RestClient(
+    options.baseUrl + '/guardian/policies',
+    clientOptions,
+    options.tokenProvider
+  );
+  this.policies = new RetryRestClient(guardianPoliciesAuth0RestClient, options.retry);
+
+  /**
+   * Provides an abstraction layer for retrieving a Guardian factor selected provider.
+   *
+   * @type {external:RestClient}
+   */
+  var guardianFactorsSelectedProviderAuth0RestClient = new Auth0RestClient(
+    options.baseUrl + '/guardian/factors/:name/selected-provider',
+    clientOptions,
+    options.tokenProvider
+  );
+  this.factorsSelectedProvider = new RetryRestClient(
+    guardianFactorsSelectedProviderAuth0RestClient,
+    options.retry
+  );
+
+  /**
+   * Provides an abstraction layer for retrieving Guardian factor message types.
+   *
+   * @type {external:RestClient}
+   */
+  var guardianFactorsMessageTypesAuth0RestClient = new Auth0RestClient(
+    options.baseUrl + '/guardian/factors/:name/message-types',
+    clientOptions,
+    options.tokenProvider
+  );
+  this.factorsMessageTypes = new RetryRestClient(
+    guardianFactorsMessageTypesAuth0RestClient,
+    options.retry
+  );
 };
 
 /**
@@ -279,5 +321,135 @@ utils.wrapPropertyMethod(GuardianManager, 'updateFactorTemplates', 'factorsTempl
  * @return  {Promise|undefined}
  */
 utils.wrapPropertyMethod(GuardianManager, 'updateFactor', 'factors.update');
+
+/**
+ * Get enabled Guardian policies
+ *
+ * @method    getPolicies
+ * @memberOf  module:management.GuardianManager.prototype
+ *
+ * @example
+ * management.guardian.getPolicies(function (err, policies) {
+ *   console.log(policies);
+ * });
+ *
+ * @param   {Function}  [cb]              Callback function.
+ *
+ * @return  {Promise|undefined}
+ */
+utils.wrapPropertyMethod(GuardianManager, 'getPolicies', 'policies.get');
+
+/**
+ * Update enabled Guardian policies
+ *
+ * @method    updatePolicies
+ * @memberOf  module:management.GuardianManager.prototype
+ *
+ * @example
+ * management.guardian.updatePolicies({}, [
+ *   'all-applications'
+ * ], function (err, policies) {
+ *   console.log(policies);
+ * });
+ *
+ * @param   {Object}    params            Parameters.
+ * @param   {String[]}  data              Policies to enable. Empty array disables all policies.
+ * @param   {Function}  [cb]              Callback function.
+ *
+ * @return  {Promise|undefined}
+ */
+utils.wrapPropertyMethod(GuardianManager, 'updatePolicies', 'policies.update');
+
+/**
+ * Get the Guardian factor's selected provider
+ *
+ * @method    getFactorSelectedProvider
+ * @memberOf  module:management.GuardianManager.prototype
+ *
+ * @example
+ * management.guardian.getFactorSelectedProvider({ name: 'phone' }, function (err, selectedProvider) {
+ *   console.log(selectedProvider);
+ * });
+ *
+ * @param   {Object}    params            Factor provider parameters.
+ * @param   {String}    params.name       Factor name (only `"phone"` is supported).
+ * @param   {Function}  [cb]              Callback function.
+ *
+ * @return  {Promise|undefined}
+ */
+utils.wrapPropertyMethod(
+  GuardianManager,
+  'getFactorSelectedProvider',
+  'factorsSelectedProvider.get'
+);
+
+/**
+ * Update the Guardian factor's selected provider
+ *
+ * @method    updateFactorSelectedProvider
+ * @memberOf  module:management.GuardianManager.prototype
+ *
+ * @example
+ * management.guardian.updateFactorSelectedProvider({ name: 'phone' }, {
+ *   provider: 'twilio'
+ * }, function (err, factor) {
+ *   console.log(factor);
+ * });
+ *
+ * @param   {Object}    params            Factor provider parameters.
+ * @param   {String}    params.name       Factor name (only `"phone"` is supported).
+ * @param   {Object}    data              Updated selected provider data.
+ * @param   {String}    data.provider     Name of the selected provider
+ * @param   {Function}  [cb]              Callback function.
+ *
+ * @return  {Promise|undefined}
+ */
+utils.wrapPropertyMethod(
+  GuardianManager,
+  'updateFactorSelectedProvider',
+  'factorsSelectedProvider.update'
+);
+
+/**
+ * Get the Guardian factor's message types
+ *
+ * @method    getFactorMessageTypes
+ * @memberOf  module:management.GuardianManager.prototype
+ *
+ * @example
+ * management.guardian.getFactorMessageTypes({ name: 'phone' }, function (err, messageTypes) {
+ *   console.log(messageTypes);
+ * });
+ *
+ * @param   {Object}    params            Factor provider parameters.
+ * @param   {String}    params.name       Factor name (only `"phone"` is supported).
+ * @param   {Function}  [cb]              Callback function.
+ *
+ * @return  {Promise|undefined}
+ */
+utils.wrapPropertyMethod(GuardianManager, 'getFactorMessageTypes', 'factorsMessageTypes.get');
+
+/**
+ * Update the Guardian factor's message types
+ *
+ * @method    updateFactorMessageTypes
+ * @memberOf  module:management.GuardianManager.prototype
+ *
+ * @example
+ * management.guardian.updateFactorMessageTypes({ name: 'phone' }, {
+ *   message_types: ['sms', 'voice']
+ * }, function (err, factor) {
+ *   console.log(factor);
+ * });
+ *
+ * @param   {Object}    params                Factor provider parameters.
+ * @param   {String}    params.name           Factor name (only `"phone"` is supported).
+ * @param   {Object}    data                  Updated selected provider data.
+ * @param   {String[]}  data.message_types    Message types (only `"sms"` and `"voice"` are supported).
+ * @param   {Function}  [cb]                  Callback function.
+ *
+ * @return  {Promise|undefined}
+ */
+utils.wrapPropertyMethod(GuardianManager, 'updateFactorMessageTypes', 'factorsMessageTypes.update');
 
 module.exports = GuardianManager;

--- a/src/management/index.js
+++ b/src/management/index.js
@@ -2735,43 +2735,40 @@ utils.wrapPropertyMethod(ManagementClient, 'getGuardianPolicies', 'guardian.getP
 utils.wrapPropertyMethod(ManagementClient, 'updateGuardianPolicies', 'guardian.updatePolicies');
 
 /**
- * Get the Guardian factor's selected provider
+ * Get the Guardian phone factor's selected provider
  *
- * @method    getGuardianFactorSelectedProvider
+ * @method    getGuardianPhoneFactorSelectedProvider
  * @memberOf  module:management.ManagementClient.prototype
  *
  * @example
- * management.getGuardianFactorSelectedProvider({ name: 'phone' }, function (err, selectedProvider) {
+ * management.getGuardianPhoneFactorSelectedProvider(function (err, selectedProvider) {
  *   console.log(selectedProvider);
  * });
  *
- * @param   {Object}    params            Factor provider parameters.
- * @param   {String}    params.name       Factor name (only `"phone"` is supported).
  * @param   {Function}  [cb]              Callback function.
  *
  * @return  {Promise|undefined}
  */
 utils.wrapPropertyMethod(
   ManagementClient,
-  'getGuardianFactorSelectedProvider',
-  'guardian.getFactorSelectedProvider'
+  'getGuardianPhoneFactorSelectedProvider',
+  'guardian.getPhoneFactorSelectedProvider'
 );
 
 /**
- * Update the Guardian factor's selected provider
+ * Update the Guardian phone factor's selected provider
  *
- * @method    updateGuardianFactorSelectedProvider
+ * @method    updateGuardianPhoneFactorSelectedProvider
  * @memberOf  module:management.ManagementClient.prototype
  *
  * @example
- * management.updateGuardianFactorSelectedProvider({ name: 'phone' }, {
+ * management.updateGuardianPhoneFactorSelectedProvider({}, {
  *   provider: 'twilio'
  * }, function (err, factor) {
  *   console.log(factor);
  * });
  *
- * @param   {Object}    params            Factor provider parameters.
- * @param   {String}    params.name       Factor name (only `"phone"` is supported).
+ * @param   {Object}    params            Parameters.
  * @param   {Object}    data              Updated selected provider data.
  * @param   {String}    data.provider     Name of the selected provider
  * @param   {Function}  [cb]              Callback function.
@@ -2780,48 +2777,45 @@ utils.wrapPropertyMethod(
  */
 utils.wrapPropertyMethod(
   ManagementClient,
-  'updateGuardianFactorSelectedProvider',
-  'guardian.updateFactorSelectedProvider'
+  'updateGuardianPhoneFactorSelectedProvider',
+  'guardian.updatePhoneFactorSelectedProvider'
 );
 
 /**
- * Get the Guardian factor's message types
+ * Get the Guardian phone factor's message types
  *
- * @method    getGuardianFactorMessageTypes
+ * @method    getGuardianPhoneFactorMessageTypes
  * @memberOf  module:management.ManagementClient.prototype
  *
  * @example
- * management.getGuardianFactorMessageTypes({ name: 'phone' }, function (err, messageTypes) {
+ * management.getGuardianPhoneFactorMessageTypes(function (err, messageTypes) {
  *   console.log(messageTypes);
  * });
  *
- * @param   {Object}    params            Factor provider parameters.
- * @param   {String}    params.name       Factor name (only `"phone"` is supported).
  * @param   {Function}  [cb]              Callback function.
  *
  * @return  {Promise|undefined}
  */
 utils.wrapPropertyMethod(
   ManagementClient,
-  'getGuardianFactorMessageTypes',
-  'guardian.getFactorMessageTypes'
+  'getGuardianPhoneFactorMessageTypes',
+  'guardian.getPhoneFactorMessageTypes'
 );
 
 /**
- * Update the Guardian factor's message types
+ * Update the Guardian phone factor's message types
  *
- * @method    updateGuardianFactorMessageTypes
+ * @method    updateGuardianPhoneFactorMessageTypes
  * @memberOf  module:management.ManagementClient.prototype
  *
  * @example
- * management.updateGuardianFactorMessageTypes({ name: 'phone' }, {
+ * management.updateGuardianPhoneFactorMessageTypes({}, {
  *   message_types: ['sms', 'voice']
  * }, function (err, factor) {
  *   console.log(factor);
  * });
  *
- * @param   {Object}    params                Factor provider parameters.
- * @param   {String}    params.name           Factor name (only `"phone"` is supported).
+ * @param   {Object}    params                Parameters.
  * @param   {Object}    data                  Updated selected provider data.
  * @param   {String[]}  data.message_types    Message types (only `"sms"` and `"voice"` are supported).
  * @param   {Function}  [cb]                  Callback function.
@@ -2830,8 +2824,8 @@ utils.wrapPropertyMethod(
  */
 utils.wrapPropertyMethod(
   ManagementClient,
-  'updateGuardianFactorMessageTypes',
-  'guardian.updateFactorMessageTypes'
+  'updateGuardianPhoneFactorMessageTypes',
+  'guardian.updatePhoneFactorMessageTypes'
 );
 
 /**

--- a/src/management/index.js
+++ b/src/management/index.js
@@ -2697,6 +2697,144 @@ utils.wrapPropertyMethod(
 utils.wrapPropertyMethod(ManagementClient, 'updateGuardianFactor', 'guardian.updateFactor');
 
 /**
+ * Get enabled Guardian policies
+ *
+ * @method    getGuardianPolicies
+ * @memberOf  module:management.ManagementClient.prototype
+ *
+ * @example
+ * management.getGuardianPolicies(function (err, policies) {
+ *   console.log(policies);
+ * });
+ *
+ * @param   {Function}  [cb]              Callback function.
+ *
+ * @return  {Promise|undefined}
+ */
+utils.wrapPropertyMethod(ManagementClient, 'getGuardianPolicies', 'guardian.getPolicies');
+
+/**
+ * Update enabled Guardian policies
+ *
+ * @method    updateGuardianPolicies
+ * @memberOf  module:management.ManagementClient.prototype
+ *
+ * @example
+ * management.updateGuardianPolicies({}, [
+ *   'all-applications'
+ * ], function (err, policies) {
+ *   console.log(policies);
+ * });
+ *
+ * @param   {Object}    params            Parameters.
+ * @param   {String[]}  data              Policies to enable. Empty array disables all policies.
+ * @param   {Function}  [cb]              Callback function.
+ *
+ * @return  {Promise|undefined}
+ */
+utils.wrapPropertyMethod(ManagementClient, 'updateGuardianPolicies', 'guardian.updatePolicies');
+
+/**
+ * Get the Guardian factor's selected provider
+ *
+ * @method    getGuardianFactorSelectedProvider
+ * @memberOf  module:management.ManagementClient.prototype
+ *
+ * @example
+ * management.getGuardianFactorSelectedProvider({ name: 'phone' }, function (err, selectedProvider) {
+ *   console.log(selectedProvider);
+ * });
+ *
+ * @param   {Object}    params            Factor provider parameters.
+ * @param   {String}    params.name       Factor name (only `"phone"` is supported).
+ * @param   {Function}  [cb]              Callback function.
+ *
+ * @return  {Promise|undefined}
+ */
+utils.wrapPropertyMethod(
+  ManagementClient,
+  'getGuardianFactorSelectedProvider',
+  'guardian.getFactorSelectedProvider'
+);
+
+/**
+ * Update the Guardian factor's selected provider
+ *
+ * @method    updateGuardianFactorSelectedProvider
+ * @memberOf  module:management.ManagementClient.prototype
+ *
+ * @example
+ * management.updateGuardianFactorSelectedProvider({ name: 'phone' }, {
+ *   provider: 'twilio'
+ * }, function (err, factor) {
+ *   console.log(factor);
+ * });
+ *
+ * @param   {Object}    params            Factor provider parameters.
+ * @param   {String}    params.name       Factor name (only `"phone"` is supported).
+ * @param   {Object}    data              Updated selected provider data.
+ * @param   {String}    data.provider     Name of the selected provider
+ * @param   {Function}  [cb]              Callback function.
+ *
+ * @return  {Promise|undefined}
+ */
+utils.wrapPropertyMethod(
+  ManagementClient,
+  'updateGuardianFactorSelectedProvider',
+  'guardian.updateFactorSelectedProvider'
+);
+
+/**
+ * Get the Guardian factor's message types
+ *
+ * @method    getGuardianFactorMessageTypes
+ * @memberOf  module:management.ManagementClient.prototype
+ *
+ * @example
+ * management.getGuardianFactorMessageTypes({ name: 'phone' }, function (err, messageTypes) {
+ *   console.log(messageTypes);
+ * });
+ *
+ * @param   {Object}    params            Factor provider parameters.
+ * @param   {String}    params.name       Factor name (only `"phone"` is supported).
+ * @param   {Function}  [cb]              Callback function.
+ *
+ * @return  {Promise|undefined}
+ */
+utils.wrapPropertyMethod(
+  ManagementClient,
+  'getGuardianFactorMessageTypes',
+  'guardian.getFactorMessageTypes'
+);
+
+/**
+ * Update the Guardian factor's message types
+ *
+ * @method    updateGuardianFactorMessageTypes
+ * @memberOf  module:management.ManagementClient.prototype
+ *
+ * @example
+ * management.updateGuardianFactorMessageTypes({ name: 'phone' }, {
+ *   message_types: ['sms', 'voice']
+ * }, function (err, factor) {
+ *   console.log(factor);
+ * });
+ *
+ * @param   {Object}    params                Factor provider parameters.
+ * @param   {String}    params.name           Factor name (only `"phone"` is supported).
+ * @param   {Object}    data                  Updated selected provider data.
+ * @param   {String[]}  data.message_types    Message types (only `"sms"` and `"voice"` are supported).
+ * @param   {Function}  [cb]                  Callback function.
+ *
+ * @return  {Promise|undefined}
+ */
+utils.wrapPropertyMethod(
+  ManagementClient,
+  'updateGuardianFactorMessageTypes',
+  'guardian.updateFactorMessageTypes'
+);
+
+/**
  * Get all roles.
  *
  * @method    getRoles

--- a/test/management/guardian.tests.js
+++ b/test/management/guardian.tests.js
@@ -25,7 +25,11 @@ describe('GuardianManager', function() {
       'updateFactorProvider',
       'getFactorTemplates',
       'updateFactorTemplates',
-      'updateFactor'
+      'updateFactor',
+      'getFactorSelectedProvider',
+      'updateFactorSelectedProvider',
+      'getFactorMessageTypes',
+      'updateFactorMessageTypes'
     ];
 
     methods.forEach(function(method) {
@@ -302,7 +306,7 @@ describe('GuardianManager', function() {
         .catch(done.bind(null, null));
     });
 
-    it('should perform a POST request to /api/v2/guardian/factors', function(done) {
+    it('should perform a GET request to /api/v2/guardian/factors', function(done) {
       var request = this.request;
 
       this.guardian.getFactors().then(function() {
@@ -368,7 +372,7 @@ describe('GuardianManager', function() {
         .catch(done.bind(null, null));
     });
 
-    it('should perform a POST request to /api/v2/guardian/factors/sms/twilio', function(done) {
+    it('should perform a GET request to /api/v2/guardian/factors/sms/twilio', function(done) {
       var request = this.request;
 
       this.guardian.getFactorProvider(this.params).then(function() {
@@ -446,7 +450,10 @@ describe('GuardianManager', function() {
       nock.cleanAll();
 
       var request = nock(API_URL)
-        .put('/guardian/factors/' + this.params.name + '/providers/' + this.params.provider)
+        .put(
+          '/guardian/factors/' + this.params.name + '/providers/' + this.params.provider,
+          this.data
+        )
         .reply(200);
 
       this.guardian.updateFactorProvider(this.params, this.data).then(function() {
@@ -512,7 +519,7 @@ describe('GuardianManager', function() {
         .catch(done.bind(null, null));
     });
 
-    it('should perform a POST request to /api/v2/guardian/factors/sms/templates', function(done) {
+    it('should perform a GET request to /api/v2/guardian/factors/sms/templates', function(done) {
       var request = this.request;
 
       this.guardian.getFactorTemplates(this.params).then(function() {
@@ -589,7 +596,7 @@ describe('GuardianManager', function() {
       nock.cleanAll();
 
       var request = nock(API_URL)
-        .put('/guardian/factors/' + this.params.name + '/templates')
+        .put('/guardian/factors/' + this.params.name + '/templates', this.data)
         .reply(200);
 
       this.guardian.updateFactorTemplates(this.params, this.data).then(function() {
@@ -664,7 +671,7 @@ describe('GuardianManager', function() {
       nock.cleanAll();
 
       var request = nock(API_URL)
-        .put('/guardian/factors/' + this.params.name)
+        .put('/guardian/factors/' + this.params.name, this.data)
         .reply(200);
 
       this.guardian.updateFactor(this.params, this.data).then(function() {
@@ -697,6 +704,413 @@ describe('GuardianManager', function() {
         .reply(200);
 
       this.guardian.updateFactor(this.params, this.data).then(function() {
+        expect(request.isDone()).to.be.true;
+
+        done();
+      });
+    });
+  });
+
+  describe('#getPolicies', function() {
+    beforeEach(function() {
+      this.data = ['all-applications'];
+
+      this.request = nock(API_URL)
+        .get('/guardian/policies')
+        .reply(200, this.data);
+    });
+
+    it('should accept a callback', function(done) {
+      this.guardian.getPolicies(done.bind(null, null));
+    });
+
+    it('should return a promise if no callback is given', function(done) {
+      this.guardian
+        .getPolicies()
+        .then(done.bind(null, null))
+        .catch(done.bind(null, null));
+    });
+
+    it('should perform a GET request to /api/v2/guardian/policies', function(done) {
+      var request = this.request;
+
+      this.guardian.getPolicies().then(function() {
+        expect(request.isDone()).to.be.true;
+
+        done();
+      });
+    });
+
+    it('should pass any errors to the promise catch handler', function(done) {
+      nock.cleanAll();
+
+      var request = nock(API_URL)
+        .get('/guardian/policies')
+        .reply(500);
+
+      this.guardian.getPolicies().catch(function(err) {
+        expect(err).to.exist;
+
+        done();
+      });
+    });
+
+    it('should include the token in the Authorization header', function(done) {
+      nock.cleanAll();
+
+      var request = nock(API_URL)
+        .get('/guardian/policies')
+        .matchHeader('Authorization', 'Bearer ' + this.token)
+        .reply(200);
+
+      this.guardian.getPolicies().then(function() {
+        expect(request.isDone()).to.be.true;
+
+        done();
+      });
+    });
+  });
+
+  describe('#updatePolicies', function() {
+    beforeEach(function() {
+      this.params = {};
+      this.data = ['all-applications'];
+    });
+
+    it('should accept a callback', function(done) {
+      this.guardian.updatePolicies(this.params, this.data, done.bind(null, null));
+    });
+
+    it('should return a promise if no callback is given', function(done) {
+      this.guardian
+        .updatePolicies(this.params, this.data)
+        .then(done.bind(null, null))
+        .catch(done.bind(null, null));
+    });
+
+    it('should perform a PUT request to /api/v2/guardian/policies', function(done) {
+      var request = nock(API_URL)
+        .put('/guardian/policies')
+        .reply(200, this.data);
+
+      this.guardian.updatePolicies(this.params, this.data).then(function() {
+        expect(request.isDone()).to.be.true;
+
+        done();
+      });
+    });
+
+    it('should include the new data in the body of the request', function(done) {
+      nock.cleanAll();
+
+      var request = nock(API_URL)
+        .put('/guardian/policies', this.data)
+        .reply(200);
+
+      this.guardian.updatePolicies(this.params, this.data).then(function() {
+        expect(request.isDone()).to.be.true;
+
+        done();
+      });
+    });
+
+    it('should pass any errors to the promise catch handler', function(done) {
+      nock.cleanAll();
+
+      var request = nock(API_URL)
+        .put('/guardian/policies')
+        .reply(500);
+
+      this.guardian.updatePolicies(this.params, this.data).catch(function(err) {
+        expect(err).to.exist;
+
+        done();
+      });
+    });
+
+    it('should include the token in the Authorization header', function(done) {
+      nock.cleanAll();
+
+      var request = nock(API_URL)
+        .put('/guardian/policies')
+        .matchHeader('Authorization', 'Bearer ' + this.token)
+        .reply(200);
+
+      this.guardian.updatePolicies(this.params, this.data).then(function() {
+        expect(request.isDone()).to.be.true;
+
+        done();
+      });
+    });
+  });
+
+  describe('#getFactorSelectedProvider', function() {
+    beforeEach(function() {
+      this.data = {
+        provider: 'twilio'
+      };
+
+      this.request = nock(API_URL)
+        .get('/guardian/factors/phone/selected-provider')
+        .reply(200, this.data);
+    });
+
+    it('should accept a callback', function(done) {
+      this.guardian.getFactorSelectedProvider({ name: 'phone' }, done.bind(null, null));
+    });
+
+    it('should return a promise if no callback is given', function(done) {
+      this.guardian
+        .getFactorSelectedProvider({ name: 'phone' })
+        .then(done.bind(null, null))
+        .catch(done.bind(null, null));
+    });
+
+    it('should perform a GET request to /api/v2/guardian/factors/phone/selected-provider', function(done) {
+      var request = this.request;
+
+      this.guardian.getFactorSelectedProvider({ name: 'phone' }).then(function() {
+        expect(request.isDone()).to.be.true;
+
+        done();
+      });
+    });
+
+    it('should pass any errors to the promise catch handler', function(done) {
+      nock.cleanAll();
+
+      var request = nock(API_URL)
+        .get('/guardian/factors/phone/selected-provider')
+        .reply(500);
+
+      this.guardian.getFactorSelectedProvider({ name: 'phone' }).catch(function(err) {
+        expect(err).to.exist;
+
+        done();
+      });
+    });
+
+    it('should include the token in the Authorization header', function(done) {
+      nock.cleanAll();
+
+      var request = nock(API_URL)
+        .get('/guardian/factors/phone/selected-provider')
+        .matchHeader('Authorization', 'Bearer ' + this.token)
+        .reply(200);
+
+      this.guardian.getFactorSelectedProvider({ name: 'phone' }).then(function() {
+        expect(request.isDone()).to.be.true;
+
+        done();
+      });
+    });
+  });
+
+  describe('#updateFactorSelectedProvider', function() {
+    beforeEach(function() {
+      this.params = { name: 'phone' };
+      this.data = {
+        provider: 'twilio'
+      };
+    });
+
+    it('should accept a callback', function(done) {
+      this.guardian.updateFactorSelectedProvider(this.params, this.data, done.bind(null, null));
+    });
+
+    it('should return a promise if no callback is given', function(done) {
+      this.guardian
+        .updateFactorSelectedProvider(this.params, this.data)
+        .then(done.bind(null, null))
+        .catch(done.bind(null, null));
+    });
+
+    it('should perform a PUT request to /api/v2/guardian/factors/phone/selected-provider', function(done) {
+      var request = nock(API_URL)
+        .put('/guardian/factors/' + this.params.name + '/selected-provider')
+        .reply(200, this.data);
+
+      this.guardian.updateFactorSelectedProvider(this.params, this.data).then(function() {
+        expect(request.isDone()).to.be.true;
+
+        done();
+      });
+    });
+
+    it('should include the new data in the body of the request', function(done) {
+      nock.cleanAll();
+
+      var request = nock(API_URL)
+        .put('/guardian/factors/' + this.params.name + '/selected-provider', this.data)
+        .reply(200);
+
+      this.guardian.updateFactorSelectedProvider(this.params, this.data).then(function() {
+        expect(request.isDone()).to.be.true;
+
+        done();
+      });
+    });
+
+    it('should pass any errors to the promise catch handler', function(done) {
+      nock.cleanAll();
+
+      var request = nock(API_URL)
+        .put('/guardian/factors/' + this.params.name + '/selected-provider')
+        .reply(500);
+
+      this.guardian.updateFactorSelectedProvider(this.params, this.data).catch(function(err) {
+        expect(err).to.exist;
+
+        done();
+      });
+    });
+
+    it('should include the token in the Authorization header', function(done) {
+      nock.cleanAll();
+
+      var request = nock(API_URL)
+        .put('/guardian/factors/' + this.params.name + '/selected-provider')
+        .matchHeader('Authorization', 'Bearer ' + this.token)
+        .reply(200);
+
+      this.guardian.updateFactorSelectedProvider(this.params, this.data).then(function() {
+        expect(request.isDone()).to.be.true;
+
+        done();
+      });
+    });
+  });
+
+  describe('#getFactorMessageTypes', function() {
+    beforeEach(function() {
+      this.data = {
+        message_types: ['sms', 'voice']
+      };
+
+      this.request = nock(API_URL)
+        .get('/guardian/factors/phone/message-types')
+        .reply(200, this.data);
+    });
+
+    it('should accept a callback', function(done) {
+      this.guardian.getFactorMessageTypes({ name: 'phone' }, done.bind(null, null));
+    });
+
+    it('should return a promise if no callback is given', function(done) {
+      this.guardian
+        .getFactorMessageTypes({ name: 'phone' })
+        .then(done.bind(null, null))
+        .catch(done.bind(null, null));
+    });
+
+    it('should perform a GET request to /api/v2/guardian/factors/phone/message-types', function(done) {
+      var request = this.request;
+
+      this.guardian.getFactorMessageTypes({ name: 'phone' }).then(function() {
+        expect(request.isDone()).to.be.true;
+
+        done();
+      });
+    });
+
+    it('should pass any errors to the promise catch handler', function(done) {
+      nock.cleanAll();
+
+      var request = nock(API_URL)
+        .get('/guardian/factors/phone/message-types')
+        .reply(500);
+
+      this.guardian.getFactorMessageTypes({ name: 'phone' }).catch(function(err) {
+        expect(err).to.exist;
+
+        done();
+      });
+    });
+
+    it('should include the token in the Authorization header', function(done) {
+      nock.cleanAll();
+
+      var request = nock(API_URL)
+        .get('/guardian/factors/phone/message-types')
+        .matchHeader('Authorization', 'Bearer ' + this.token)
+        .reply(200);
+
+      this.guardian.getFactorMessageTypes({ name: 'phone' }).then(function() {
+        expect(request.isDone()).to.be.true;
+
+        done();
+      });
+    });
+  });
+
+  describe('#updateFactorMessageTypes', function() {
+    beforeEach(function() {
+      this.params = { name: 'phone' };
+      this.data = {
+        message_types: ['sms', 'voice']
+      };
+    });
+
+    it('should accept a callback', function(done) {
+      this.guardian.updateFactorMessageTypes(this.params, this.data, done.bind(null, null));
+    });
+
+    it('should return a promise if no callback is given', function(done) {
+      this.guardian
+        .updateFactorMessageTypes(this.params, this.data)
+        .then(done.bind(null, null))
+        .catch(done.bind(null, null));
+    });
+
+    it('should perform a PUT request to /api/v2/guardian/factors/phone/message-types', function(done) {
+      var request = nock(API_URL)
+        .put('/guardian/factors/' + this.params.name + '/message-types')
+        .reply(200, this.data);
+
+      this.guardian.updateFactorMessageTypes(this.params, this.data).then(function() {
+        expect(request.isDone()).to.be.true;
+
+        done();
+      });
+    });
+
+    it('should include the new data in the body of the request', function(done) {
+      nock.cleanAll();
+
+      var request = nock(API_URL)
+        .put('/guardian/factors/' + this.params.name + '/message-types', this.data)
+        .reply(200);
+
+      this.guardian.updateFactorMessageTypes(this.params, this.data).then(function() {
+        expect(request.isDone()).to.be.true;
+
+        done();
+      });
+    });
+
+    it('should pass any errors to the promise catch handler', function(done) {
+      nock.cleanAll();
+
+      var request = nock(API_URL)
+        .put('/guardian/factors/' + this.params.name + '/message-types')
+        .reply(500);
+
+      this.guardian.updateFactorMessageTypes(this.params, this.data).catch(function(err) {
+        expect(err).to.exist;
+
+        done();
+      });
+    });
+
+    it('should include the token in the Authorization header', function(done) {
+      nock.cleanAll();
+
+      var request = nock(API_URL)
+        .put('/guardian/factors/' + this.params.name + '/message-types')
+        .matchHeader('Authorization', 'Bearer ' + this.token)
+        .reply(200);
+
+      this.guardian.updateFactorMessageTypes(this.params, this.data).then(function() {
         expect(request.isDone()).to.be.true;
 
         done();

--- a/test/management/guardian.tests.js
+++ b/test/management/guardian.tests.js
@@ -851,7 +851,7 @@ describe('GuardianManager', function() {
       };
 
       this.request = nock(API_URL)
-        .get('/guardian/factors/phone/selected-provider')
+        .get('/guardian/factors/sms/selected-provider')
         .reply(200, this.data);
     });
 
@@ -866,7 +866,7 @@ describe('GuardianManager', function() {
         .catch(done.bind(null, null));
     });
 
-    it('should perform a GET request to /api/v2/guardian/factors/phone/selected-provider', function(done) {
+    it('should perform a GET request to /api/v2/guardian/factors/sms/selected-provider', function(done) {
       var request = this.request;
 
       this.guardian.getPhoneFactorSelectedProvider().then(function() {
@@ -880,7 +880,7 @@ describe('GuardianManager', function() {
       nock.cleanAll();
 
       var request = nock(API_URL)
-        .get('/guardian/factors/phone/selected-provider')
+        .get('/guardian/factors/sms/selected-provider')
         .reply(500);
 
       this.guardian.getPhoneFactorSelectedProvider().catch(function(err) {
@@ -894,7 +894,7 @@ describe('GuardianManager', function() {
       nock.cleanAll();
 
       var request = nock(API_URL)
-        .get('/guardian/factors/phone/selected-provider')
+        .get('/guardian/factors/sms/selected-provider')
         .matchHeader('Authorization', 'Bearer ' + this.token)
         .reply(200);
 
@@ -929,9 +929,9 @@ describe('GuardianManager', function() {
         .catch(done.bind(null, null));
     });
 
-    it('should perform a PUT request to /api/v2/guardian/factors/phone/selected-provider', function(done) {
+    it('should perform a PUT request to /api/v2/guardian/factors/sms/selected-provider', function(done) {
       var request = nock(API_URL)
-        .put('/guardian/factors/phone/selected-provider')
+        .put('/guardian/factors/sms/selected-provider')
         .reply(200, this.data);
 
       this.guardian.updatePhoneFactorSelectedProvider(this.params, this.data).then(function() {
@@ -945,7 +945,7 @@ describe('GuardianManager', function() {
       nock.cleanAll();
 
       var request = nock(API_URL)
-        .put('/guardian/factors/phone/selected-provider', this.data)
+        .put('/guardian/factors/sms/selected-provider', this.data)
         .reply(200);
 
       this.guardian.updatePhoneFactorSelectedProvider(this.params, this.data).then(function() {
@@ -959,7 +959,7 @@ describe('GuardianManager', function() {
       nock.cleanAll();
 
       var request = nock(API_URL)
-        .put('/guardian/factors/phone/selected-provider')
+        .put('/guardian/factors/sms/selected-provider')
         .reply(500);
 
       this.guardian.updatePhoneFactorSelectedProvider(this.params, this.data).catch(function(err) {
@@ -973,7 +973,7 @@ describe('GuardianManager', function() {
       nock.cleanAll();
 
       var request = nock(API_URL)
-        .put('/guardian/factors/phone/selected-provider')
+        .put('/guardian/factors/sms/selected-provider')
         .matchHeader('Authorization', 'Bearer ' + this.token)
         .reply(200);
 

--- a/test/management/guardian.tests.js
+++ b/test/management/guardian.tests.js
@@ -26,10 +26,10 @@ describe('GuardianManager', function() {
       'getFactorTemplates',
       'updateFactorTemplates',
       'updateFactor',
-      'getFactorSelectedProvider',
-      'updateFactorSelectedProvider',
-      'getFactorMessageTypes',
-      'updateFactorMessageTypes'
+      'getPhoneFactorSelectedProvider',
+      'updatePhoneFactorSelectedProvider',
+      'getPhoneFactorMessageTypes',
+      'updatePhoneFactorMessageTypes'
     ];
 
     methods.forEach(function(method) {
@@ -844,7 +844,7 @@ describe('GuardianManager', function() {
     });
   });
 
-  describe('#getFactorSelectedProvider', function() {
+  describe('#getPhoneFactorSelectedProvider', function() {
     beforeEach(function() {
       this.data = {
         provider: 'twilio'
@@ -856,12 +856,12 @@ describe('GuardianManager', function() {
     });
 
     it('should accept a callback', function(done) {
-      this.guardian.getFactorSelectedProvider({ name: 'phone' }, done.bind(null, null));
+      this.guardian.getPhoneFactorSelectedProvider(done.bind(null, null));
     });
 
     it('should return a promise if no callback is given', function(done) {
       this.guardian
-        .getFactorSelectedProvider({ name: 'phone' })
+        .getPhoneFactorSelectedProvider()
         .then(done.bind(null, null))
         .catch(done.bind(null, null));
     });
@@ -869,7 +869,7 @@ describe('GuardianManager', function() {
     it('should perform a GET request to /api/v2/guardian/factors/phone/selected-provider', function(done) {
       var request = this.request;
 
-      this.guardian.getFactorSelectedProvider({ name: 'phone' }).then(function() {
+      this.guardian.getPhoneFactorSelectedProvider().then(function() {
         expect(request.isDone()).to.be.true;
 
         done();
@@ -883,7 +883,7 @@ describe('GuardianManager', function() {
         .get('/guardian/factors/phone/selected-provider')
         .reply(500);
 
-      this.guardian.getFactorSelectedProvider({ name: 'phone' }).catch(function(err) {
+      this.guardian.getPhoneFactorSelectedProvider().catch(function(err) {
         expect(err).to.exist;
 
         done();
@@ -898,7 +898,7 @@ describe('GuardianManager', function() {
         .matchHeader('Authorization', 'Bearer ' + this.token)
         .reply(200);
 
-      this.guardian.getFactorSelectedProvider({ name: 'phone' }).then(function() {
+      this.guardian.getPhoneFactorSelectedProvider().then(function() {
         expect(request.isDone()).to.be.true;
 
         done();
@@ -906,31 +906,35 @@ describe('GuardianManager', function() {
     });
   });
 
-  describe('#updateFactorSelectedProvider', function() {
+  describe('#updatePhoneFactorSelectedProvider', function() {
     beforeEach(function() {
-      this.params = { name: 'phone' };
+      this.params = {};
       this.data = {
         provider: 'twilio'
       };
     });
 
     it('should accept a callback', function(done) {
-      this.guardian.updateFactorSelectedProvider(this.params, this.data, done.bind(null, null));
+      this.guardian.updatePhoneFactorSelectedProvider(
+        this.params,
+        this.data,
+        done.bind(null, null)
+      );
     });
 
     it('should return a promise if no callback is given', function(done) {
       this.guardian
-        .updateFactorSelectedProvider(this.params, this.data)
+        .updatePhoneFactorSelectedProvider(this.params, this.data)
         .then(done.bind(null, null))
         .catch(done.bind(null, null));
     });
 
     it('should perform a PUT request to /api/v2/guardian/factors/phone/selected-provider', function(done) {
       var request = nock(API_URL)
-        .put('/guardian/factors/' + this.params.name + '/selected-provider')
+        .put('/guardian/factors/phone/selected-provider')
         .reply(200, this.data);
 
-      this.guardian.updateFactorSelectedProvider(this.params, this.data).then(function() {
+      this.guardian.updatePhoneFactorSelectedProvider(this.params, this.data).then(function() {
         expect(request.isDone()).to.be.true;
 
         done();
@@ -941,10 +945,10 @@ describe('GuardianManager', function() {
       nock.cleanAll();
 
       var request = nock(API_URL)
-        .put('/guardian/factors/' + this.params.name + '/selected-provider', this.data)
+        .put('/guardian/factors/phone/selected-provider', this.data)
         .reply(200);
 
-      this.guardian.updateFactorSelectedProvider(this.params, this.data).then(function() {
+      this.guardian.updatePhoneFactorSelectedProvider(this.params, this.data).then(function() {
         expect(request.isDone()).to.be.true;
 
         done();
@@ -955,10 +959,10 @@ describe('GuardianManager', function() {
       nock.cleanAll();
 
       var request = nock(API_URL)
-        .put('/guardian/factors/' + this.params.name + '/selected-provider')
+        .put('/guardian/factors/phone/selected-provider')
         .reply(500);
 
-      this.guardian.updateFactorSelectedProvider(this.params, this.data).catch(function(err) {
+      this.guardian.updatePhoneFactorSelectedProvider(this.params, this.data).catch(function(err) {
         expect(err).to.exist;
 
         done();
@@ -969,11 +973,11 @@ describe('GuardianManager', function() {
       nock.cleanAll();
 
       var request = nock(API_URL)
-        .put('/guardian/factors/' + this.params.name + '/selected-provider')
+        .put('/guardian/factors/phone/selected-provider')
         .matchHeader('Authorization', 'Bearer ' + this.token)
         .reply(200);
 
-      this.guardian.updateFactorSelectedProvider(this.params, this.data).then(function() {
+      this.guardian.updatePhoneFactorSelectedProvider(this.params, this.data).then(function() {
         expect(request.isDone()).to.be.true;
 
         done();
@@ -981,7 +985,7 @@ describe('GuardianManager', function() {
     });
   });
 
-  describe('#getFactorMessageTypes', function() {
+  describe('#getPhoneFactorMessageTypes', function() {
     beforeEach(function() {
       this.data = {
         message_types: ['sms', 'voice']
@@ -993,12 +997,12 @@ describe('GuardianManager', function() {
     });
 
     it('should accept a callback', function(done) {
-      this.guardian.getFactorMessageTypes({ name: 'phone' }, done.bind(null, null));
+      this.guardian.getPhoneFactorMessageTypes(done.bind(null, null));
     });
 
     it('should return a promise if no callback is given', function(done) {
       this.guardian
-        .getFactorMessageTypes({ name: 'phone' })
+        .getPhoneFactorMessageTypes()
         .then(done.bind(null, null))
         .catch(done.bind(null, null));
     });
@@ -1006,7 +1010,7 @@ describe('GuardianManager', function() {
     it('should perform a GET request to /api/v2/guardian/factors/phone/message-types', function(done) {
       var request = this.request;
 
-      this.guardian.getFactorMessageTypes({ name: 'phone' }).then(function() {
+      this.guardian.getPhoneFactorMessageTypes().then(function() {
         expect(request.isDone()).to.be.true;
 
         done();
@@ -1020,7 +1024,7 @@ describe('GuardianManager', function() {
         .get('/guardian/factors/phone/message-types')
         .reply(500);
 
-      this.guardian.getFactorMessageTypes({ name: 'phone' }).catch(function(err) {
+      this.guardian.getPhoneFactorMessageTypes().catch(function(err) {
         expect(err).to.exist;
 
         done();
@@ -1035,7 +1039,7 @@ describe('GuardianManager', function() {
         .matchHeader('Authorization', 'Bearer ' + this.token)
         .reply(200);
 
-      this.guardian.getFactorMessageTypes({ name: 'phone' }).then(function() {
+      this.guardian.getPhoneFactorMessageTypes().then(function() {
         expect(request.isDone()).to.be.true;
 
         done();
@@ -1043,31 +1047,31 @@ describe('GuardianManager', function() {
     });
   });
 
-  describe('#updateFactorMessageTypes', function() {
+  describe('#updatePhoneFactorMessageTypes', function() {
     beforeEach(function() {
-      this.params = { name: 'phone' };
+      this.params = {};
       this.data = {
         message_types: ['sms', 'voice']
       };
     });
 
     it('should accept a callback', function(done) {
-      this.guardian.updateFactorMessageTypes(this.params, this.data, done.bind(null, null));
+      this.guardian.updatePhoneFactorMessageTypes(this.params, this.data, done.bind(null, null));
     });
 
     it('should return a promise if no callback is given', function(done) {
       this.guardian
-        .updateFactorMessageTypes(this.params, this.data)
+        .updatePhoneFactorMessageTypes(this.params, this.data)
         .then(done.bind(null, null))
         .catch(done.bind(null, null));
     });
 
     it('should perform a PUT request to /api/v2/guardian/factors/phone/message-types', function(done) {
       var request = nock(API_URL)
-        .put('/guardian/factors/' + this.params.name + '/message-types')
+        .put('/guardian/factors/phone/message-types')
         .reply(200, this.data);
 
-      this.guardian.updateFactorMessageTypes(this.params, this.data).then(function() {
+      this.guardian.updatePhoneFactorMessageTypes(this.params, this.data).then(function() {
         expect(request.isDone()).to.be.true;
 
         done();
@@ -1078,10 +1082,10 @@ describe('GuardianManager', function() {
       nock.cleanAll();
 
       var request = nock(API_URL)
-        .put('/guardian/factors/' + this.params.name + '/message-types', this.data)
+        .put('/guardian/factors/phone/message-types', this.data)
         .reply(200);
 
-      this.guardian.updateFactorMessageTypes(this.params, this.data).then(function() {
+      this.guardian.updatePhoneFactorMessageTypes(this.params, this.data).then(function() {
         expect(request.isDone()).to.be.true;
 
         done();
@@ -1092,10 +1096,10 @@ describe('GuardianManager', function() {
       nock.cleanAll();
 
       var request = nock(API_URL)
-        .put('/guardian/factors/' + this.params.name + '/message-types')
+        .put('/guardian/factors/phone/message-types')
         .reply(500);
 
-      this.guardian.updateFactorMessageTypes(this.params, this.data).catch(function(err) {
+      this.guardian.updatePhoneFactorMessageTypes(this.params, this.data).catch(function(err) {
         expect(err).to.exist;
 
         done();
@@ -1106,11 +1110,11 @@ describe('GuardianManager', function() {
       nock.cleanAll();
 
       var request = nock(API_URL)
-        .put('/guardian/factors/' + this.params.name + '/message-types')
+        .put('/guardian/factors/phone/message-types')
         .matchHeader('Authorization', 'Bearer ' + this.token)
         .reply(200);
 
-      this.guardian.updateFactorMessageTypes(this.params, this.data).then(function() {
+      this.guardian.updatePhoneFactorMessageTypes(this.params, this.data).then(function() {
         expect(request.isDone()).to.be.true;
 
         done();

--- a/test/management/management-client.tests.js
+++ b/test/management/management-client.tests.js
@@ -300,10 +300,10 @@ describe('ManagementClient', function() {
           requestHeaders
         );
         expect(
-          client.guardian.factorsSelectedProvider.restClient.restClient.options.headers
+          client.guardian.factorsPhoneSelectedProvider.restClient.restClient.options.headers
         ).to.contain(requestHeaders);
         expect(
-          client.guardian.factorsMessageTypes.restClient.restClient.options.headers
+          client.guardian.factorsPhoneMessageTypes.restClient.restClient.options.headers
         ).to.contain(requestHeaders);
 
         expect(client.customDomains.resource.restClient.restClient.options.headers).to.contain(
@@ -445,10 +445,10 @@ describe('ManagementClient', function() {
           requestHeaders
         );
         expect(
-          client.guardian.factorsSelectedProvider.restClient.restClient.options.headers
+          client.guardian.factorsPhoneSelectedProvider.restClient.restClient.options.headers
         ).to.contain(requestHeaders);
         expect(
-          client.guardian.factorsMessageTypes.restClient.restClient.options.headers
+          client.guardian.factorsPhoneMessageTypes.restClient.restClient.options.headers
         ).to.contain(requestHeaders);
 
         expect(client.customDomains.resource.restClient.restClient.options.headers).to.contain(
@@ -588,10 +588,10 @@ describe('ManagementClient', function() {
           client.guardian.factorsProviders.restClient.restClient.options.headers
         ).to.not.have.property('Auth0-Client');
         expect(
-          client.guardian.factorsSelectedProvider.restClient.restClient.options.headers
+          client.guardian.factorsPhoneSelectedProvider.restClient.restClient.options.headers
         ).to.not.have.property('Auth0-Client');
         expect(
-          client.guardian.factorsMessageTypes.restClient.restClient.options.headers
+          client.guardian.factorsPhoneMessageTypes.restClient.restClient.options.headers
         ).to.not.have.property('Auth0-Client');
 
         expect(
@@ -734,10 +734,10 @@ describe('ManagementClient', function() {
           client.guardian.factorsProviders.restClient.restClient.options.headers
         ).to.not.have.property('Auth0-Client');
         expect(
-          client.guardian.factorsSelectedProvider.restClient.restClient.options.headers
+          client.guardian.factorsPhoneSelectedProvider.restClient.restClient.options.headers
         ).to.not.have.property('Auth0-Client');
         expect(
-          client.guardian.factorsMessageTypes.restClient.restClient.options.headers
+          client.guardian.factorsPhoneMessageTypes.restClient.restClient.options.headers
         ).to.not.have.property('Auth0-Client');
 
         expect(
@@ -892,10 +892,10 @@ describe('ManagementClient', function() {
       'updateGuardianFactor',
       'getGuardianPolicies',
       'updateGuardianPolicies',
-      'getGuardianFactorSelectedProvider',
-      'updateGuardianFactorSelectedProvider',
-      'getGuardianFactorMessageTypes',
-      'updateGuardianFactorMessageTypes',
+      'getGuardianPhoneFactorSelectedProvider',
+      'updateGuardianPhoneFactorSelectedProvider',
+      'getGuardianPhoneFactorMessageTypes',
+      'updateGuardianPhoneFactorMessageTypes',
       'getUserBlocks',
       'unblockUser',
       'getUserBlocksByIdentifier',

--- a/test/management/management-client.tests.js
+++ b/test/management/management-client.tests.js
@@ -299,6 +299,12 @@ describe('ManagementClient', function() {
         expect(client.guardian.factorsProviders.restClient.restClient.options.headers).to.contain(
           requestHeaders
         );
+        expect(
+          client.guardian.factorsSelectedProvider.restClient.restClient.options.headers
+        ).to.contain(requestHeaders);
+        expect(
+          client.guardian.factorsMessageTypes.restClient.restClient.options.headers
+        ).to.contain(requestHeaders);
 
         expect(client.customDomains.resource.restClient.restClient.options.headers).to.contain(
           requestHeaders
@@ -438,6 +444,12 @@ describe('ManagementClient', function() {
         expect(client.guardian.factorsProviders.restClient.restClient.options.headers).to.contain(
           requestHeaders
         );
+        expect(
+          client.guardian.factorsSelectedProvider.restClient.restClient.options.headers
+        ).to.contain(requestHeaders);
+        expect(
+          client.guardian.factorsMessageTypes.restClient.restClient.options.headers
+        ).to.contain(requestHeaders);
 
         expect(client.customDomains.resource.restClient.restClient.options.headers).to.contain(
           requestHeaders
@@ -574,6 +586,12 @@ describe('ManagementClient', function() {
         ).to.not.have.property('Auth0-Client');
         expect(
           client.guardian.factorsProviders.restClient.restClient.options.headers
+        ).to.not.have.property('Auth0-Client');
+        expect(
+          client.guardian.factorsSelectedProvider.restClient.restClient.options.headers
+        ).to.not.have.property('Auth0-Client');
+        expect(
+          client.guardian.factorsMessageTypes.restClient.restClient.options.headers
         ).to.not.have.property('Auth0-Client');
 
         expect(
@@ -714,6 +732,12 @@ describe('ManagementClient', function() {
         ).to.not.have.property('Auth0-Client');
         expect(
           client.guardian.factorsProviders.restClient.restClient.options.headers
+        ).to.not.have.property('Auth0-Client');
+        expect(
+          client.guardian.factorsSelectedProvider.restClient.restClient.options.headers
+        ).to.not.have.property('Auth0-Client');
+        expect(
+          client.guardian.factorsMessageTypes.restClient.restClient.options.headers
         ).to.not.have.property('Auth0-Client');
 
         expect(
@@ -866,6 +890,12 @@ describe('ManagementClient', function() {
       'getGuardianFactorTemplates',
       'updateGuardianFactorTemplates',
       'updateGuardianFactor',
+      'getGuardianPolicies',
+      'updateGuardianPolicies',
+      'getGuardianFactorSelectedProvider',
+      'updateGuardianFactorSelectedProvider',
+      'getGuardianFactorMessageTypes',
+      'updateGuardianFactorMessageTypes',
       'getUserBlocks',
       'unblockUser',
       'getUserBlocksByIdentifier',
@@ -878,7 +908,7 @@ describe('ManagementClient', function() {
       this.client = new ManagementClient(config);
     });
 
-    methods.forEach(function (method) {
+    methods.forEach(function(method) {
       it('should have a ' + method + ' method', function() {
         expect(this.client[method]).to.exist.to.be.an.instanceOf(Function);
       });


### PR DESCRIPTION
### Changes

Adding support for 6 Management API endpoints, related to Guardian/MFA features. Here is the list of API endpoints and their related method added to this SDK:

- `GET /api/v2/guardian/policies`
  - `management.guardian.getPolicies()`
  - `management.getGuardianPolicies()` (alias)
- `PUT /api/v2/guardian/policies`
  - `management.guardian.updatePolicies()`
  - `management.updateGuardianPolicies()` (alias)
- `GET /api/v2/guardian/factors/sms/selected-provider`
  - `management.guardian.getPhoneFactorSelectedProvider()`
  - `management.getGuardianPhoneFactorSelectedProvider()` (alias)
- `PUT /api/v2/guardian/factors/sms/selected-provider`
  - `management.guardian.updatePhoneFactorSelectedProvider()`
  - `management.updateGuardianPhoneFactorSelectedProvider()` (alias)
- `GET /api/v2/guardian/factors/phone/message-types`
  - `management.guardian.getPhoneFactorMessageTypes()`
  - `management.getGuardianPhoneFactorMessageTypes()` (alias)
- `PUT /api/v2/guardian/factors/phone/message-types`
  - `management.guardian.updatePhoneFactorMessageTypes()`
  - `management.updateGuardianPhoneFactorMessageTypes()` (alias)

These endpoints are going to be publicly documented in [our API explorer](https://auth0.com/docs/api/management/v2) once we kick off our Voice MFA beta program.

### References

https://auth0team.atlassian.net/browse/MFA-310

### Testing

- Do a manual round of testing by calling the methods.
- Generate the jsdoc (`npm run jsdoc:generate`) and browse the resulting documentation website to ensure the methods are clearly documented.

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
