### PR TITLE
Allow passwordless SMS code verification to use token endpoint

### DIFF
--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -238,9 +238,28 @@ AuthenticationClient.prototype.requestSMSCode = function(data, cb) {
  * @memberOf  module:auth.AuthenticationClient.prototype
  *
  * @example <caption>
- *   Given the user credentials (`phone_number` and `code`), it will do the
- *   authentication on the provider and return a JSON with the `access_token`
- *   and `id_token`.
+ *   Given the user credentials (`phone_number` and `otp`), authenticates
+ *   with the provider using the `/oauth/token` endpoint. Upon successful
+ *   authentication, returns a JSON object containing the `access_token` and
+ *   `id_token`.
+ * </caption>
+ *
+ * var data = {
+ *   username: '{PHONE_NUMBER}'
+ *   otp: '{VERIFICATION_CODE}'
+ * };
+ *
+ * auth0.verifySMSCode(data, function (err) {
+ *   if (err) {
+ *     // Handle error.
+ *   }
+ * });
+ *
+ * @example <caption>
+ *   Given the user credentials (`phone_number` and `password`), authenticates
+ *   with the provider using the deprecated `/oauth/ro` endpoint. Upon successful
+ *   authentication, returns a JSON object containing the `access_token` and
+ *   `id_token`.
  * </caption>
  *
  * var data = {
@@ -266,18 +285,22 @@ AuthenticationClient.prototype.requestSMSCode = function(data, cb) {
  *
  * @param   {Object}    data              Credentials object.
  * @param   {String}    data.username     Phone number.
- * @param   {String}    data.password     Verification code.
- * @param   {String}    data.target       Target client ID.
- * @param   {String}    data.grant_type   Grant type.
+ * @param   {String}    data.otp          Verification code. Use this instead of `password` to use the `/oauth/token` endpoint.
+ * @param   {String}    data.password     Verification code. Use this instead of `otp` to use the `/oauth/ro` endpoint.
  * @param   {Function}  [cb]              Method callback.
  *
  * @return  {Promise|undefined}
  */
 AuthenticationClient.prototype.verifySMSCode = function(data, cb) {
   var translatedData = {
-    username: data.phoneNumber || data.phone_number || data.username,
-    password: data.code || data.password
+    username: data.phoneNumber || data.phone_number || data.username
   };
+
+  if (data.otp) {
+    translatedData.otp = data.otp;
+  } else {
+    translatedData.password = data.code || data.password;
+  }
 
   return this.passwordless.signIn(translatedData, cb);
 };

--- a/test/auth/authentication-client.tests.js
+++ b/test/auth/authentication-client.tests.js
@@ -187,4 +187,38 @@ describe('AuthenticationClient', function() {
       ensureMethod(client, method);
     });
   });
+
+  describe(`verifySMSCode`, () => {
+    before(function() {
+      this.client = new AuthenticationClient({ token: 'token', domain: 'auth0.com' });
+      this.passwordlessMock = sinon.mock(this.client.passwordless);
+      this.callback = function() {};
+    });
+    it('should call signIn with otp if provided', function() {
+      this.passwordlessMock
+        .expects('signIn')
+        .once()
+        .withExactArgs(
+          {
+            username: '123',
+            otp: 'code'
+          },
+          this.callback
+        );
+      this.client.verifySMSCode({ phone_number: '123', otp: 'code' }, this.callback);
+    });
+    it('should call signIn with password if provided', function() {
+      this.passwordlessMock
+        .expects('signIn')
+        .once()
+        .withExactArgs(
+          {
+            username: '123',
+            password: 'code'
+          },
+          this.callback
+        );
+      this.client.verifySMSCode({ phone_number: '123', password: 'code' }, this.callback);
+    });
+  });
 });


### PR DESCRIPTION
### Changes

The `verifySMSCode` method on the `AuthenticationClient` delegates to the `signIn` method of the `PasswordlessAuthenticator`. It only passed the `username` and `password`, which results in calling the deprecated `/oauth/ro` endpoint to authenticate. With the addition of #556, passing the `otp` will result in calling the `/oauth/token` endpoint to authenticate.

This change allows sending the `otp` option when calling `verifySMSCode`, which will enable using the token endpoint instead of `/oauth/ro`. Callers passing a `code` or `password` will still use the `/oauth/ro` endpoint.

### References

#556 

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
