### PR TITLE
Provide headers on mgmt token fetch

### DIFF
--- a/src/management/ManagementTokenProvider.js
+++ b/src/management/ManagementTokenProvider.js
@@ -19,6 +19,8 @@ var DEFAULT_OPTIONS = { enableCache: true };
  * @param {String}  options.audience                Audience of the Management API.
  * @param {Boolean} [options.enableCache=true]      Enabled or Disable Cache
  * @param {Number}  [options.cacheTTLInSeconds]     By default the `expires_in` value will be used to determine the cached time of the token, this can be overridden.
+ * @param {Object}  [options.headers]               Additional headers that will be added to the outgoing requests.
+ *
  */
 var ManagementTokenProvider = function(options) {
   if (!options || typeof options !== 'object') {
@@ -67,7 +69,8 @@ var ManagementTokenProvider = function(options) {
     clientId: this.options.clientId,
     clientSecret: this.options.clientSecret,
     telemetry: this.options.telemetry,
-    clientInfo: this.options.clientInfo
+    clientInfo: this.options.clientInfo,
+    headers: this.options.headers
   };
   this.authenticationClient = new AuthenticationClient(authenticationClientOptions);
 

--- a/test/management/management-token-provider.tests.js
+++ b/test/management/management-token-provider.tests.js
@@ -138,6 +138,16 @@ describe('ManagementTokenProvider', function() {
     expect(provider.options.cacheTTLInSeconds).to.be.equal(15);
   });
 
+  it('should set headers when passed into options', function() {
+    var config = Object.assign({}, defaultConfig);
+    config.headers = {
+      'User-agent': 'node.js',
+      'Content-Type': 'application/json'
+    };
+    var provider = new ManagementTokenProvider(config);
+    expect(provider.options.headers).to.be.equal(config.headers);
+  });
+
   it('should handle network errors correctly', function(done) {
     var config = Object.assign({}, defaultConfig);
     config.domain = 'domain';


### PR DESCRIPTION
Header options specified in on the Mgmt client aren't used on the token endpoints for the MGMT Client.  This PR passes those options through.