### PR TITLE
feat: drop object.assign polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "jsonwebtoken": "^8.5.1",
     "jwks-rsa": "^1.10.0",
     "lru-memoizer": "^2.1.0",
-    "object.assign": "^4.1.0",
     "rest-facade": "^1.12.0",
     "retry": "^0.12.0"
   },

--- a/src/RetryRestClient.js
+++ b/src/RetryRestClient.js
@@ -1,7 +1,5 @@
 var retry = require('retry');
 var ArgumentError = require('rest-facade').ArgumentError;
-var assign = Object.assign || require('object.assign');
-
 var DEFAULT_OPTIONS = { maxRetries: 10, enabled: true };
 
 /**
@@ -19,7 +17,7 @@ var RetryRestClient = function(restClient, options) {
     throw new ArgumentError('Must provide RestClient');
   }
 
-  var params = assign({}, DEFAULT_OPTIONS, options);
+  var params = Object.assign({}, DEFAULT_OPTIONS, options);
 
   if (typeof params.enabled !== 'boolean') {
     throw new ArgumentError('Must provide enabled boolean value');

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -4,7 +4,6 @@ var util = require('util');
 var utils = require('../utils');
 var jsonToBase64 = utils.jsonToBase64;
 var ArgumentError = require('rest-facade').ArgumentError;
-var assign = Object.assign || require('object.assign');
 
 // Authenticators.
 var OAuthAuthenticator = require('./OAuthAuthenticator');
@@ -64,7 +63,7 @@ var AuthenticationClient = function(options) {
     clientId: options.clientId,
     domain: options.domain,
     clientSecret: options.clientSecret,
-    headers: assign(defaultHeaders, options.headers || {}),
+    headers: Object.assign(defaultHeaders, options.headers || {}),
     baseUrl: util.format(BASE_URL_FORMAT, options.domain),
     supportedAlgorithms: options.supportedAlgorithms,
     __bypassIdTokenValidation: options.__bypassIdTokenValidation

--- a/src/management/ManagementTokenProvider.js
+++ b/src/management/ManagementTokenProvider.js
@@ -1,5 +1,4 @@
 var ArgumentError = require('rest-facade').ArgumentError;
-var assign = Object.assign || require('object.assign');
 var AuthenticationClient = require('../auth');
 var memoizer = require('lru-memoizer');
 var es6Promisify = require('es6-promisify');
@@ -26,7 +25,7 @@ var ManagementTokenProvider = function(options) {
     throw new ArgumentError('Options must be an object');
   }
 
-  var params = assign({}, DEFAULT_OPTIONS, options);
+  var params = Object.assign({}, DEFAULT_OPTIONS, options);
 
   if (!params.domain || params.domain.length === 0) {
     throw new ArgumentError('Must provide a domain');

--- a/src/management/index.js
+++ b/src/management/index.js
@@ -5,7 +5,6 @@ var utils = require('../utils');
 var jsonToBase64 = utils.jsonToBase64;
 var generateClientInfo = utils.generateClientInfo;
 var ArgumentError = require('rest-facade').ArgumentError;
-var assign = Object.assign || require('object.assign');
 
 // Managers.
 var ClientsManager = require('./ClientsManager');
@@ -114,12 +113,12 @@ var ManagementClient = function(options) {
   };
 
   var managerOptions = {
-    headers: assign(defaultHeaders, options.headers || {}),
+    headers: Object.assign(defaultHeaders, options.headers || {}),
     baseUrl: baseUrl
   };
 
   if (options.token === undefined) {
-    var config = assign(
+    var config = Object.assign(
       { audience: util.format(MANAGEMENT_API_AUD_FORMAT, options.domain) },
       options
     );

--- a/test/management/management-client.tests.js
+++ b/test/management/management-client.tests.js
@@ -1,7 +1,6 @@
 var expect = require('chai').expect;
 var nock = require('nock');
 var sinon = require('sinon');
-var assign = Object.assign || require('object.assign');
 var proxyquire = require('proxyquire');
 
 var ManagementClient = require('../../src/management');
@@ -49,7 +48,10 @@ describe('ManagementClient', function() {
   });
 
   it('should expose an instance of ManagementClient when withTokenProviderConfig and audience is passed', function() {
-    var config = assign({ audience: 'https://auth0-node-sdk.auth0.com/api/v2/' }, withTokenConfig);
+    var config = Object.assign(
+      { audience: 'https://auth0-node-sdk.auth0.com/api/v2/' },
+      withTokenConfig
+    );
     expect(new ManagementClient(config)).to.exist.to.be.an.instanceOf(ManagementClient);
   });
 
@@ -61,7 +63,7 @@ describe('ManagementClient', function() {
   });
 
   it('should raise an error when the domain is not set', function() {
-    var config = assign({}, withTokenConfig);
+    var config = Object.assign({}, withTokenConfig);
     delete config.domain;
     var client = ManagementClient.bind(null, config);
 
@@ -69,7 +71,7 @@ describe('ManagementClient', function() {
   });
 
   it('should raise an error when the domain is not valid', function() {
-    var config = assign({}, withTokenConfig);
+    var config = Object.assign({}, withTokenConfig);
     config.domain = '';
     var client = ManagementClient.bind(null, config);
 
@@ -77,7 +79,7 @@ describe('ManagementClient', function() {
   });
 
   it('should raise an error when the token is not valid', function() {
-    var config = assign({}, withTokenConfig);
+    var config = Object.assign({}, withTokenConfig);
     config.token = '';
     var client = ManagementClient.bind(null, config);
 
@@ -85,7 +87,7 @@ describe('ManagementClient', function() {
   });
 
   it('should raise an error when the token and clientId are not set', function() {
-    var config = assign({}, withTokenProviderConfig);
+    var config = Object.assign({}, withTokenProviderConfig);
     delete config.clientId;
     var client = ManagementClient.bind(null, config);
 
@@ -93,7 +95,7 @@ describe('ManagementClient', function() {
   });
 
   it('should raise an error when the token and clientSecret are not set', function() {
-    var config = assign({}, withTokenProviderConfig);
+    var config = Object.assign({}, withTokenProviderConfig);
     delete config.clientSecret;
     var client = ManagementClient.bind(null, config);
 
@@ -102,7 +104,7 @@ describe('ManagementClient', function() {
 
   describe('getAccessToken', function() {
     it('should return token provided in config', function(done) {
-      var config = assign({}, withTokenConfig);
+      var config = Object.assign({}, withTokenConfig);
       var client = new ManagementClient(config);
 
       client.getAccessToken().then(function(accessToken) {
@@ -111,7 +113,7 @@ describe('ManagementClient', function() {
       });
     });
     it('should return token from provider', function(done) {
-      var config = assign({}, withTokenProviderConfig);
+      var config = Object.assign({}, withTokenProviderConfig);
       var client = new ManagementClient(config);
 
       nock('https://' + config.domain)
@@ -218,7 +220,7 @@ describe('ManagementClient', function() {
             'Another-header': 'test-header'
           };
 
-          var options = assign({ headers: customHeaders }, withTokenConfig);
+          var options = Object.assign({ headers: customHeaders }, withTokenConfig);
           var client = new ManagementClient(options);
 
           expect(
@@ -831,7 +833,7 @@ describe('ManagementClient', function() {
     });
 
     before(function() {
-      var config = assign({}, withTokenConfig);
+      var config = Object.assign({}, withTokenConfig);
       this.client = new ManagementClient(config);
     });
 
@@ -918,7 +920,7 @@ describe('ManagementClient', function() {
     ];
 
     before(function() {
-      var config = assign({}, withTokenConfig);
+      var config = Object.assign({}, withTokenConfig);
       this.client = new ManagementClient(config);
     });
 

--- a/test/management/management-token-provider.tests.js
+++ b/test/management/management-token-provider.tests.js
@@ -1,6 +1,5 @@
 var expect = require('chai').expect;
 var nock = require('nock');
-var assign = Object.assign || require('object.assign');
 var ArgumentError = require('rest-facade').ArgumentError;
 var SanitizedError = require('../../src/errors').SanitizedError;
 
@@ -25,7 +24,7 @@ describe('ManagementTokenProvider', function() {
   });
 
   it('should raise an error when domain is not set', function() {
-    var config = assign({}, defaultConfig);
+    var config = Object.assign({}, defaultConfig);
     delete config.domain;
     var provider = ManagementTokenProvider.bind(null, config);
 
@@ -33,7 +32,7 @@ describe('ManagementTokenProvider', function() {
   });
 
   it('should raise an error when domain is not valid', function() {
-    var config = assign({}, defaultConfig);
+    var config = Object.assign({}, defaultConfig);
     config.domain = '';
     var provider = ManagementTokenProvider.bind(null, config);
 
@@ -41,7 +40,7 @@ describe('ManagementTokenProvider', function() {
   });
 
   it('should raise an error when clientId is not set', function() {
-    var config = assign({}, defaultConfig);
+    var config = Object.assign({}, defaultConfig);
     delete config.clientId;
     var provider = ManagementTokenProvider.bind(null, config);
 
@@ -49,7 +48,7 @@ describe('ManagementTokenProvider', function() {
   });
 
   it('should raise an error when clientId is not valid', function() {
-    var config = assign({}, defaultConfig);
+    var config = Object.assign({}, defaultConfig);
     config.clientId = '';
     var provider = ManagementTokenProvider.bind(null, config);
 
@@ -57,7 +56,7 @@ describe('ManagementTokenProvider', function() {
   });
 
   it('should raise an error when clientSecret is not set', function() {
-    var config = assign({}, defaultConfig);
+    var config = Object.assign({}, defaultConfig);
     delete config.clientSecret;
     var provider = ManagementTokenProvider.bind(null, config);
 
@@ -65,7 +64,7 @@ describe('ManagementTokenProvider', function() {
   });
 
   it('should raise an error when clientSecret is not valid', function() {
-    var config = assign({}, defaultConfig);
+    var config = Object.assign({}, defaultConfig);
     config.clientSecret = '';
     var provider = ManagementTokenProvider.bind(null, config);
 
@@ -73,7 +72,7 @@ describe('ManagementTokenProvider', function() {
   });
 
   it('should raise an error when enableCache is not of type boolean', function() {
-    var config = assign({}, defaultConfig);
+    var config = Object.assign({}, defaultConfig);
     config.enableCache = 'string';
     var provider = ManagementTokenProvider.bind(null, config);
 
@@ -81,7 +80,7 @@ describe('ManagementTokenProvider', function() {
   });
 
   it('should raise an error when scope is not of type string', function() {
-    var config = assign({}, defaultConfig);
+    var config = Object.assign({}, defaultConfig);
     config.scope = ['foo', 'bar'];
     var provider = ManagementTokenProvider.bind(null, config);
 
@@ -89,35 +88,35 @@ describe('ManagementTokenProvider', function() {
   });
 
   it('should set scope to read:users when passed as read:users', function() {
-    var config = assign({}, defaultConfig);
+    var config = Object.assign({}, defaultConfig);
     config.scope = 'read:users';
     var provider = new ManagementTokenProvider(config);
     expect(provider.options.scope).to.be.equal('read:users');
   });
 
   it('should set enableCache to true when not specified', function() {
-    var config = assign({}, defaultConfig);
+    var config = Object.assign({}, defaultConfig);
     delete config.enableCache;
     var provider = new ManagementTokenProvider(config);
     expect(provider.options.enableCache).to.be.true;
   });
 
   it('should set enableCache to true when passed as true', function() {
-    var config = assign({}, defaultConfig);
+    var config = Object.assign({}, defaultConfig);
     config.enableCache = true;
     var provider = new ManagementTokenProvider(config);
     expect(provider.options.enableCache).to.be.true;
   });
 
   it('should set enableCache to false when passed as false', function() {
-    var config = assign({}, defaultConfig);
+    var config = Object.assign({}, defaultConfig);
     config.enableCache = false;
     var provider = new ManagementTokenProvider(config);
     expect(provider.options.enableCache).to.be.false;
   });
 
   it('should raise an error when the cacheTTLInSeconds is not of type number', function() {
-    var config = assign({}, defaultConfig);
+    var config = Object.assign({}, defaultConfig);
     config.cacheTTLInSeconds = 'string';
     var provider = ManagementTokenProvider.bind(null, config);
 
@@ -125,7 +124,7 @@ describe('ManagementTokenProvider', function() {
   });
 
   it('should raise an error when the cacheTTLInSeconds is not a greater than 0', function() {
-    var config = assign({}, defaultConfig);
+    var config = Object.assign({}, defaultConfig);
     config.cacheTTLInSeconds = -1;
     var provider = ManagementTokenProvider.bind(null, config);
 
@@ -133,14 +132,14 @@ describe('ManagementTokenProvider', function() {
   });
 
   it('should set cacheTTLInSeconds to 15 when passed as 15', function() {
-    var config = assign({}, defaultConfig);
+    var config = Object.assign({}, defaultConfig);
     config.cacheTTLInSeconds = 15;
     var provider = new ManagementTokenProvider(config);
     expect(provider.options.cacheTTLInSeconds).to.be.equal(15);
   });
 
   it('should handle network errors correctly', function(done) {
-    var config = assign({}, defaultConfig);
+    var config = Object.assign({}, defaultConfig);
     config.domain = 'domain';
     var client = new ManagementTokenProvider(config);
 
@@ -170,7 +169,7 @@ describe('ManagementTokenProvider', function() {
   });
 
   it('should return access token', function(done) {
-    var config = assign({}, defaultConfig);
+    var config = Object.assign({}, defaultConfig);
     config.domain = 'auth0-node-sdk-1.auth0.com';
     var client = new ManagementTokenProvider(config);
 
@@ -190,7 +189,7 @@ describe('ManagementTokenProvider', function() {
   });
 
   it('should contain correct body payload', function(done) {
-    var config = assign({}, defaultConfig);
+    var config = Object.assign({}, defaultConfig);
     config.domain = 'auth0-node-sdk-2.auth0.com';
     var client = new ManagementTokenProvider(config);
 
@@ -212,7 +211,7 @@ describe('ManagementTokenProvider', function() {
   });
 
   it('should return access token from the cache the second call', function(done) {
-    var config = assign({}, defaultConfig);
+    var config = Object.assign({}, defaultConfig);
     config.domain = 'auth0-node-sdk-3.auth0.com';
     var client = new ManagementTokenProvider(config);
 
@@ -247,7 +246,7 @@ describe('ManagementTokenProvider', function() {
   });
 
   it('should request new access token when cache is expired', function(done) {
-    var config = assign({}, defaultConfig);
+    var config = Object.assign({}, defaultConfig);
     config.domain = 'auth0-node-sdk-4.auth0.com';
     var client = new ManagementTokenProvider(config);
 
@@ -286,7 +285,7 @@ describe('ManagementTokenProvider', function() {
   });
 
   it('should return new access token on the second call when cache is disabled', function(done) {
-    var config = assign({}, defaultConfig);
+    var config = Object.assign({}, defaultConfig);
     config.enableCache = false;
     config.domain = 'auth0-node-sdk-3.auth0.com';
     var client = new ManagementTokenProvider(config);
@@ -326,7 +325,7 @@ describe('ManagementTokenProvider', function() {
   });
 
   it('should return cached access token on the second call when cacheTTLInSeconds is not passed', function(done) {
-    var config = assign({}, defaultConfig);
+    var config = Object.assign({}, defaultConfig);
     config.domain = 'auth0-node-sdk-5.auth0.com';
     config.cacheTTLInSeconds = 10; // 1sec / 40 = 25ms;
     var client = new ManagementTokenProvider(config);
@@ -364,7 +363,7 @@ describe('ManagementTokenProvider', function() {
   });
 
   it('should return new access token on the second call when cacheTTLInSeconds is passed', function(done) {
-    var config = assign({}, defaultConfig);
+    var config = Object.assign({}, defaultConfig);
     config.domain = 'auth0-node-sdk-6.auth0.com';
     config.cacheTTLInSeconds = 1 / 40; // 1sec / 40 = 25ms
     var client = new ManagementTokenProvider(config);
@@ -402,7 +401,7 @@ describe('ManagementTokenProvider', function() {
   });
 
   it('should pass the correct payload in the body of the oauth/token request with cache enabled', function(done) {
-    var config = assign({}, defaultConfig);
+    var config = Object.assign({}, defaultConfig);
     var client = new ManagementTokenProvider(config);
 
     nock('https://' + config.domain)
@@ -422,7 +421,7 @@ describe('ManagementTokenProvider', function() {
   });
 
   it('should pass the correct payload in the body of the oauth/token request with cache disabled', function(done) {
-    var config = assign({}, defaultConfig);
+    var config = Object.assign({}, defaultConfig);
     config.enableCache = false;
     var client = new ManagementTokenProvider(config);
 


### PR DESCRIPTION
### Changes

No functional changes, but the removal of a long unnecessary prod dependency.

`Object.assign` has been present since node 4 (2015). The library
even uses `Object.assign` without the polyfill in some places,
so is unlikely to work on node 4, even before this commit.

This library now pulls in es-abstract, which pulls in a ridiculous tree of libraries:

```
│ ├─┬ object.assign@4.1.1
│ │ ├─┬ define-properties@1.1.3
│ │ │ └── object-keys@1.1.1 deduped
│ │ ├─┬ es-abstract@1.18.0-next.0
│ │ │ ├─┬ es-to-primitive@1.2.1
│ │ │ │ ├── is-callable@1.2.2 deduped
│ │ │ │ ├── is-date-object@1.0.2
│ │ │ │ └─┬ is-symbol@1.0.3
│ │ │ │   └── has-symbols@1.0.1 deduped
│ │ │ ├── function-bind@1.1.1
│ │ │ ├─┬ has@1.0.3
│ │ │ │ └── function-bind@1.1.1 deduped
│ │ │ ├── has-symbols@1.0.1 deduped
│ │ │ ├── is-callable@1.2.2
│ │ │ ├── is-negative-zero@2.0.0
│ │ │ ├─┬ is-regex@1.1.1
│ │ │ │ └── has-symbols@1.0.1 deduped
│ │ │ ├── object-inspect@1.8.0
│ │ │ ├── object-keys@1.1.1 deduped
│ │ │ ├── object.assign@4.1.1 deduped
│ │ │ ├─┬ string.prototype.trimend@1.0.1
│ │ │ │ ├── define-properties@1.1.3 deduped
│ │ │ │ └─┬ es-abstract@1.17.6
│ │ │ │   ├── es-to-primitive@1.2.1 deduped
│ │ │ │   ├── function-bind@1.1.1 deduped
│ │ │ │   ├── has@1.0.3 deduped
│ │ │ │   ├── has-symbols@1.0.1 deduped
│ │ │ │   ├── is-callable@1.2.2 deduped
│ │ │ │   ├── is-regex@1.1.1 deduped
│ │ │ │   ├── object-inspect@1.8.0 deduped
│ │ │ │   ├── object-keys@1.1.1 deduped
│ │ │ │   ├── object.assign@4.1.1 deduped
│ │ │ │   ├── string.prototype.trimend@1.0.1 deduped
│ │ │ │   └── string.prototype.trimstart@1.0.1 deduped
│ │ │ └─┬ string.prototype.trimstart@1.0.1
│ │ │   ├── define-properties@1.1.3 deduped
│ │ │   └─┬ es-abstract@1.17.6
│ │ │     ├── es-to-primitive@1.2.1 deduped
│ │ │     ├── function-bind@1.1.1 deduped
│ │ │     ├── has@1.0.3 deduped
│ │ │     ├── has-symbols@1.0.1 deduped
│ │ │     ├── is-callable@1.2.2 deduped
│ │ │     ├── is-regex@1.1.1 deduped
│ │ │     ├── object-inspect@1.8.0 deduped
│ │ │     ├── object-keys@1.1.1 deduped
│ │ │     ├── object.assign@4.1.1 deduped
│ │ │     ├── string.prototype.trimend@1.0.1 deduped
│ │ │     └── string.prototype.trimstart@1.0.1 deduped
```

### References

https://node.green/#ES2015-built-in-extensions-Object-static-methods-Object-assign

https://github.com/auth0/node-auth0/blob/cfa6903dc506bc2aa8e75a8cb5837299cf7f1fbd/src/errors.js#L52

### Testing

No new functionality.

The code coverage is red apparently because it isn't very good at rounding, not sure what I can do about that?

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
