### PR TITLE
Adding docs for secondary and federated identity email verification

### DIFF
--- a/src/management/JobsManager.js
+++ b/src/management/JobsManager.js
@@ -362,6 +362,9 @@ JobsManager.prototype.errors = function(params, cb) {
  *
  * @param   {Object}    data          User data object.
  * @param   {String}    data.user_id  ID of the user to be verified.
+ * @param   {Object}    [data.identity] Used to verify secondary, federated, and passwordless-email identities
+ * @param   {String}    data.identity.user_id user_id of the identity
+ * @param   {String}    data.identity.provider provider of the identity
  * @param   {Function}  [cb]          Callback function.
  *
  * @return  {Promise|undefined}

--- a/src/management/JobsManager.js
+++ b/src/management/JobsManager.js
@@ -362,9 +362,10 @@ JobsManager.prototype.errors = function(params, cb) {
  *
  * @param   {Object}    data          User data object.
  * @param   {String}    data.user_id  ID of the user to be verified.
- * @param   {Object}    [data.identity] Used to verify secondary, federated, and passwordless-email identities
- * @param   {String}    data.identity.user_id user_id of the identity
- * @param   {String}    data.identity.provider provider of the identity
+ * @param   {String}    [data.client_id] client_id of the client (application). If no value provided, the global Client ID will be used.
+ * @param   {Object}    [data.identity] Used to verify secondary, federated, and passwordless-email identities.
+ * @param   {String}    data.identity.user_id user_id of the identity.
+ * @param   {String}    data.identity.provider provider of the identity.
  * @param   {Function}  [cb]          Callback function.
  *
  * @return  {Promise|undefined}

--- a/src/management/TicketsManager.js
+++ b/src/management/TicketsManager.js
@@ -98,6 +98,14 @@ TicketsManager.prototype.changePassword = function(data, cb) {
  *   }
  * });
  *
+ * @param   {Object}  data
+ * @param   {String}  [data.result_url] URL the user will be redirected to once ticket is used
+ * @param   {String}  data.user_id user_id for whom the ticket should be created
+ * @param   {Integer} [data.ttl_sec] Number of seconds for which the ticket is valid before expiration
+ * @param   {Boolean} [data.includeEmailInRedirect] Whether to include the email address as part of the returnUrl in the reset_email (true), or not (false)
+ * @param   {Object}  [data.identity] Used to verify secondary, federated, and passwordless-email identities
+ * @param   {String}  data.identity.user_id user_id of the identity
+ * @param   {String}  data.identity.provider provider of the identity
  * @param   {Function}  [cb]  Callback function.
  * @return  {Promise}
  */

--- a/src/management/TicketsManager.js
+++ b/src/management/TicketsManager.js
@@ -99,13 +99,13 @@ TicketsManager.prototype.changePassword = function(data, cb) {
  * });
  *
  * @param   {Object}  data
- * @param   {String}  [data.result_url] URL the user will be redirected to once ticket is used
- * @param   {String}  data.user_id user_id for whom the ticket should be created
- * @param   {Integer} [data.ttl_sec] Number of seconds for which the ticket is valid before expiration
- * @param   {Boolean} [data.includeEmailInRedirect] Whether to include the email address as part of the returnUrl in the reset_email (true), or not (false)
- * @param   {Object}  [data.identity] Used to verify secondary, federated, and passwordless-email identities
- * @param   {String}  data.identity.user_id user_id of the identity
- * @param   {String}  data.identity.provider provider of the identity
+ * @param   {String}  [data.result_url] URL the user will be redirected to once ticket is used.
+ * @param   {String}  data.user_id user_id for whom the ticket should be created.
+ * @param   {Integer} [data.ttl_sec] Number of seconds for which the ticket is valid before expiration.
+ * @param   {Boolean} [data.includeEmailInRedirect] Whether to include the email address as part of the result_url (true), or not (false).
+ * @param   {Object}  [data.identity] Used to verify secondary, federated, and passwordless-email identities.
+ * @param   {String}  data.identity.user_id user_id of the identity.
+ * @param   {String}  data.identity.provider provider of the identity.
  * @param   {Function}  [cb]  Callback function.
  * @return  {Promise}
  */


### PR DESCRIPTION
### Changes

Docs for verification of secondary and federated identity emails.  Also added some missing existing parameters.

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
