### PR TITLE
feat: use keep alive agent to support persistent connections

### DIFF
--- a/src/Auth0RestClient.js
+++ b/src/Auth0RestClient.js
@@ -2,7 +2,6 @@ var RestClient = require('./KeepAliveRestClient');
 var ArgumentError = require('rest-facade').ArgumentError;
 
 var utils = require('./utils');
-var keepAliveAgent = require('./KeepAliveRestClient');
 var SanitizedError = require('./errors').SanitizedError;
 
 var Auth0RestClient = function(resourceUrl, options, provider) {

--- a/src/Auth0RestClient.js
+++ b/src/Auth0RestClient.js
@@ -1,7 +1,8 @@
-var RestClient = require('rest-facade').Client;
+var RestClient = require('./KeepAliveRestClient');
 var ArgumentError = require('rest-facade').ArgumentError;
 
 var utils = require('./utils');
+var keepAliveAgent = require('./KeepAliveRestClient');
 var SanitizedError = require('./errors').SanitizedError;
 
 var Auth0RestClient = function(resourceUrl, options, provider) {

--- a/src/KeepAliveRestClient.js
+++ b/src/KeepAliveRestClient.js
@@ -1,0 +1,18 @@
+var RestClient = require('rest-facade').Client;
+var keepAliveAgent = require('./utils').keepAliveAgent;
+
+// Wraps the original rest-facade client, providing persistent connections when requested in the input options.
+var KeepAliveRestClient = function(resourceUrl, options) {
+  if (options.keepAlive) {
+    options.request = Object.assign(options.request || {}, {
+      customizer: this.useKeepAliveAgent
+    });
+  }
+  return new RestClient(resourceUrl, options);
+};
+
+KeepAliveRestClient.prototype.useKeepAliveAgent = function(superAgentRequest) {
+  superAgentRequest.agent(keepAliveAgent);
+};
+
+module.exports = KeepAliveRestClient;

--- a/src/auth/DatabaseAuthenticator.js
+++ b/src/auth/DatabaseAuthenticator.js
@@ -1,7 +1,7 @@
 var extend = require('util')._extend;
 
 var ArgumentError = require('rest-facade').ArgumentError;
-var RestClient = require('rest-facade').Client;
+var RestClient = require('../KeepAliveRestClient');
 
 /**
  * @class
@@ -31,6 +31,7 @@ var DatabaseAuthenticator = function(options, oauth) {
    */
   var clientOptions = {
     errorFormatter: { message: 'message', name: 'error' },
+    keepAlive: options.keepAlive || false,
     headers: options.headers
   };
 

--- a/src/auth/DatabaseAuthenticator.js
+++ b/src/auth/DatabaseAuthenticator.js
@@ -10,10 +10,11 @@ var RestClient = require('../KeepAliveRestClient');
  * @constructor
  * @memberOf module:auth
  *
- * @param  {Object}              options            Authenticator options.
- * @param  {String}              options.baseUrl    The auth0 account URL.
- * @param  {String}              [options.clientId] Default client ID.
- * @param  {OAuthAuthenticator}  oauth              OAuthAuthenticator instance.
+ * @param  {Object}              options                    Authenticator options.
+ * @param  {String}              options.baseUrl            The auth0 account URL.
+ * @param  {String}              [options.clientId]         Default client ID.
+ * @param  {Boolean}             [options.keepAlive=false]  Enable HTTP persistent connections.
+ * @param  {OAuthAuthenticator}  oauth                      OAuthAuthenticator instance.
  */
 var DatabaseAuthenticator = function(options, oauth) {
   if (!options) {

--- a/src/auth/OAuthAuthenticator.js
+++ b/src/auth/OAuthAuthenticator.js
@@ -2,8 +2,7 @@ var extend = require('util')._extend;
 var sanitizeArguments = require('../utils').sanitizeArguments;
 
 var ArgumentError = require('rest-facade').ArgumentError;
-var RestClient = require('rest-facade').Client;
-
+var RestClient = require('../KeepAliveRestClient');
 var SanitizedError = require('../errors').SanitizedError;
 var OAUthWithIDTokenValidation = require('./OAUthWithIDTokenValidation');
 
@@ -51,6 +50,7 @@ var OAuthAuthenticator = function(options) {
   var clientOptions = {
     errorCustomizer: SanitizedError,
     errorFormatter: { message: 'message', name: 'error' },
+    keepAlive: options.keepAlive || false,
     headers: options.headers
   };
 

--- a/src/auth/OAuthAuthenticator.js
+++ b/src/auth/OAuthAuthenticator.js
@@ -26,12 +26,13 @@ function getParamsFromOptions(options) {
  * @constructor
  * @memberOf module:auth
  *
- * @param  {Object}              options                             Authenticator options.
- * @param  {String}              options.baseUrl                     The Auth0 account URL.
- * @param  {String}              options.domain                      AuthenticationClient server domain
- * @param  {String}              [options.clientId]                  Default client ID.
- * @param  {String}              [options.clientSecret]              Default client Secret.
- * @param  {Boolean}             [options.__bypassIdTokenValidation] Whether the id_token should be validated or not
+ * @param  {Object}   options                             Authenticator options.
+ * @param  {String}   options.baseUrl                     The Auth0 account URL.
+ * @param  {String}   options.domain                      AuthenticationClient server domain
+ * @param  {String}   [options.clientId]                  Default client ID.
+ * @param  {String}   [options.clientSecret]              Default client Secret.
+ * @param  {Boolean}  [options.__bypassIdTokenValidation] Whether the id_token should be validated or not
+ * @param  {Boolean}  [options.keepAlive=false]           Enable HTTP persistent connections.
  */
 var OAuthAuthenticator = function(options) {
   if (!options) {

--- a/src/auth/PasswordlessAuthenticator.js
+++ b/src/auth/PasswordlessAuthenticator.js
@@ -9,11 +9,12 @@ var RestClient = require('../KeepAliveRestClient');
  * @constructor
  * @memberOf module:auth
  *
- * @param  {Object}              options            Authenticator options.
- * @param  {String}              options.baseUrl    The auth0 account URL.
- * @param  {String}              [options.clientId] Default client ID.
- * @param  {String}              [options.clientSecret] Default client secret.
- * @param  {OAuthAuthenticator}  oauth              OAuthAuthenticator instance.
+ * @param  {Object}              options                    Authenticator options.
+ * @param  {String}              options.baseUrl            The auth0 account URL.
+ * @param  {String}              [options.clientId]         Default client ID.
+ * @param  {String}              [options.clientSecret]     Default client secret.
+ * @param  {Boolean}             [options.keepAlive=false]  Enable HTTP persistent connections.
+ * @param  {OAuthAuthenticator}  oauth                      OAuthAuthenticator instance.
  */
 var PasswordlessAuthenticator = function(options, oauth) {
   if (!options) {

--- a/src/auth/PasswordlessAuthenticator.js
+++ b/src/auth/PasswordlessAuthenticator.js
@@ -1,7 +1,7 @@
 var extend = require('util')._extend;
 
 var ArgumentError = require('rest-facade').ArgumentError;
-var RestClient = require('rest-facade').Client;
+var RestClient = require('../KeepAliveRestClient');
 
 /**
  * @class
@@ -31,6 +31,7 @@ var PasswordlessAuthenticator = function(options, oauth) {
    */
   var clientOptions = {
     errorFormatter: { message: 'message', name: 'error' },
+    keepAlive: options.keepAlive || false,
     headers: options.headers
   };
 

--- a/src/auth/TokensManager.js
+++ b/src/auth/TokensManager.js
@@ -2,6 +2,7 @@ var extend = require('util')._extend;
 var axios = require('axios');
 
 var ArgumentError = require('rest-facade').ArgumentError;
+var keepAliveAgent = require('../utils').keepAliveAgent;
 
 /**
  * @class
@@ -26,6 +27,11 @@ var TokensManager = function(options) {
   this.baseUrl = options.baseUrl;
   this.headers = options.headers || {};
   this.clientId = options.clientId || '';
+  var axiosConfig = {};
+  if (options.keepAlive) {
+    axiosConfig.httpsAgent = keepAliveAgent;
+  }
+  this.axiosInstance = axios.create(axiosConfig);
 };
 
 /**
@@ -66,12 +72,14 @@ TokensManager.prototype.getInfo = function(idToken, cb) {
   }
 
   // Perform the request.
-  var promise = axios({
-    method: 'POST',
-    url: this.baseUrl + '/tokeninfo',
-    data: { id_token: idToken },
-    headers: headers
-  }).then(({ data }) => data);
+  var promise = this.axiosInstance
+    .request({
+      method: 'POST',
+      url: this.baseUrl + '/tokeninfo',
+      data: { id_token: idToken },
+      headers: headers
+    })
+    .then(({ data }) => data);
 
   // Use callback if given.
   if (cb instanceof Function) {
@@ -156,12 +164,14 @@ TokensManager.prototype.getDelegationToken = function(data, cb) {
   }
 
   // Perform the request.
-  var promise = axios({
-    method: 'POST',
-    url: this.baseUrl + '/delegation',
-    data: body,
-    headers: headers
-  }).then(({ data }) => data);
+  var promise = this.axiosInstance
+    .request({
+      method: 'POST',
+      url: this.baseUrl + '/delegation',
+      data: body,
+      headers: headers
+    })
+    .then(({ data }) => data);
 
   // Use callback if given.
   if (cb instanceof Function) {

--- a/src/auth/TokensManager.js
+++ b/src/auth/TokensManager.js
@@ -10,10 +10,11 @@ var keepAliveAgent = require('../utils').keepAliveAgent;
  * @constructor
  * @memberOf module:auth
  *
- * @param  {Object}   options               Manager options.
- * @param  {String}   options.baseUrl       The auth0 account URL.
- * @param  {String}   [options.headers]     Default request headers.
- * @param  {String}   [options.clientId]    Default client ID.
+ * @param  {Object}   options                   Manager options.
+ * @param  {String}   options.baseUrl           The auth0 account URL.
+ * @param  {Boolean}  [options.keepAlive=false] Enable HTTP persistent connections.
+ * @param  {String}   [options.headers]         Default request headers.
+ * @param  {String}   [options.clientId]        Default client ID.
  */
 var TokensManager = function(options) {
   if (typeof options !== 'object') {

--- a/src/auth/UsersManager.js
+++ b/src/auth/UsersManager.js
@@ -10,10 +10,11 @@ var keepAliveAgent = require('../utils').keepAliveAgent;
  * @constructor
  * @memberOf module:auth
  *
- * @param  {Object}   options               Manager options.
- * @param  {String}   options.baseUrl       The auth0 account URL.
- * @param  {String}   [options.headers]     Default request headers.
- * @param  {String}   [options.clientId]    Default client ID.
+ * @param  {Object}   options                    Manager options.
+ * @param  {String}   options.baseUrl            The auth0 account URL.
+ * @param  {String}   [options.headers]          Default request headers.
+ * @param  {String}   [options.clientId]         Default client ID.
+ * @param  {Boolean}  [options.keepAlive=false]  Enable HTTP persistent connections.
  */
 var UsersManager = function(options) {
   if (typeof options !== 'object') {

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -42,8 +42,9 @@ var BASE_URL_FORMAT = 'https://%s';
  * @param   {String}  [options.clientId]                Default client ID.
  * @param   {String}  [options.clientSecret]            Default client Secret.
  * @param   {String}  [options.supportedAlgorithms]     Algorithms that your application expects to receive
- * @param  {Boolean}  [options.__bypassIdTokenValidation] Whether the id_token should be validated or not
+ * @param   {Boolean}  [options.__bypassIdTokenValidation] Whether the id_token should be validated or not
  * @param   {Object}  [options.headers]                 Additional headers that will be added to the outgoing requests.
+ * @param   {Boolean}  [options.keepAlive=false]        Enable HTTP persistent connections.
  */
 var AuthenticationClient = function(options) {
   if (!options || typeof options !== 'object') {
@@ -66,6 +67,7 @@ var AuthenticationClient = function(options) {
     headers: Object.assign(defaultHeaders, options.headers || {}),
     baseUrl: util.format(BASE_URL_FORMAT, options.domain),
     supportedAlgorithms: options.supportedAlgorithms,
+    keepAlive: options.keepAlive || false,
     __bypassIdTokenValidation: options.__bypassIdTokenValidation
   };
 

--- a/src/management/BlacklistedTokensManager.js
+++ b/src/management/BlacklistedTokensManager.js
@@ -35,6 +35,7 @@ var BlacklistedTokensManager = function(options) {
    */
   var clientOptions = {
     errorFormatter: { message: 'message', name: 'error' },
+    keepAlive: options.keepAlive || false,
     headers: options.headers,
     query: { repeatParams: false }
   };

--- a/src/management/BlacklistedTokensManager.js
+++ b/src/management/BlacklistedTokensManager.js
@@ -10,10 +10,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf  module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 var BlacklistedTokensManager = function(options) {
   if (options === null || typeof options !== 'object') {

--- a/src/management/BrandingManager.js
+++ b/src/management/BrandingManager.js
@@ -35,6 +35,7 @@ var BrandingManager = function(options) {
 
   var clientOptions = {
     errorFormatter: { message: 'message', name: 'error' },
+    keepAlive: options.keepAlive || false,
     headers: options.headers,
     query: { repeatParams: false }
   };

--- a/src/management/BrandingManager.js
+++ b/src/management/BrandingManager.js
@@ -15,10 +15,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 var BrandingManager = function(options) {
   if (options === null || typeof options !== 'object') {

--- a/src/management/ClientGrantsManager.js
+++ b/src/management/ClientGrantsManager.js
@@ -37,6 +37,7 @@ var ClientGrantsManager = function(options) {
   var clientOptions = {
     errorFormatter: { message: 'message', name: 'error' },
     headers: options.headers,
+    keepAlive: options.keepAlive || false,
     query: { repeatParams: false }
   };
 

--- a/src/management/ClientGrantsManager.js
+++ b/src/management/ClientGrantsManager.js
@@ -11,10 +11,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 var ClientGrantsManager = function(options) {
   if (options === null || typeof options !== 'object') {

--- a/src/management/ClientsManager.js
+++ b/src/management/ClientsManager.js
@@ -41,6 +41,7 @@ var ClientsManager = function(options) {
   var clientOptions = {
     errorFormatter: { message: 'message', name: 'error' },
     headers: options.headers,
+    keepAlive: options.keepAlive || false,
     query: { repeatParams: false }
   };
 

--- a/src/management/ClientsManager.js
+++ b/src/management/ClientsManager.js
@@ -15,10 +15,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 var ClientsManager = function(options) {
   if (options === null || typeof options !== 'object') {

--- a/src/management/ConnectionsManager.js
+++ b/src/management/ConnectionsManager.js
@@ -9,10 +9,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 var ConnectionsManager = function(options) {
   if (options === null || typeof options !== 'object') {

--- a/src/management/ConnectionsManager.js
+++ b/src/management/ConnectionsManager.js
@@ -34,6 +34,7 @@ var ConnectionsManager = function(options) {
    */
   var clientOptions = {
     headers: options.headers,
+    keepAlive: options.keepAlive || false,
     query: { repeatParams: false }
   };
 

--- a/src/management/CustomDomainsManager.js
+++ b/src/management/CustomDomainsManager.js
@@ -15,10 +15,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 var CustomDomainsManager = function(options) {
   if (options === null || typeof options !== 'object') {

--- a/src/management/CustomDomainsManager.js
+++ b/src/management/CustomDomainsManager.js
@@ -41,6 +41,7 @@ var CustomDomainsManager = function(options) {
   var clientOptions = {
     errorFormatter: { message: 'message', name: 'error' },
     headers: options.headers,
+    keepAlive: options.keepAlive || false,
     query: { repeatParams: false }
   };
 

--- a/src/management/DeviceCredentialsManager.js
+++ b/src/management/DeviceCredentialsManager.js
@@ -15,10 +15,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 var DeviceCredentialsManager = function(options) {
   if (options === null || typeof options !== 'object') {

--- a/src/management/DeviceCredentialsManager.js
+++ b/src/management/DeviceCredentialsManager.js
@@ -41,6 +41,7 @@ var DeviceCredentialsManager = function(options) {
   var clientOptions = {
     errorFormatter: { message: 'message', name: 'error' },
     headers: options.headers,
+    keepAlive: options.keepAlive || false,
     query: { repeatParams: false }
   };
 

--- a/src/management/EmailProviderManager.js
+++ b/src/management/EmailProviderManager.js
@@ -41,6 +41,7 @@ var EmailProviderManager = function(options) {
   var clientOptions = {
     errorFormatter: { message: 'message', name: 'error' },
     headers: options.headers,
+    keepAlive: options.keepAlive || false,
     query: { repeatParams: false }
   };
 

--- a/src/management/EmailProviderManager.js
+++ b/src/management/EmailProviderManager.js
@@ -15,10 +15,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 var EmailProviderManager = function(options) {
   if (options === null || typeof options !== 'object') {

--- a/src/management/EmailTemplatesManager.js
+++ b/src/management/EmailTemplatesManager.js
@@ -16,10 +16,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 var EmailTemplatesManager = function(options) {
   if (!options || 'object' !== typeof options) {

--- a/src/management/EmailTemplatesManager.js
+++ b/src/management/EmailTemplatesManager.js
@@ -37,6 +37,7 @@ var EmailTemplatesManager = function(options) {
    */
   var clientOptions = {
     headers: options.headers,
+    keepAlive: options.keepAlive || false,
     query: { repeatParams: false }
   };
 

--- a/src/management/GrantsManager.js
+++ b/src/management/GrantsManager.js
@@ -11,10 +11,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 var GrantsManager = function(options) {
   if (options === null || typeof options !== 'object') {

--- a/src/management/GrantsManager.js
+++ b/src/management/GrantsManager.js
@@ -37,6 +37,7 @@ var GrantsManager = function(options) {
   var clientOptions = {
     errorFormatter: { message: 'message', name: 'error' },
     headers: options.headers,
+    keepAlive: options.keepAlive || false,
     query: { repeatParams: false }
   };
 

--- a/src/management/GuardianManager.js
+++ b/src/management/GuardianManager.js
@@ -36,6 +36,7 @@ var GuardianManager = function(options) {
   var clientOptions = {
     errorFormatter: { message: 'message', name: 'error' },
     headers: options.headers,
+    keepAlive: options.keepAlive || false,
     query: { repeatParams: false }
   };
 

--- a/src/management/GuardianManager.js
+++ b/src/management/GuardianManager.js
@@ -15,10 +15,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 var GuardianManager = function(options) {
   if (options === null || typeof options !== 'object') {

--- a/src/management/HooksManager.js
+++ b/src/management/HooksManager.js
@@ -16,10 +16,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 var HooksManager = function(options) {
   if (options === null || typeof options !== 'object') {

--- a/src/management/HooksManager.js
+++ b/src/management/HooksManager.js
@@ -41,6 +41,7 @@ var HooksManager = function(options) {
    */
   var clientOptions = {
     headers: options.headers,
+    keepAlive: options.keepAlive || false,
     query: { repeatParams: false }
   };
 

--- a/src/management/JobsManager.js
+++ b/src/management/JobsManager.js
@@ -40,6 +40,7 @@ var JobsManager = function(options) {
   var clientOptions = {
     errorFormatter: { message: 'message', name: 'error' },
     headers: options.headers,
+    keepAlive: options.keepAlive || false,
     query: { repeatParams: false }
   };
 

--- a/src/management/JobsManager.js
+++ b/src/management/JobsManager.js
@@ -19,10 +19,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 var JobsManager = function(options) {
   if (options === null || typeof options !== 'object') {

--- a/src/management/LogStreamsManager.js
+++ b/src/management/LogStreamsManager.js
@@ -10,10 +10,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 var LogStreamsManager = function(options) {
   if (options === null || typeof options !== 'object') {

--- a/src/management/LogStreamsManager.js
+++ b/src/management/LogStreamsManager.js
@@ -35,6 +35,7 @@ var LogStreamsManager = function(options) {
    */
   var clientOptions = {
     headers: options.headers,
+    keepAlive: options.keepAlive || false,
     query: { repeatParams: false }
   };
 

--- a/src/management/LogsManager.js
+++ b/src/management/LogsManager.js
@@ -9,10 +9,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 var LogsManager = function(options) {
   if (options === null || typeof options !== 'object') {

--- a/src/management/LogsManager.js
+++ b/src/management/LogsManager.js
@@ -34,6 +34,7 @@ var LogsManager = function(options) {
    */
   var clientOptions = {
     headers: options.headers,
+    keepAlive: options.keepAlive || false,
     query: { repeatParams: false }
   };
 

--- a/src/management/MigrationsManager.js
+++ b/src/management/MigrationsManager.js
@@ -29,6 +29,7 @@ var MigrationsManager = function(options) {
   var clientOptions = {
     errorFormatter: { message: 'message', name: 'error' },
     headers: options.headers,
+    keepAlive: options.keepAlive || false,
     query: { repeatParams: false }
   };
 

--- a/src/management/MigrationsManager.js
+++ b/src/management/MigrationsManager.js
@@ -8,10 +8,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 var MigrationsManager = function(options) {
   if (options === null || typeof options !== 'object') {

--- a/src/management/PromptsManager.js
+++ b/src/management/PromptsManager.js
@@ -15,10 +15,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 var PromptsManager = function(options) {
   if (options === null || typeof options !== 'object') {

--- a/src/management/PromptsManager.js
+++ b/src/management/PromptsManager.js
@@ -36,6 +36,7 @@ var PromptsManager = function(options) {
   var clientOptions = {
     errorFormatter: { message: 'message', name: 'error' },
     headers: options.headers,
+    keepAlive: options.keepAlive || false,
     query: { repeatParams: false }
   };
 

--- a/src/management/ResourceServersManager.js
+++ b/src/management/ResourceServersManager.js
@@ -15,10 +15,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 
 var ResourceServersManager = function(options) {

--- a/src/management/ResourceServersManager.js
+++ b/src/management/ResourceServersManager.js
@@ -41,6 +41,7 @@ var ResourceServersManager = function(options) {
    */
   var clientOptions = {
     headers: options.headers,
+    keepAlive: options.keepAlive || false,
     query: { repeatParams: false }
   };
 

--- a/src/management/RolesManager.js
+++ b/src/management/RolesManager.js
@@ -41,6 +41,7 @@ var RolesManager = function(options) {
    */
   var clientOptions = {
     headers: options.headers,
+    keepAlive: options.keepAlive || false,
     query: { repeatParams: false }
   };
 

--- a/src/management/RolesManager.js
+++ b/src/management/RolesManager.js
@@ -16,10 +16,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 var RolesManager = function(options) {
   if (options === null || typeof options !== 'object') {

--- a/src/management/RulesConfigsManager.js
+++ b/src/management/RulesConfigsManager.js
@@ -16,10 +16,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 var RulesConfigsManager = function(options) {
   if (options === null || typeof options !== 'object') {

--- a/src/management/RulesConfigsManager.js
+++ b/src/management/RulesConfigsManager.js
@@ -41,6 +41,7 @@ var RulesConfigsManager = function(options) {
    */
   var clientOptions = {
     headers: options.headers,
+    keepAlive: options.keepAlive || false,
     query: { repeatParams: false }
   };
 

--- a/src/management/RulesManager.js
+++ b/src/management/RulesManager.js
@@ -16,10 +16,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 var RulesManager = function(options) {
   if (options === null || typeof options !== 'object') {

--- a/src/management/RulesManager.js
+++ b/src/management/RulesManager.js
@@ -41,6 +41,7 @@ var RulesManager = function(options) {
    */
   var clientOptions = {
     headers: options.headers,
+    keepAlive: options.keepAlive || false,
     query: { repeatParams: false }
   };
 

--- a/src/management/StatsManager.js
+++ b/src/management/StatsManager.js
@@ -35,6 +35,7 @@ var StatsManager = function(options) {
   var clientOptions = {
     errorFormatter: { message: 'message', name: 'error' },
     headers: options.headers,
+    keepAlive: options.keepAlive || false,
     query: { repeatParams: false }
   };
 

--- a/src/management/StatsManager.js
+++ b/src/management/StatsManager.js
@@ -14,10 +14,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 var StatsManager = function(options) {
   if (options === null || typeof options !== 'object') {

--- a/src/management/TenantManager.js
+++ b/src/management/TenantManager.js
@@ -35,6 +35,7 @@ var TenantManager = function(options) {
   var clientOptions = {
     errorFormatter: { message: 'message', name: 'error' },
     headers: options.headers,
+    keepAlive: options.keepAlive || false,
     query: { repeatParams: false }
   };
 

--- a/src/management/TenantManager.js
+++ b/src/management/TenantManager.js
@@ -14,10 +14,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 var TenantManager = function(options) {
   if (options === null || typeof options !== 'object') {

--- a/src/management/TicketsManager.js
+++ b/src/management/TicketsManager.js
@@ -8,10 +8,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 var TicketsManager = function(options) {
   if (options === null || typeof options !== 'object') {

--- a/src/management/TicketsManager.js
+++ b/src/management/TicketsManager.js
@@ -29,6 +29,7 @@ var TicketsManager = function(options) {
   var clientOptions = {
     errorFormatter: { message: 'message', name: 'error' },
     headers: options.headers,
+    keepAlive: options.keepAlive || false,
     query: { repeatParams: false }
   };
 

--- a/src/management/UserBlocksManager.js
+++ b/src/management/UserBlocksManager.js
@@ -14,10 +14,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 var UserBlocksManager = function(options) {
   if (options === null || typeof options !== 'object') {

--- a/src/management/UserBlocksManager.js
+++ b/src/management/UserBlocksManager.js
@@ -35,6 +35,7 @@ var UserBlocksManager = function(options) {
   var clientOptions = {
     errorFormatter: { message: 'message', name: 'error' },
     headers: options.headers,
+    keepAlive: options.keepAlive || false,
     query: { repeatParams: false }
   };
 

--- a/src/management/UsersManager.js
+++ b/src/management/UsersManager.js
@@ -14,10 +14,11 @@ var RetryRestClient = require('../RetryRestClient');
  * @constructor
  * @memberOf module:management
  *
- * @param {Object} options            The client options.
- * @param {String} options.baseUrl    The URL of the API.
- * @param {Object} [options.headers]  Headers to be included in all requests.
- * @param {Object} [options.retry]    Retry Policy Config
+ * @param {Object}  options                   The client options.
+ * @param {String}  options.baseUrl           The URL of the API.
+ * @param {Object}  [options.headers]         Headers to be included in all requests.
+ * @param {Object}  [options.retry]           Retry Policy Config
+ * @param {Boolean} [options.keepAlive=false] Enable HTTP persistent connections.
  */
 var UsersManager = function(options) {
   if (options === null || typeof options !== 'object') {

--- a/src/management/UsersManager.js
+++ b/src/management/UsersManager.js
@@ -35,6 +35,7 @@ var UsersManager = function(options) {
   var clientOptions = {
     errorFormatter: { message: 'message', name: 'error' },
     headers: options.headers,
+    keepAlive: options.keepAlive || false,
     query: { repeatParams: false }
   };
 

--- a/src/management/index.js
+++ b/src/management/index.js
@@ -93,7 +93,7 @@ var MANAGEMENT_API_AUD_FORMAT = 'https://%s/api/v2/';
  * @param   {Boolean} [options.retry.enabled=true]                Enabled or Disable Retry Policy functionality.
  * @param   {Number}  [options.retry.maxRetries=10]               Retry failed requests X times.
  * @param   {Object}  [options.headers]                           Additional headers that will be added to the outgoing requests.
- *  @param   {Boolean}  [options.keepAlive=false]                  Enable HTTP persistent connections.
+ * @param   {Boolean} [options.keepAlive=false]                   Enable HTTP persistent connections.
  *
  */
 var ManagementClient = function(options) {

--- a/src/management/index.js
+++ b/src/management/index.js
@@ -93,6 +93,7 @@ var MANAGEMENT_API_AUD_FORMAT = 'https://%s/api/v2/';
  * @param   {Boolean} [options.retry.enabled=true]                Enabled or Disable Retry Policy functionality.
  * @param   {Number}  [options.retry.maxRetries=10]               Retry failed requests X times.
  * @param   {Object}  [options.headers]                           Additional headers that will be added to the outgoing requests.
+ *  @param   {Boolean}  [options.keepAlive=false]                  Enable HTTP persistent connections.
  *
  */
 var ManagementClient = function(options) {
@@ -114,7 +115,8 @@ var ManagementClient = function(options) {
 
   var managerOptions = {
     headers: Object.assign(defaultHeaders, options.headers || {}),
-    baseUrl: baseUrl
+    baseUrl: baseUrl,
+    keepAlive: options.keepAlive || false
   };
 
   if (options.token === undefined) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 var pkg = require('../package.json');
-
+var HttpsAgent = require('https').Agent;
 /**
  * @module utils
  */
@@ -87,3 +87,8 @@ utils.sanitizeArguments = function(optionsCandidate, cbCandidate) {
     options: optionsCandidate
   };
 };
+
+utils.keepAliveAgent = new HttpsAgent({
+  keepAlive: true,
+  keepAliveMsecs: 30000
+});

--- a/test/management/management-client.tests.js
+++ b/test/management/management-client.tests.js
@@ -233,6 +233,84 @@ describe('ManagementClient', function() {
       }
     });
 
+    describe('when using persistent connections', function() {
+      it('should provide the keep alive option to the rest client', function() {
+        var client = new ManagementClient({
+          token: 'token',
+          domain: 'auth0.com',
+          keepAlive: true
+        });
+
+        expect(client.clients.resource.restClient.restClient.options.keepAlive).to.be.true;
+
+        expect(client.clientGrants.resource.restClient.restClient.options.keepAlive).to.be.true;
+
+        expect(client.grants.resource.restClient.restClient.options.keepAlive).to.be.true;
+
+        expect(client.users.users.restClient.restClient.options.keepAlive).to.be.true;
+        expect(client.users.multifactor.restClient.restClient.options.keepAlive).to.be.true;
+        expect(client.users.identities.restClient.restClient.options.keepAlive).to.be.true;
+        expect(client.users.userLogs.restClient.restClient.options.keepAlive).to.be.true;
+        expect(client.users.enrollments.restClient.restClient.options.keepAlive).to.be.true;
+        expect(client.users.usersByEmail.restClient.restClient.options.keepAlive).to.be.true;
+        expect(client.users.recoveryCodeRegenerations.restClient.restClient.options.keepAlive).to.be
+          .true;
+        expect(client.users.invalidateRememberBrowsers.restClient.restClient.options.keepAlive).to
+          .be.true;
+        expect(client.users.roles.restClient.restClient.options.keepAlive).to.be.true;
+        expect(client.users.permissions.restClient.restClient.options.keepAlive).to.be.true;
+
+        expect(client.guardian.enrollments.restClient.restClient.options.keepAlive).to.be.true;
+        expect(client.guardian.tickets.restClient.restClient.options.keepAlive).to.be.true;
+        expect(client.guardian.factors.restClient.restClient.options.keepAlive).to.be.true;
+        expect(client.guardian.factorsTemplates.restClient.restClient.options.keepAlive).to.be.true;
+        expect(client.guardian.factorsProviders.restClient.restClient.options.keepAlive).to.be.true;
+        expect(client.guardian.factorsPhoneSelectedProvider.restClient.restClient.options.keepAlive)
+          .to.be.true;
+        expect(client.guardian.factorsPhoneMessageTypes.restClient.restClient.options.keepAlive).to
+          .be.true;
+
+        expect(client.customDomains.resource.restClient.restClient.options.keepAlive).to.be.true;
+        expect(client.customDomains.vefifyResource.restClient.restClient.options.keepAlive).to.be
+          .true;
+
+        expect(client.connections.resource.restClient.restClient.options.keepAlive).to.be.true;
+
+        expect(client.deviceCredentials.resource.restClient.restClient.options.keepAlive).to.be
+          .true;
+
+        expect(client.rules.resource.restClient.restClient.options.keepAlive).to.be.true;
+
+        expect(client.blacklistedTokens.resource.restClient.restClient.options.keepAlive).to.be
+          .true;
+
+        expect(client.emailProvider.resource.restClient.restClient.options.keepAlive).to.be.true;
+
+        expect(client.emailTemplates.resource.restClient.restClient.options.keepAlive).to.be.true;
+
+        expect(client.stats.resource.restClient.restClient.options.keepAlive).to.be.true;
+
+        expect(client.tenant.resource.restClient.restClient.options.keepAlive).to.be.true;
+
+        expect(client.jobs.jobs.restClient.restClient.options.keepAlive).to.be.true;
+        expect(client.jobs.usersExports.restClient.restClient.options.keepAlive).to.be.true;
+
+        expect(client.tickets.resource.restClient.restClient.options.keepAlive).to.be.true;
+
+        expect(client.logs.resource.restClient.restClient.options.keepAlive).to.be.true;
+
+        expect(client.resourceServers.resource.restClient.restClient.options.keepAlive).to.be.true;
+
+        expect(client.emailTemplates.resource.restClient.restClient.options.keepAlive).to.be.true;
+
+        expect(client.rulesConfigs.resource.restClient.restClient.options.keepAlive).to.be.true;
+
+        expect(client.roles.resource.restClient.restClient.options.keepAlive).to.be.true;
+        expect(client.roles.permissions.restClient.restClient.options.keepAlive).to.be.true;
+        expect(client.roles.users.restClient.restClient.options.keepAlive).to.be.true;
+      });
+    });
+
     describe('client info', function() {
       it('should configure instances with default telemetry header', function() {
         var utilsStub = {


### PR DESCRIPTION
### Changes

- Add optional `keepAlive` configuration option to the management and auth clients;
- Add optional `keepAlive` configuration option to all the rest-facades;
- Add new `KeepAliveRestClient`, which wraps the original rest-facade `Client`, configuring a customizer to set a custom agent on the superagent request.
- For the clients using axios, use a custom configuration to provided the agent;
- Add tests to check the keep alive configuration;

### References

- Issue: https://github.com/auth0/node-auth0/issues/545
- Rest facade request customizer: https://github.com/ngonzalvez/rest-facade/blob/master/src/Client.js#L279
- Axios with persistent connections: https://github.com/axios/axios/issues/1846
- Why use keep-alive: https://www.lob.com/blog/use-http-keep-alive

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
