### PR TITLE
Fix passing a custom User-Agent to Axios.

### DIFF
--- a/docs/auth_index.js.html
+++ b/docs/auth_index.js.html
@@ -96,7 +96,7 @@ var AuthenticationClient = function(options) {
   }
 
   var defaultHeaders = {
-    'User-agent': 'node.js/' + process.version.replace('v', ''),
+    'User-Agent': 'node.js/' + process.version.replace('v', ''),
     'Content-Type': 'application/json'
   };
 

--- a/docs/management_index.js.html
+++ b/docs/management_index.js.html
@@ -149,7 +149,7 @@ var ManagementClient = function(options) {
   var userAgent = options.userAgent || 'node.js/' + process.version.replace('v', '');
 
   var defaultHeaders = {
-    'User-agent': 'node.js/' + process.version.replace('v', ''),
+    'User-Agent': 'node.js/' + process.version.replace('v', ''),
     'Content-Type': 'application/json'
   };
 

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -55,7 +55,7 @@ var AuthenticationClient = function(options) {
   }
 
   var defaultHeaders = {
-    'User-agent': 'node.js/' + process.version.replace('v', ''),
+    'User-Agent': 'node.js/' + process.version.replace('v', ''),
     'Content-Type': 'application/json'
   };
 

--- a/src/management/index.js
+++ b/src/management/index.js
@@ -108,7 +108,7 @@ var ManagementClient = function(options) {
   var userAgent = options.userAgent || 'node.js/' + process.version.replace('v', '');
 
   var defaultHeaders = {
-    'User-agent': 'node.js/' + process.version.replace('v', ''),
+    'User-Agent': 'node.js/' + process.version.replace('v', ''),
     'Content-Type': 'application/json'
   };
 

--- a/test/auth/authentication-client.tests.js
+++ b/test/auth/authentication-client.tests.js
@@ -150,7 +150,7 @@ describe('AuthenticationClient', function() {
         domain: 'auth0.com'
       });
 
-      var expected = { 'User-agent': 'node.js/' + process.version.replace('v', '') };
+      var expected = { 'User-Agent': 'node.js/' + process.version.replace('v', '') };
 
       expect(client.oauth.oauth.options.headers).to.contain(expected);
       expect(client.database.dbConnections.options.headers).to.contain(expected);
@@ -161,7 +161,7 @@ describe('AuthenticationClient', function() {
 
     it('should include additional headers when provided', function() {
       var customHeaders = {
-        'User-agent': 'my-user-agent',
+        'User-Agent': 'my-user-agent',
         'Another-header': 'test-header'
       };
 

--- a/test/management/management-client.tests.js
+++ b/test/management/management-client.tests.js
@@ -210,13 +210,13 @@ describe('ManagementClient', function() {
           expect(
             client[manager.property].resource.restClient.restClient.options.headers
           ).to.contain({
-            'User-agent': 'node.js/' + process.version.replace('v', '')
+            'User-Agent': 'node.js/' + process.version.replace('v', '')
           });
         });
 
         it(manager + ' should include additional headers when provided', function() {
           var customHeaders = {
-            'User-agent': 'my-user-agent',
+            'User-Agent': 'my-user-agent',
             'Another-header': 'test-header'
           };
 
@@ -226,7 +226,7 @@ describe('ManagementClient', function() {
           expect(
             client[manager.property].resource.restClient.restClient.options.headers
           ).to.contain({
-            'User-agent': 'my-user-agent',
+            'User-Agent': 'my-user-agent',
             'Another-header': 'test-header'
           });
         });

--- a/test/management/management-token-provider.tests.js
+++ b/test/management/management-token-provider.tests.js
@@ -141,7 +141,7 @@ describe('ManagementTokenProvider', function() {
   it('should set headers when passed into options', function() {
     var config = Object.assign({}, defaultConfig);
     config.headers = {
-      'User-agent': 'node.js',
+      'User-Agent': 'node.js',
       'Content-Type': 'application/json'
     };
     var provider = new ManagementTokenProvider(config);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,15 +1,15 @@
 var Webpack = require('webpack');
-var pkg     = require('./package.json');
+var pkg = require('./package.json');
 
-var StringReplacePlugin = require("string-replace-webpack-plugin");
+var StringReplacePlugin = require('string-replace-webpack-plugin');
 
 module.exports = {
   entry: './src/index.js',
   output: {
     path: './build',
-    filename: pkg.name+'-'+pkg.version+'.min.js',
+    filename: pkg.name + '-' + pkg.version + '.min.js',
     library: 'Auth0',
-    libraryTarget: 'umd',
+    libraryTarget: 'umd'
   },
   node: {
     Buffer: true,
@@ -27,10 +27,10 @@ module.exports = {
         loader: StringReplacePlugin.replace({
           replacements: [
             {
-              // Remove User-agent for browser version
-              pattern: /'User-agent': 'node\.js/gmi,
-              replacement: function (match, p1, offset, string) {
-                return "// 'User-agent': 'node.js";
+              // Remove User-Agent for browser version
+              pattern: /'User-Agent': 'node\.js/gim,
+              replacement: function(match, p1, offset, string) {
+                return "// 'User-Agent': 'node.js";
               }.bind(this)
             }
           ]
@@ -50,6 +50,6 @@ module.exports = {
   resolve: {
     modulesDirectories: ['node_modules'],
     root: __dirname,
-    alias: {},
+    alias: {}
   }
 };


### PR DESCRIPTION
### Changes

- Fix passing a custom User-Agent header to Axios
- Current behavior tries to send two HTTP headers: `User-agent` and `User-Agent`
- Leading to issues such as https://github.com/nock/nock/issues/1969
- Seems like the way to pass a custom user agent string is to pass a properly capitalized header name: https://github.com/axios/axios/issues/2560#issuecomment-555778304


### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
