### PR TITLE
Fix deprecation warning in importUserJobs

### DIFF
--- a/src/management/JobsManager.js
+++ b/src/management/JobsManager.js
@@ -124,42 +124,7 @@ JobsManager.prototype.get = function(params, cb) {
   return this.jobs.get(params);
 };
 
-/**
- * Given a path to a file and a connection id, create a new job that imports the
- * users contained in the file or JSON string and associate them with the given
- * connection.
- * @deprecated since version 2.26. It will be deleted in version 3.0.
- *
- * @method   importUsers
- * @memberOf module:management.JobsManager.prototype
- *
- * @example
- * var params = {
- *   connection_id: '{CONNECTION_ID}',
- *   users: '{PATH_TO_USERS_FILE}' // or users_json: '{USERS_JSON_STRING}'
- * };
- *
- * management.jobs.importUsers(params, function (err) {
- *   if (err) {
- *     // Handle error.
- *   }
- * });
- *
- * @param   {Object}    data                          Users import data.
- * @param   {String}    data.connection_id            connection_id of the connection to which users will be imported.
- * @param   {String}    [data.users]                  Path to the users data file. Either users or users_json is mandatory.
- * @param   {String}    [data.users_json]             JSON data for the users.
- * @param   {Boolean}   [data.upsert]                 Whether to update users if they already exist (true) or to ignore them (false).
- * @param   {Boolean}   [data.send_completion_email]  Whether to send a completion email to all tenant owners when the job is finished (true) or not (false).
- * @param   {Function}  [cb]                          Callback function.
- *
- * @return  {Promise|undefined}
- */
-JobsManager.prototype.importUsers = function(data, cb) {
-  console.warn(
-    '"importUsers" has been deprecated as it was inconsistent with the API. Please, use "importUsersJob" which returns the response data directly.'
-  );
-
+JobsManager.prototype._importUsers = function(data, cb) {
   var options = this.options;
   var url = options.baseUrl + '/jobs/users-imports';
   var userData = data.users_json ? Buffer.from(data.users_json) : fs.createReadStream(data.users);
@@ -207,6 +172,44 @@ JobsManager.prototype.importUsers = function(data, cb) {
  * Given a path to a file and a connection id, create a new job that imports the
  * users contained in the file or JSON string and associate them with the given
  * connection.
+ * @deprecated since version 2.26. It will be deleted in version 3.0.
+ *
+ * @method   importUsers
+ * @memberOf module:management.JobsManager.prototype
+ *
+ * @example
+ * var params = {
+ *   connection_id: '{CONNECTION_ID}',
+ *   users: '{PATH_TO_USERS_FILE}' // or users_json: '{USERS_JSON_STRING}'
+ * };
+ *
+ * management.jobs.importUsers(params, function (err) {
+ *   if (err) {
+ *     // Handle error.
+ *   }
+ * });
+ *
+ * @param   {Object}    data                          Users import data.
+ * @param   {String}    data.connection_id            connection_id of the connection to which users will be imported.
+ * @param   {String}    [data.users]                  Path to the users data file. Either users or users_json is mandatory.
+ * @param   {String}    [data.users_json]             JSON data for the users.
+ * @param   {Boolean}   [data.upsert]                 Whether to update users if they already exist (true) or to ignore them (false).
+ * @param   {Boolean}   [data.send_completion_email]  Whether to send a completion email to all tenant owners when the job is finished (true) or not (false).
+ * @param   {Function}  [cb]                          Callback function.
+ *
+ * @return  {Promise|undefined}
+ */
+JobsManager.prototype.importUsers = function(data, cb) {
+  console.warn(
+    '"importUsers" has been deprecated as it was inconsistent with the API. Please, use "importUsersJob" which returns the response data directly.'
+  );
+  return this._importUsers(data, cb);
+};
+
+/**
+ * Given a path to a file and a connection id, create a new job that imports the
+ * users contained in the file or JSON string and associate them with the given
+ * connection.
  *
  * @method   importUsersJob
  * @memberOf module:management.JobsManager.prototype
@@ -234,7 +237,7 @@ JobsManager.prototype.importUsers = function(data, cb) {
  * @return  {Promise|undefined}
  */
 JobsManager.prototype.importUsersJob = function(data, cb) {
-  var promise = this.importUsers(data).then(response => response.data);
+  var promise = this._importUsers(data).then(response => response.data);
 
   // Don't return a promise if a callback was given.
   if (cb && cb instanceof Function) {


### PR DESCRIPTION
### Changes

The `importUsers` deprecation warning shows up even when using the suggested `importUsersJob`, this MR fixes that by moving `importUsers` logic into `_importUsers`. Then only when the deprecated function is called we display the warning.

### References

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] `management.jobs.importUsersJob` **should not** display a warning
- [x] `management.jobs.importUsers` **should** display a warning
- [x] Existing tests still run

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
