### PR TITLE
Expose assignUsersToRole to ManagementClient

### DIFF
--- a/src/management/index.js
+++ b/src/management/index.js
@@ -1411,6 +1411,35 @@ utils.wrapPropertyMethod(ManagementClient, 'getUserRoles', 'users.getRoles');
 utils.wrapPropertyMethod(ManagementClient, 'assignRolestoUser', 'users.assignRoles');
 
 /**
+ * Assign users to a role
+ *
+ * @method    assignUsersToRole
+ * @memberOf  module:management.ManagementClient.prototype
+ *
+ * @example
+ * var params =  { id :'ROLE_ID'};
+ * var data = { "users" : ["userId1","userId2"]};
+ *
+ * management.roles.assignUsers(params, data, function (err, user) {
+ *   if (err) {
+ *     // Handle error.
+ *   }
+ *
+ *   // permissions added.
+ * });
+ *
+ * @param   {String}    params.id                                     ID of the Role.
+ * @param   {Object}    data                                          permissions data
+ * @param   {String}    data.permissions                              Array of permissions
+ * @param   {String}    data.permissions.permission_name              Name of a permission
+ * @param   {String}    data.permissions.resource_server_identifier   Identifier for a resource
+ * @param   {Function}  [cb]                                          Callback function.
+ *
+ * @return  {Promise|undefined}
+ */
+utils.wrapPropertyMethod(ManagementClient, 'assignUsersToRole', 'roles.assignUsers');
+
+/**
  * Remove roles from a user
  *
  * @method    removeRolesFromUser


### PR DESCRIPTION
Similar PR as https://github.com/auth0/node-auth0/pull/553

`roles.assignUsers` had already been implemented but was not exposed to ManagementClient. This PR is to expose it as `assignUsersToRole`.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors