### PR TITLE
Added deleteUserByEmail to ConnectionsManager

### DIFF
--- a/src/management/ConnectionsManager.js
+++ b/src/management/ConnectionsManager.js
@@ -50,6 +50,20 @@ var ConnectionsManager = function(options) {
     options.tokenProvider
   );
   this.resource = new RetryRestClient(auth0RestClient, options.retry);
+
+  /**
+   * Provides an abstraction layer for consuming the
+   * {@link https://auth0.com/docs/api/management/v2#!/Connections/delete_users_by_email
+   * endpoint}.
+   *
+   * @type {external:RestClient}
+   */
+  var userAuth0RestClient = new Auth0RestClient(
+    options.baseUrl + '/connections/:id/users',
+    clientOptions,
+    options.tokenProvider
+  );
+  this.user = new RetryRestClient(userAuth0RestClient, options.retry);
 };
 
 /**
@@ -177,5 +191,43 @@ utils.wrapPropertyMethod(ConnectionsManager, 'update', 'resource.patch');
  * @return  {Promise|undefined}
  */
 utils.wrapPropertyMethod(ConnectionsManager, 'delete', 'resource.delete');
+
+/**
+ * Delete a connection user by email.
+ *
+ * @method    delete
+ * @memberOf  module:management.ConnectionsManager.prototype
+ *
+ * @example
+ * management.connections.deleteUserByEmail({ id: CONNECTION_ID, email:USER_EMAIL }, function (err) {
+ *   if (err) {
+ *     // Handle error.
+ *   }
+ *
+ *   // User deleted.
+ * });
+ *
+ * @param   {Object}    params          Connection parameters.
+ * @param   {String}    params.id       Connection ID.
+ * @param   {String}    params.email    User Email.
+ * @param   {Function}  [cb]            Callback function.
+ *
+ * @return  {Promise|undefined}
+ */
+ConnectionsManager.prototype.deleteUserByEmail = function(params, cb) {
+  if (typeof params !== 'object' || typeof params.email !== 'string' || params.email.length < 1) {
+    throw new ArgumentError('You must provide an email for the deleteUserByEmail method');
+  }
+
+  if (!params.id) {
+    throw new ArgumentError('The connection id cannot be null or undefined');
+  }
+
+  if (cb && cb instanceof Function) {
+    return this.user.delete(params, {}, cb);
+  }
+
+  return this.user.delete(params, {});
+};
 
 module.exports = ConnectionsManager;

--- a/test/management/connections.tests.js
+++ b/test/management/connections.tests.js
@@ -454,4 +454,77 @@ describe('ConnectionsManager', function() {
       });
     });
   });
+
+  describe('#delete user', function() {
+    var id = 5;
+    var email = 'user@domain.com';
+    var endpoint = '/connections/' + id + '/users?email=' + encodeURIComponent(email);
+
+    beforeEach(function() {
+      this.request = nock(API_URL)
+        .delete(endpoint, {})
+        .reply(200);
+    });
+
+    it('should accept a callback', function(done) {
+      this.connections.deleteUserByEmail({ id: id, email: email }, done.bind(null, null));
+    });
+
+    it('should return a promise when no callback is given', function(done) {
+      this.connections.deleteUserByEmail({ id: id, email: email }).then(done.bind(null, null));
+    });
+
+    it('should perform a DELETE request to ' + endpoint, function(done) {
+      var request = this.request;
+
+      this.connections.deleteUserByEmail({ id: id, email: email }).then(function() {
+        expect(request.isDone()).to.be.true;
+
+        done();
+      });
+    });
+
+    it('should pass any errors to the promise catch handler', function(done) {
+      nock.cleanAll();
+
+      var request = nock(API_URL)
+        .delete(endpoint, {})
+        .reply(500);
+
+      this.connections.deleteUserByEmail({ id: id, email: email }).catch(function(err) {
+        expect(err).to.exist;
+
+        done();
+      });
+    });
+
+    it('should require a connection id', function() {
+      expect(this.connections.deleteUserByEmail.bind(null, { email: email })).to.throw(
+        ArgumentError,
+        'The connection id cannot be null or undefined'
+      );
+    });
+
+    it('should require an email', function() {
+      expect(this.connections.deleteUserByEmail.bind(null, { id: id })).to.throw(
+        ArgumentError,
+        'You must provide an email for the deleteUserByEmail method'
+      );
+    });
+
+    it('should include the token in the Authorization header', function(done) {
+      nock.cleanAll();
+
+      var request = nock(API_URL)
+        .delete(endpoint, {})
+        .matchHeader('Authorization', 'Bearer ' + this.token)
+        .reply(200);
+
+      this.connections.deleteUserByEmail({ id: id, email: email }).then(function() {
+        expect(request.isDone()).to.be.true;
+
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
The ConnectionsManager did not have a function calling the [Delete Connections User](https://auth0.com/docs/api/management/v2#!/Connections/delete_users_by_email) endpoint which deletes users by their email address.  Added a deleteUserByEmail function to ConnectionsManager for this endpoint.  Unit tests added to connections.tests.js for the new function.