### PR TITLE
Incorrect example for "passwordGrant"

### DIFF
--- a/docs/auth_index.js.html
+++ b/docs/auth_index.js.html
@@ -550,7 +550,7 @@ utils.wrapPropertyMethod(
  *   scope: 'openid'  // Optional field.
  * };
  *
- * auth0.oauth.token(data, function (err, userData) {
+ * auth0.passwordGrant(data, function (err, userData) {
  *   if (err) {
  *     // Handle error.
  *   }

--- a/docs/module-auth.AuthenticationClient.html
+++ b/docs/module-auth.AuthenticationClient.html
@@ -2305,7 +2305,7 @@ auth0.getDelegationToken(data, function (err, token) {
   scope: 'openid'  // Optional field.
 };
 
-auth0.oauth.token(data, function (err, userData) {
+auth0.passwordGrant(data, function (err, userData) {
   if (err) {
     // Handle error.
   }

--- a/docs/module-auth.AuthenticationClient.html
+++ b/docs/module-auth.AuthenticationClient.html
@@ -2305,7 +2305,7 @@ auth0.getDelegationToken(data, function (err, token) {
   scope: 'openid'  // Optional field.
 };
 
-auth0.oauth.passwordGrant(data, function (err, userData) {
+auth0.oauth.token(data, function (err, userData) {
   if (err) {
     // Handle error.
   }

--- a/docs/module-auth.AuthenticationClient.html
+++ b/docs/module-auth.AuthenticationClient.html
@@ -2305,7 +2305,7 @@ auth0.getDelegationToken(data, function (err, token) {
   scope: 'openid'  // Optional field.
 };
 
-auth0.oauth.token(data, function (err, userData) {
+auth0.oauth.passwordGrant(data, function (err, userData) {
   if (err) {
     // Handle error.
   }

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -509,7 +509,7 @@ utils.wrapPropertyMethod(
  *   scope: 'openid'  // Optional field.
  * };
  *
- * auth0.oauth.token(data, function (err, userData) {
+ * auth0.oauth.passwordGrant(data, function (err, userData) {
  *   if (err) {
  *     // Handle error.
  *   }

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -509,7 +509,7 @@ utils.wrapPropertyMethod(
  *   scope: 'openid'  // Optional field.
  * };
  *
- * auth0.oauth.passwordGrant(data, function (err, userData) {
+ * auth0.passwordGrant(data, function (err, userData) {
  *   if (err) {
  *     // Handle error.
  *   }


### PR DESCRIPTION
### Changes
Edit example in documentation for `AuthenticationClient.oauth.token `

The "AuthenticationClient.oauth.token" is not a function. 
The correct function is "passwordGrant".

### Testing
* [ ]  This change adds unit test coverage
* [ ]  This change adds integration test coverage

### Checklist
* [x]  I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x]  I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x]  All existing and new tests complete without errors
