### PR TITLE
[SDK-2261] Add forwardFor support to passwordless calls

### DIFF
--- a/test/auth/passwordless.tests.js
+++ b/test/auth/passwordless.tests.js
@@ -54,6 +54,9 @@ describe('PasswordlessAuthenticator', function() {
         username: 'username',
         password: 'pwd'
       };
+      var options = {
+        forwardedFor: '0.0.0.0'
+      };
 
       beforeEach(function() {
         var oauth = new OAuth(validOptions);
@@ -246,6 +249,25 @@ describe('PasswordlessAuthenticator', function() {
           })
           .catch(done);
       });
+
+      it('should make it possible to pass auth0-forwarded-for header', function(done) {
+        nock.cleanAll();
+
+        var request = nock(API_URL)
+          .post(path, function() {
+            return this.getHeader('auth0-forwarded-for') === options.forwardedFor;
+          })
+          .reply(200);
+
+        this.authenticator
+          .signIn(userData, options)
+          .then(function() {
+            expect(request.isDone()).to.be.true;
+
+            done();
+          })
+          .catch(done);
+      });
     });
 
     describe('/oauth/token', function() {
@@ -253,6 +275,9 @@ describe('PasswordlessAuthenticator', function() {
       var userData = {
         username: 'username',
         otp: '000000'
+      };
+      var options = {
+        forwardedFor: '0.0.0.0'
       };
 
       beforeEach(function() {
@@ -446,6 +471,25 @@ describe('PasswordlessAuthenticator', function() {
           })
           .catch(done);
       });
+
+      it('should make it possible to pass auth0-forwarded-for header', function(done) {
+        nock.cleanAll();
+
+        var request = nock(API_URL)
+          .post(path, function() {
+            return this.getHeader('auth0-forwarded-for') === options.forwardedFor;
+          })
+          .reply(200);
+
+        this.authenticator
+          .signIn(userData, options)
+          .then(function() {
+            expect(request.isDone()).to.be.true;
+
+            done();
+          })
+          .catch(done);
+      });
     });
   });
 
@@ -454,6 +498,9 @@ describe('PasswordlessAuthenticator', function() {
     var userData = {
       email: 'email@domain.com',
       send: 'link'
+    };
+    var options = {
+      forwardedFor: '0.0.0.0'
     };
 
     beforeEach(function() {
@@ -612,12 +659,34 @@ describe('PasswordlessAuthenticator', function() {
         })
         .catch(done);
     });
+
+    it('should make it possible to pass auth0-forwarded-for header', function(done) {
+      nock.cleanAll();
+
+      var request = nock(API_URL)
+        .post(path, function() {
+          return this.getHeader('auth0-forwarded-for') === options.forwardedFor;
+        })
+        .reply(200);
+
+      this.authenticator
+        .sendEmail(userData, options)
+        .then(function() {
+          expect(request.isDone()).to.be.true;
+
+          done();
+        })
+        .catch(done);
+    });
   });
 
   describe('#sendSMS', function() {
     var path = '/passwordless/start';
     var userData = {
       phone_number: '12345678'
+    };
+    var options = {
+      forwardedFor: '0.0.0.0'
     };
 
     beforeEach(function() {
@@ -739,6 +808,25 @@ describe('PasswordlessAuthenticator', function() {
 
       this.authenticator
         .sendSMS(data)
+        .then(function() {
+          expect(request.isDone()).to.be.true;
+
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should make it possible to pass auth0-forwarded-for header', function(done) {
+      nock.cleanAll();
+
+      var request = nock(API_URL)
+        .post(path, function() {
+          return this.getHeader('auth0-forwarded-for') === options.forwardedFor;
+        })
+        .reply(200);
+
+      this.authenticator
+        .sendSMS(userData, options)
         .then(function() {
           expect(request.isDone()).to.be.true;
 


### PR DESCRIPTION
### Changes

Ensure forwardedFor is supported for the passwordless calls just as they are supported for the passwordGrant calls.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
