### PR TITLE
Remove bluebird

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "axios": "^0.19.2",
     "bluebird": "^3.5.5",
+    "es6-promisify": "^6.1.1",
     "form-data": "^3.0.0",
     "jsonwebtoken": "^8.5.1",
     "jwks-rsa": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "homepage": "https://github.com/auth0/node-auth0",
   "dependencies": {
     "axios": "^0.19.2",
-    "bluebird": "^3.5.5",
     "es6-promisify": "^6.1.1",
     "form-data": "^3.0.0",
     "jsonwebtoken": "^8.5.1",

--- a/src/Auth0RestClient.js
+++ b/src/Auth0RestClient.js
@@ -1,5 +1,4 @@
 var RestClient = require('rest-facade').Client;
-var Promise = require('bluebird');
 var ArgumentError = require('rest-facade').ArgumentError;
 
 var utils = require('./utils');

--- a/src/RetryRestClient.js
+++ b/src/RetryRestClient.js
@@ -1,4 +1,3 @@
-var Promise = require('bluebird');
 var retry = require('retry');
 var ArgumentError = require('rest-facade').ArgumentError;
 var assign = Object.assign || require('object.assign');

--- a/src/auth/OAUthWithIDTokenValidation.js
+++ b/src/auth/OAUthWithIDTokenValidation.js
@@ -1,6 +1,5 @@
 var jwt = require('jsonwebtoken');
 var jwksClient = require('jwks-rsa');
-var Promise = require('bluebird');
 
 var ArgumentError = require('rest-facade').ArgumentError;
 var validateIdToken = require('./idToken').validate;

--- a/src/management/JobsManager.js
+++ b/src/management/JobsManager.js
@@ -1,6 +1,5 @@
 var axios = require('axios');
 var extend = require('util')._extend;
-var Promise = require('bluebird');
 var FormData = require('form-data');
 var fs = require('fs');
 

--- a/src/management/ManagementTokenProvider.js
+++ b/src/management/ManagementTokenProvider.js
@@ -2,7 +2,7 @@ var ArgumentError = require('rest-facade').ArgumentError;
 var assign = Object.assign || require('object.assign');
 var AuthenticationClient = require('../auth');
 var memoizer = require('lru-memoizer');
-var Promise = require('bluebird');
+var es6Promisify = require('es6-promisify');
 
 var DEFAULT_OPTIONS = { enableCache: true };
 
@@ -73,7 +73,7 @@ var ManagementTokenProvider = function(options) {
   this.authenticationClient = new AuthenticationClient(authenticationClientOptions);
 
   var self = this;
-  this.getCachedAccessToken = Promise.promisify(
+  this.getCachedAccessToken = es6Promisify.promisify(
     memoizer({
       load: function(options, callback) {
         self

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,3 @@
-var Promise = require('bluebird');
 var pkg = require('../package.json');
 
 /**

--- a/test/auth/oauth-with-idtoken-validation.tests.js
+++ b/test/auth/oauth-with-idtoken-validation.tests.js
@@ -1,5 +1,4 @@
 var expect = require('chai').expect;
-var Promise = require('bluebird');
 var sinon = require('sinon');
 var proxyquire = require('proxyquire');
 

--- a/test/auth/oauth.tests.js
+++ b/test/auth/oauth.tests.js
@@ -1,7 +1,6 @@
 var expect = require('chai').expect;
 var extend = require('util')._extend;
 var nock = require('nock');
-var Promise = require('bluebird');
 var sinon = require('sinon');
 
 // Constants.

--- a/test/management/client-grants.tests.js
+++ b/test/management/client-grants.tests.js
@@ -1,6 +1,5 @@
 var expect = require('chai').expect;
 var nock = require('nock');
-var Promise = require('bluebird');
 
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';

--- a/test/management/client.tests.js
+++ b/test/management/client.tests.js
@@ -1,6 +1,5 @@
 var expect = require('chai').expect;
 var nock = require('nock');
-var Promise = require('bluebird');
 
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';

--- a/test/management/grants.tests.js
+++ b/test/management/grants.tests.js
@@ -1,6 +1,5 @@
 var expect = require('chai').expect;
 var nock = require('nock');
-var Promise = require('bluebird');
 
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';

--- a/test/management/resource-servers.tests.js
+++ b/test/management/resource-servers.tests.js
@@ -1,6 +1,5 @@
 var expect = require('chai').expect;
 var nock = require('nock');
-var Promise = require('bluebird');
 
 var SRC_DIR = '../../src';
 var API_URL = 'https://tenant.auth0.com';

--- a/test/retry-rest-client.tests.js
+++ b/test/retry-rest-client.tests.js
@@ -1,7 +1,6 @@
 var expect = require('chai').expect;
 var nock = require('nock');
 
-var Promise = require('bluebird');
 var ArgumentError = require('rest-facade').ArgumentError;
 var RestClient = require('rest-facade').Client;
 var RetryRestClient = require('../src/RetryRestClient');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1548,7 +1548,7 @@ es6-promisify@^5.0.0:
   dependencies:
     es6-promise "^4.0.3"
 
-es6-promisify@^6.0.0:
+es6-promisify@^6.0.0, es6-promisify@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-6.1.1.tgz#46837651b7b06bf6fff893d03f29393668d01621"
   integrity sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg==


### PR DESCRIPTION
### Changes

This was originally attempted as part of migrating to ES6 #304, but it seems like `node-auth0` and its dependencies were not ready at that point. Since then, `rest-facade` has removed bluebird as was requested by @luisrudge in https://github.com/ngonzalvez/rest-facade/issues/39. As mentioned by @andreineculau in https://github.com/auth0/node-auth0/issues/180#issuecomment-304944996, the bluebird dependency should be treated as peer dependency, and leave it up to the app developers to implement a polyfill if necessary.

I did not put any requirements for the node engine in the package.json, as that would technically be a breaking change. Considering that `rest-facade@1.10.2` removed bluebird and `node-auth0` use `^1.12.0` it is safe to assume that older apps already have (or are required to have) some sort of promise polyfill.

Finally, there was a bluebird `promisify` function in `src/management/ManagementTokenProvider.js`, which I replaced with `es6-promisify` instead of node's `util` as was discussed in https://github.com/auth0/node-auth0/issues/307#issuecomment-427039169.

_Note: because `jsdoc` and `webpack` still depend on bluebird, the `yarn.lock` does not remove the dependency. However, I believe that's fine as both are dev dependencies._

### References

- https://github.com/auth0/node-auth0/pull/304 es6 migration
- https://github.com/auth0/node-auth0/issues/180 bluebird dependency discussion
- https://github.com/ngonzalvez/rest-facade/issues/39 rest-facade bluebird removal
- https://github.com/auth0/node-auth0/issues/307 es6-promisify discussion

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
