### PR TITLE
Small fix to ManagementTokenProvider Cache

### DIFF
--- a/src/auth/OAuthAuthenticator.js
+++ b/src/auth/OAuthAuthenticator.js
@@ -357,8 +357,6 @@ OAuthAuthenticator.prototype.clientCredentialsGrant = function(options, cb) {
  * var options = {
  *   code: '{CODE}',
  *   redirect_uri: '{REDIRECT_URI}',
- *   client_id: '{CLIENT_ID}',  // Optional field.
- *   client_secret: '{CLIENT_SECRET}',  // Optional field.
  *   organization: '{ORGANIZATION_ID}' // Optiional field.
  * };
  *

--- a/src/management/ManagementTokenProvider.js
+++ b/src/management/ManagementTokenProvider.js
@@ -95,8 +95,8 @@ var ManagementTokenProvider = function(options) {
           return options.cacheTTLInSeconds * 1000;
         }
 
-        // if the expires_in is lower than 10 seconds, do not subtract 10 additional seconds.
-        if (data.expires_in && data.expires_in < 10 /* seconds */) {
+        // if the expires_in is lower or equal to than 10 seconds, do not subtract 10 additional seconds.
+        if (data.expires_in && data.expires_in <= 10 /* seconds */) {
           return data.expires_in * 1000;
         } else if (data.expires_in) {
           // Subtract 10 seconds from expires_in to fetch a new one, before it expires.

--- a/test/management/management-token-provider.tests.js
+++ b/test/management/management-token-provider.tests.js
@@ -177,6 +177,41 @@ describe('ManagementTokenProvider', function() {
       nock.cleanAll();
     });
   });
+  function timeout(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+  it('should expire access token from cache by the expires_in setting', async function() {
+    this.timeout(15000); // buffer time to test an artificial delay of 10s
+
+    var config = Object.assign({}, defaultConfig);
+    config.domain = 'auth0-node-sdk-1.auth0.com';
+    var client = new ManagementTokenProvider(config);
+
+    nock('https://' + config.domain)
+      .post('/oauth/token')
+      .reply(200, {
+        access_token: 'token',
+        expires_in: 10
+      });
+
+    const access_token = await client.getAccessToken();
+    expect(access_token).to.exist;
+    expect(access_token).to.be.equal('token');
+    await client.getAccessToken();
+    await timeout(10000);
+
+    nock('https://' + config.domain)
+      .post('/oauth/token')
+      .reply(200, {
+        access_token: 'token2',
+        expires_in: 10
+      });
+    const access_token2 = await client.getAccessToken();
+    expect(access_token2).to.exist;
+    expect(access_token2).to.be.equal('token2');
+
+    nock.cleanAll();
+  });
 
   it('should return access token', function(done) {
     var config = Object.assign({}, defaultConfig);


### PR DESCRIPTION
Currently if the expires_in on a token is set to 10seconds, we subtract 10seconds and then pass 0 seconds to the memoizer func, which causes it to set the expiration as unlimited.  This should be a less than or equals to 10.

Also fixed a doc issue on oAuthAuthenticator