### PR TITLE
Use [REDACTED] instead of [SANITIZED] when cleaning errors

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -33,7 +33,7 @@ var sanitizeErrors = function(collection) {
 
   Object.keys(collection).forEach(function(key) {
     if (key.toLowerCase().match('password|secret|authorization')) {
-      collection[key] = '[SANITIZED]';
+      collection[key] = '[REDACTED]';
     }
   });
 };

--- a/test/auth0-rest-client.tests.js
+++ b/test/auth0-rest-client.tests.js
@@ -163,7 +163,7 @@ describe('Auth0RestClient', function() {
     var client = new Auth0RestClient(API_URL + '/some-resource', options, this.providerMock);
     client.getAll().catch(function(err) {
       const originalRequestHeader = err.originalError.response.request._header;
-      expect(originalRequestHeader.authorization).to.equal('[SANITIZED]');
+      expect(originalRequestHeader.authorization).to.equal('[REDACTED]');
       done();
       nock.cleanAll();
     });

--- a/test/errors.tests.js
+++ b/test/errors.tests.js
@@ -6,10 +6,10 @@ describe('Errors', function() {
   describe('sanitizeErrorRequestData', function() {
     describe('when passed in error is missing request data and headers', function() {
       var error = { response: { request: {} } };
-      var sanitizedError = errors.sanitizeErrorRequestData(error);
+      var redactedError = errors.sanitizeErrorRequestData(error);
 
       it('should return error', function() {
-        expect(sanitizedError).to.equal(error);
+        expect(redactedError).to.equal(error);
       });
     });
 
@@ -25,8 +25,8 @@ describe('Errors', function() {
           }
         }
       };
-      const sanitizedError = errors.sanitizeErrorRequestData(error);
-      const sanitizedData = sanitizedError.response.request._data;
+      const redactedError = errors.sanitizeErrorRequestData(error);
+      const sanitizedData = redactedError.response.request._data;
 
       it('should return [REDACTED] for DATA_SECRET', function() {
         expect(sanitizedData.DATA_SECRET).to.equal('[REDACTED]');
@@ -49,8 +49,8 @@ describe('Errors', function() {
           }
         }
       };
-      const sanitizedError = errors.sanitizeErrorRequestData(error);
-      const sanitizedData = sanitizedError.response.request._header;
+      const redactedError = errors.sanitizeErrorRequestData(error);
+      const sanitizedData = redactedError.response.request._header;
 
       it('should return [REDACTED] for authorization', function() {
         expect(sanitizedData.authorization).to.equal('[REDACTED]');
@@ -100,7 +100,7 @@ describe('Errors', function() {
       expect(sanitizedError.originalError).to.eql(originalError);
     });
 
-    it('should sanitize the original error sensitive information', function() {
+    it('should redact the original error sensitive information', function() {
       expect(sanitizedError.originalError.response.request._data.secret).to.eql('[REDACTED]');
     });
 

--- a/test/errors.tests.js
+++ b/test/errors.tests.js
@@ -28,11 +28,11 @@ describe('Errors', function() {
       const sanitizedError = errors.sanitizeErrorRequestData(error);
       const sanitizedData = sanitizedError.response.request._data;
 
-      it('should return [SANITIZED] for DATA_SECRET', function() {
-        expect(sanitizedData.DATA_SECRET).to.equal('[SANITIZED]');
+      it('should return [REDACTED] for DATA_SECRET', function() {
+        expect(sanitizedData.DATA_SECRET).to.equal('[REDACTED]');
       });
-      it('should return [SANITIZED] for DATA_SECRET', function() {
-        expect(sanitizedData.DATA_SECRET).to.equal('[SANITIZED]');
+      it('should return [REDACTED] for DATA_SECRET', function() {
+        expect(sanitizedData.DATA_SECRET).to.equal('[REDACTED]');
       });
       it('should return original value for USER_NAME', function() {
         expect(sanitizedData.USER_NAME).to.equal(sanitizedData.USER_NAME);
@@ -52,8 +52,8 @@ describe('Errors', function() {
       const sanitizedError = errors.sanitizeErrorRequestData(error);
       const sanitizedData = sanitizedError.response.request._header;
 
-      it('should return [SANITIZED] for authorization', function() {
-        expect(sanitizedData.authorization).to.equal('[SANITIZED]');
+      it('should return [REDACTED] for authorization', function() {
+        expect(sanitizedData.authorization).to.equal('[REDACTED]');
       });
     });
   });
@@ -101,7 +101,7 @@ describe('Errors', function() {
     });
 
     it('should sanitize the original error sensitive information', function() {
-      expect(sanitizedError.originalError.response.request._data.secret).to.eql('[SANITIZED]');
+      expect(sanitizedError.originalError.response.request._data.secret).to.eql('[REDACTED]');
     });
 
     it('should have a stack with the message and location the error was created', function() {


### PR DESCRIPTION
### Testing 

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
