### PR TITLE
[SDK-1975] Use exponential backoff rather than rate limit headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "prettier": "^1.18.2",
     "pretty-quick": "^1.11.1",
     "proxyquire": "^2.1.1",
-    "sinon": "^7.3.2",
+    "sinon": "^9.0.3",
     "string-replace-webpack-plugin": "0.1.3",
     "webpack": "^4.36.1"
   }

--- a/src/RetryRestClient.js
+++ b/src/RetryRestClient.js
@@ -3,7 +3,7 @@ var ArgumentError = require('rest-facade').ArgumentError;
 var assign = Object.assign || require('object.assign');
 
 var DEFAULT_OPTIONS = {
-  maxRetries: 10,
+  maxRetries: 3,
   enabled: true,
   randomize: true
 };

--- a/src/RetryRestClient.js
+++ b/src/RetryRestClient.js
@@ -91,7 +91,6 @@ RetryRestClient.prototype.handleRetry = function(method, args) {
   };
 
   var self = this;
-  let now = Date.now();
   return new Promise(function(resolve, reject) {
     var operation = retry.operation(retryOptions);
 
@@ -102,7 +101,6 @@ RetryRestClient.prototype.handleRetry = function(method, args) {
           resolve(body);
         })
         .catch(function(err) {
-          now = Date.now();
           if (err && err.statusCode === 429 && operation.retry(err)) {
             return;
           }

--- a/test/retry-rest-client.tests.js
+++ b/test/retry-rest-client.tests.js
@@ -207,7 +207,7 @@ describe('RetryRestClient', function() {
       .get('/')
       .reply(200, { success: true });
 
-    var client = new RetryRestClient(restClientSpy);
+    var client = new RetryRestClient(restClientSpy, { maxRetries: 10 });
 
     client.getAll().then(function(data) {
       clock.restore();

--- a/test/retry-rest-client.tests.js
+++ b/test/retry-rest-client.tests.js
@@ -1,4 +1,5 @@
 var expect = require('chai').expect;
+var sinon = require('sinon');
 var nock = require('nock');
 
 var ArgumentError = require('rest-facade').ArgumentError;
@@ -102,15 +103,7 @@ describe('RetryRestClient', function() {
 
     nock(API_URL)
       .get('/')
-      .reply(
-        429,
-        { success: false },
-        {
-          'x-ratelimit-limit': '10',
-          'x-ratelimit-remaining': '0',
-          'x-ratelimit-reset': '1508253300'
-        }
-      )
+      .reply(429, { success: false })
       .get('/')
       .reply(200, { success: true });
 
@@ -124,104 +117,56 @@ describe('RetryRestClient', function() {
 
   it('should try 4 times when request fails 3 times', function(done) {
     var self = this;
+    var clock = sinon.useFakeTimers();
     var timesCalled = 0;
     var restClientSpy = {
       getAll: function() {
         timesCalled += 1;
-        return self.restClient.getAll(arguments);
+        return self.restClient.getAll(arguments).finally(() => {
+          clock.runAllAsync();
+        });
       }
     };
 
     nock(API_URL)
       .get('/')
       .times(3)
-      .reply(
-        429,
-        { success: false },
-        {
-          'x-ratelimit-limit': '10',
-          'x-ratelimit-remaining': '0',
-          'x-ratelimit-reset': '1508253300'
-        }
-      )
+      .reply(429, { success: false })
       .get('/')
       .reply(200, { success: true });
 
     var client = new RetryRestClient(restClientSpy);
     client.getAll().then(function(data) {
+      clock.restore();
       expect(data.success).to.be.true;
       expect(timesCalled).to.be.equal(4);
       done();
     });
   });
 
-  it('should retry 2 times and fail when maxRetries is exceeded with no delay time', function(done) {
+  it('should retry 2 times and fail when maxRetries is exceeded', function(done) {
     var self = this;
+    var clock = sinon.useFakeTimers();
     var timesCalled = 0;
     var restClientSpy = {
       getAll: function() {
         timesCalled += 1;
-        return self.restClient.getAll(arguments);
+        return self.restClient.getAll(arguments).finally(() => {
+          clock.runAllAsync();
+        });
       }
     };
 
     nock(API_URL)
       .get('/')
       .times(4)
-      .reply(
-        429,
-        { success: false },
-        {
-          'x-ratelimit-limit': '10',
-          'x-ratelimit-remaining': '0',
-          'x-ratelimit-reset': (new Date().getTime() - 10) / 1000 // past.
-        }
-      );
+      .reply(429, { success: false });
 
     var client = new RetryRestClient(restClientSpy, { maxRetries: 3 });
     client.getAll().catch(function(err) {
+      clock.restore();
       expect(err).to.not.null;
       expect(timesCalled).to.be.equal(4); // Initial call + 3 retires.
-      done();
-    });
-  });
-
-  it('should retry 2 times and fail when maxRetries is exceeded with delay time', function(done) {
-    var self = this;
-    var timesCalled = 0;
-    var restClientSpy = {
-      getAll: function() {
-        timesCalled += 1;
-        return self.restClient.getAll(arguments);
-      }
-    };
-
-    nock(API_URL)
-      .get('/')
-      .reply(
-        429,
-        { success: false },
-        {
-          'x-ratelimit-limit': '10',
-          'x-ratelimit-remaining': '0',
-          'x-ratelimit-reset': (new Date().getTime() + 50) / 1000 // epoch seconds + 50ms
-        }
-      )
-      .get('/')
-      .reply(
-        429,
-        { success: false },
-        {
-          'x-ratelimit-limit': '10',
-          'x-ratelimit-remaining': '0',
-          'x-ratelimit-reset': (new Date().getTime() + 100) / 1000 // epoch seconds + 100ms
-        }
-      );
-
-    var client = new RetryRestClient(restClientSpy, { maxRetries: 1 });
-    client.getAll().catch(function(err) {
-      expect(err).to.not.null;
-      expect(timesCalled).to.be.equal(2); // Initial call + 3 retires.
       done();
     });
   });
@@ -239,38 +184,44 @@ describe('RetryRestClient', function() {
     });
   });
 
-  it('should delay the retry using x-ratelimit-reset header value and succeed after retry', function(done) {
+  it('should delay the retry using exponential backoff and succeed after retry', function(done) {
     var self = this;
-    var calledAt = [];
+    var clock = sinon.useFakeTimers();
+    var backoffs = [];
+    var prev = 0;
     var restClientSpy = {
       getAll: function() {
-        calledAt.push(new Date().getTime());
-        return self.restClient.getAll(arguments);
+        var now = new Date().getTime();
+        backoffs.push(now - prev);
+        prev = now;
+        return self.restClient.getAll(arguments).finally(() => {
+          clock.runAllAsync();
+        });
       }
     };
 
     nock(API_URL)
       .get('/')
-      .reply(
-        429,
-        { success: false },
-        {
-          'x-ratelimit-limit': '10',
-          'x-ratelimit-remaining': '0',
-          'x-ratelimit-reset': (new Date().getTime() + 50) / 1000 // epoch seconds + 50ms
-        }
-      )
+      .times(9)
+      .reply(429, { success: false })
       .get('/')
       .reply(200, { success: true });
 
     var client = new RetryRestClient(restClientSpy);
 
     client.getAll().then(function(data) {
+      clock.restore();
       expect(data.success).to.be.true;
-      expect(calledAt.length).to.be.equal(2);
+      expect(backoffs.length).to.be.equal(10);
 
-      var elapsedTime = calledAt[1] - calledAt[0];
-      expect(elapsedTime).to.be.above(49); // Time between the requests should at least be more than 49ms
+      expect(backoffs.shift()).to.be.equal(0, 'first request should happen immediately');
+      for (var i = 0; i < backoffs.length; i++) {
+        expect(backoffs[i] / 1000).to.be.within(
+          Math.pow(2, i),
+          2 * Math.pow(2, i),
+          'attempt ' + (i + 1) + ' in secs'
+        );
+      }
       done();
     });
   });
@@ -287,15 +238,7 @@ describe('RetryRestClient', function() {
 
     nock(API_URL)
       .get('/')
-      .reply(
-        429,
-        { success: false },
-        {
-          'x-ratelimit-limit': '10',
-          'x-ratelimit-remaining': '0',
-          'x-ratelimit-reset': '1508253300'
-        }
-      );
+      .reply(429, { success: false });
 
     var client = new RetryRestClient(restClientSpy, { enabled: false });
     client.getAll().catch(function(err) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,29 +94,43 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@sinonjs/commons@^1", "@sinonjs/commons@^1.3.0", "@sinonjs/commons@^1.4.0", "@sinonjs/commons@^1.7.0":
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.7.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.0.tgz#c8d68821a854c555bba172f3b06959a0039b236d"
   integrity sha512-wEj54PfsZ5jGSwMX68G8ZXFawcSglQSXqCftWX3ec8MDUzQdHgcKvw97awHbY0efQEL5iKUOAmmVtoYgmrSG4Q==
   dependencies:
     type-detect "4.0.8"
 
-"@sinonjs/formatio@^3.2.1":
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.2.2.tgz#771c60dfa75ea7f2d68e3b94c7e888a78781372c"
-  integrity sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==
+"@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.2":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
+  integrity sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/fake-timers@^6.0.0", "@sinonjs/fake-timers@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz#293674fccb3262ac782c7aadfdeca86b10c75c40"
+  integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+
+"@sinonjs/formatio@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-5.0.1.tgz#f13e713cb3313b1ab965901b01b0828ea6b77089"
+  integrity sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==
   dependencies:
     "@sinonjs/commons" "^1"
-    "@sinonjs/samsam" "^3.1.0"
+    "@sinonjs/samsam" "^5.0.2"
 
-"@sinonjs/samsam@^3.1.0", "@sinonjs/samsam@^3.3.3":
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.3.3.tgz#46682efd9967b259b81136b9f120fd54585feb4a"
-  integrity sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==
+"@sinonjs/samsam@^5.0.2", "@sinonjs/samsam@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-5.1.0.tgz#3afe719232b541bb6cf3411a4c399a188de21ec0"
+  integrity sha512-42nyaQOVunX5Pm6GRJobmzbS7iLI+fhERITnETXzzwDZh+TtDr/Au3yAvXVjFmZ4wEUaE4Y3NFZfKv0bV0cbtg==
   dependencies:
-    "@sinonjs/commons" "^1.3.0"
-    array-from "^2.1.1"
-    lodash "^4.17.15"
+    "@sinonjs/commons" "^1.6.0"
+    lodash.get "^4.4.2"
+    type-detect "^4.0.8"
 
 "@sinonjs/text-encoding@^0.7.1":
   version "0.7.1"
@@ -507,11 +521,6 @@ array-differ@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-2.1.0.tgz#4b9c1c3f14b906757082925769e8ab904f4801b1"
   integrity sha512-KbUpJgx909ZscOc/7CLATBFam7P1Z1QRQInvgT0UztM9Q72aGKCunKASAl7WNW0tnPmPyEMeMhdsfWhfmW037w==
-
-array-from@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
-  integrity sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=
 
 array-union@^1.0.2:
   version "1.0.2"
@@ -1399,10 +1408,15 @@ des.js@^1.0.0:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
 
-diff@3.5.0, diff@^3.5.0:
+diff@3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+
+diff@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -2000,6 +2014,11 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
 has-symbols@^1.0.0, has-symbols@^1.0.1:
   version "1.0.1"
@@ -2821,18 +2840,6 @@ log-symbols@2.2.0:
   dependencies:
     chalk "^2.0.1"
 
-lolex@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-4.2.0.tgz#ddbd7f6213ca1ea5826901ab1222b65d714b3cd7"
-  integrity sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==
-
-lolex@^5.0.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-5.1.2.tgz#953694d098ce7c07bc5ed6d0e42bc6c0c6d5a367"
-  integrity sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==
-  dependencies:
-    "@sinonjs/commons" "^1.7.0"
-
 lower-case-first@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/lower-case-first/-/lower-case-first-1.0.2.tgz#e5da7c26f29a7073be02d52bac9980e5922adfa1"
@@ -3221,15 +3228,15 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-nise@^1.5.2:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/nise/-/nise-1.5.3.tgz#9d2cfe37d44f57317766c6e9408a359c5d3ac1f7"
-  integrity sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==
+nise@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-4.0.4.tgz#d73dea3e5731e6561992b8f570be9e363c4512dd"
+  integrity sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==
   dependencies:
-    "@sinonjs/formatio" "^3.2.1"
+    "@sinonjs/commons" "^1.7.0"
+    "@sinonjs/fake-timers" "^6.0.0"
     "@sinonjs/text-encoding" "^0.7.1"
     just-extend "^4.0.2"
-    lolex "^5.0.1"
     path-to-regexp "^1.7.0"
 
 nock@^10.0.6:
@@ -4206,18 +4213,18 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
-sinon@^7.3.2:
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.5.0.tgz#e9488ea466070ea908fd44a3d6478fd4923c67ec"
-  integrity sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==
+sinon@^9.0.3:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-9.0.3.tgz#bffc3ec28c936332cd2a41833547b9eed201ecff"
+  integrity sha512-IKo9MIM111+smz9JGwLmw5U1075n1YXeAq8YeSFlndCLhAL5KGn6bLgu7b/4AYHTV/LcEMcRm2wU2YiL55/6Pg==
   dependencies:
-    "@sinonjs/commons" "^1.4.0"
-    "@sinonjs/formatio" "^3.2.1"
-    "@sinonjs/samsam" "^3.3.3"
-    diff "^3.5.0"
-    lolex "^4.2.0"
-    nise "^1.5.2"
-    supports-color "^5.5.0"
+    "@sinonjs/commons" "^1.7.2"
+    "@sinonjs/fake-timers" "^6.0.1"
+    "@sinonjs/formatio" "^5.0.1"
+    "@sinonjs/samsam" "^5.1.0"
+    diff "^4.0.2"
+    nise "^4.0.4"
+    supports-color "^7.1.0"
 
 slash@^3.0.0:
   version "3.0.0"
@@ -4596,7 +4603,7 @@ supports-color@6.0.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^5.3.0, supports-color@^5.5.0:
+supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -4609,6 +4616,13 @@ supports-color@^6.1.0:
   integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
+
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
 
 swap-case@^1.1.0:
   version "1.1.2"
@@ -4765,7 +4779,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==


### PR DESCRIPTION
### Changes

Currently `RetryRestClient` uses the `X-RateLimit-Reset` header to calculate retry duration, eg if you hit a per minute rate limit, the backoff for 10 retries will be: [60s, 60s, ..., 60s, 60s]

But the `X-RateLimit-Reset` only tells when the `bucket` of available requests is full - not when there might be a request available in the bucket to use. So 60s will likely be too long to wait, and cause things like Webtasks to fail.

Instead we are switching to a generic exponential backoff with jitter, starting at ~1sec, eg for 10 retries: [ 1-2s, 2-4s, 4-8s, 8-16s, 16-32s, 32-64s, 64-128s, 128-256s, 256-512s, 512-1024s ]

Calculated by `(1 + Math.random()) * 1sec * Math.pow(2, attemptNumber)` - happy to tweak these numbers if we want

The SDK already uses [retry](https://github.com/tim-kos/node-retry) - so we can leverage the default behaviour of this library

### References

https://auth0team.atlassian.net/browse/ESD-8390
https://auth0.com/docs/policies/rate-limit-policy#handle-rates-limitations-in-code
https://auth0.com/docs/policies/rate-limit-policy/management-api-endpoint-rate-limits
https://github.com/tim-kos/node-retry

### Testing

- [x] This change adds unit test coverage
~~- [ ] This change adds integration test coverage~~
