### PR TITLE
Expose getJobErrors to management client

### DIFF
--- a/src/management/index.js
+++ b/src/management/index.js
@@ -2184,6 +2184,34 @@ utils.wrapPropertyMethod(ManagementClient, 'importUsersJob', 'jobs.importUsersJo
 utils.wrapPropertyMethod(ManagementClient, 'exportUsers', 'jobs.exportUsers');
 
 /**
+ * Given a job ID, retrieve the failed/errored items
+ *
+ * @method   errors
+ * @memberOf module:management.JobsManager.prototype
+ *
+ * @example
+ * var params = {
+ *   id: '{JOB_ID}'
+ * };
+ *
+ * management.jobs.errors(params, function (err, job) {
+ *   if (err) {
+ *     // Handle error.
+ *   }
+ *
+ *   // Retrieved job.
+ *   console.log(job);
+ * });
+ *
+ * @param   {Object}    params        Job parameters.
+ * @param   {String}    params.id     Job ID.
+ * @param   {Function}  [cb]          Callback function.
+ *
+ * @return  {Promise|undefined}
+ */
+utils.wrapPropertyMethod(ManagementClient, 'getJobErrors', 'jobs.errors');
+
+/**
  * Send a verification email to a user.
  *
  * @method    sendEmailVerification


### PR DESCRIPTION
### Changes

`jobs.errors` has already been implemented but was not exposed to ManagementClient. This PR is to expose it as `getJobErrors`.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
