### PR TITLE
Document user_id parameter for getDeviceCredentials API

### DIFF
--- a/src/management/DeviceCredentialsManager.js
+++ b/src/management/DeviceCredentialsManager.js
@@ -88,10 +88,13 @@ utils.wrapPropertyMethod(DeviceCredentialsManager, 'createPublicKey', 'resource.
  * @memberOf  module:management.DeviceCredentialsManager.prototype
  *
  * @example
- * management.deviceCredentials.getAll(function (err, credentials) {
+ * var params = {user_id: "USER_ID"};
+ *
+ * management.deviceCredentials.getAll(params, function (err, credentials) {
  *   console.log(credentials.length);
  * });
  *
+ * @param   {Object}    params  Credential parameters.
  * @param   {Function}  [cb]    Callback function.
  *
  * @return  {Promise|undefined}

--- a/src/management/index.js
+++ b/src/management/index.js
@@ -791,10 +791,13 @@ utils.wrapPropertyMethod(
  * @memberOf  module:management.ManagementClient.prototype
  *
  * @example
- * management.getDeviceCredentials(function (err, credentials) {
+ * var params = {user_id: "USER_ID"};
+ *
+ * management.getDeviceCredentials(params, function (err, credentials) {
  *   console.log(credentials.length);
  * });
  *
+ * @param   {Object}    params  Credential parameters.
  * @param   {Function}  [cb]    Callback function.
  *
  * @return  {Promise|undefined}


### PR DESCRIPTION
### Changes

The `user_id` parameter is now required when calling the GET `/api/v2/device-credentials` endpoint. This is currently supported by the SDK, but the documentation did not reflect how to pass parameters. This change is docs-only.

### References

https://auth0.com/docs/api/management/v2#!/Device_Credentials/get_device_credentials

### Testing

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
