### PR TITLE
Add proxy support

### DIFF
--- a/src/Auth0RestClient.js
+++ b/src/Auth0RestClient.js
@@ -1,4 +1,4 @@
-var RestClient = require('rest-facade').Client;
+var RestClientProxy = require('./RestClientProxy');
 var ArgumentError = require('rest-facade').ArgumentError;
 
 var utils = require('./utils');
@@ -22,7 +22,7 @@ var Auth0RestClient = function(resourceUrl, options, provider) {
 
   this.options = options;
   this.provider = provider;
-  this.restClient = new RestClient(resourceUrl, options);
+  this.restClient = new RestClientProxy(resourceUrl, options);
 
   this.wrappedProvider = function(method, args) {
     if (!this.provider) {

--- a/src/RestClientProxy.js
+++ b/src/RestClientProxy.js
@@ -1,0 +1,18 @@
+var RestClient = require('rest-facade').Client;
+
+var RestClientProxy = function(restClient, options) {
+  if (RestClientProxy.getProxy()) {
+    options.proxy = RestClientProxy.getProxy();
+  }
+  return new RestClient(restClient, options);
+};
+
+RestClientProxy.getProxy = function() {
+  return RestClientProxy.proxy;
+}
+
+RestClientProxy.setProxy = function(proxy) {
+  RestClientProxy.proxy = proxy;
+}
+
+module.exports = RestClientProxy;

--- a/src/RestClientProxy.js
+++ b/src/RestClientProxy.js
@@ -1,11 +1,11 @@
 var RestClient = require('rest-facade').Client;
 
-var RestClientProxy = function(restClient, options) {
+var RestClientProxy = function(url, options) {
   options = options || {};
   if (RestClientProxy.getProxy()) {
     options.proxy = RestClientProxy.getProxy();
   }
-  return new RestClient(restClient, options);
+  return new RestClient(url, options);
 };
 
 RestClientProxy.getProxy = function() {

--- a/src/RestClientProxy.js
+++ b/src/RestClientProxy.js
@@ -1,6 +1,7 @@
 var RestClient = require('rest-facade').Client;
 
 var RestClientProxy = function(restClient, options) {
+  options = options || {};
   if (RestClientProxy.getProxy()) {
     options.proxy = RestClientProxy.getProxy();
   }

--- a/src/auth/DatabaseAuthenticator.js
+++ b/src/auth/DatabaseAuthenticator.js
@@ -1,7 +1,7 @@
 var extend = require('util')._extend;
 
 var ArgumentError = require('rest-facade').ArgumentError;
-var RestClient = require('rest-facade').Client;
+var RestClientProxy = require('../RestClientProxy');
 
 /**
  * @class
@@ -35,7 +35,7 @@ var DatabaseAuthenticator = function(options, oauth) {
   };
 
   this.oauth = oauth;
-  this.dbConnections = new RestClient(options.baseUrl + '/dbconnections/:type', clientOptions);
+  this.dbConnections = new RestClientProxy(options.baseUrl + '/dbconnections/:type', clientOptions);
   this.clientId = options.clientId;
 };
 

--- a/src/auth/OAuthAuthenticator.js
+++ b/src/auth/OAuthAuthenticator.js
@@ -2,7 +2,7 @@ var extend = require('util')._extend;
 var sanitizeArguments = require('../utils').sanitizeArguments;
 
 var ArgumentError = require('rest-facade').ArgumentError;
-var RestClient = require('rest-facade').Client;
+var RestClientProxy = require('../RestClientProxy');
 
 var SanitizedError = require('../errors').SanitizedError;
 var OAUthWithIDTokenValidation = require('./OAUthWithIDTokenValidation');
@@ -57,7 +57,7 @@ var OAuthAuthenticator = function(options) {
     headers: options.headers
   };
 
-  this.oauth = new RestClient(options.baseUrl + '/oauth/:type', clientOptions);
+  this.oauth = new RestClientProxy(options.baseUrl + '/oauth/:type', clientOptions);
   this.oauthWithIDTokenValidation = new OAUthWithIDTokenValidation(this.oauth, options);
   this.clientId = options.clientId;
   this.clientSecret = options.clientSecret;

--- a/src/auth/PasswordlessAuthenticator.js
+++ b/src/auth/PasswordlessAuthenticator.js
@@ -1,7 +1,7 @@
 var extend = require('util')._extend;
 
 var ArgumentError = require('rest-facade').ArgumentError;
-var RestClient = require('rest-facade').Client;
+var RestClientProxy = require('../RestClientProxy');
 var sanitizeArguments = require('../utils').sanitizeArguments;
 
 function getParamsFromOptions(options) {
@@ -49,7 +49,7 @@ var PasswordlessAuthenticator = function(options, oauth) {
   };
 
   this.oauth = oauth;
-  this.passwordless = new RestClient(options.baseUrl + '/passwordless/start', clientOptions);
+  this.passwordless = new RestClientProxy(options.baseUrl + '/passwordless/start', clientOptions);
   this.clientId = options.clientId;
   this.clientSecret = options.clientSecret;
 };

--- a/test/retry-rest-client.tests.js
+++ b/test/retry-rest-client.tests.js
@@ -3,14 +3,14 @@ var sinon = require('sinon');
 var nock = require('nock');
 
 var ArgumentError = require('rest-facade').ArgumentError;
-var RestClient = require('rest-facade').Client;
+var RestClientProxy = require('../src/RestClientProxy');
 var RetryRestClient = require('../src/RetryRestClient');
 
 var API_URL = 'https://tenant.auth0.com';
 
 describe('RetryRestClient', function() {
   before(function() {
-    this.restClient = new RestClient(API_URL);
+    this.restClient = new RestClientProxy(API_URL);
   });
 
   it('should raise an error when no RestClient is provided', function() {
@@ -30,7 +30,7 @@ describe('RetryRestClient', function() {
   });
 
   describe('instance', function() {
-    var client = new RetryRestClient(new RestClient(API_URL));
+    var client = new RetryRestClient(new RestClientProxy(API_URL));
     var methods = ['getAll', 'get', 'create', 'update', 'delete'];
 
     methods.forEach(function(method) {


### PR DESCRIPTION
Hi, did not really have time to look at the code, but find it sad that proxy support is still lagging. So making a dead-simple suggestion here - a wrapper around `RestClient` called `RestClientProxy` for obvious reasons.

The idea is to do a `RestClientProxy.setProxy(<corporate_proxy>);` before all the real fun starts.

`Fully Untested!` .. but please allow users behind a corporate proxy to use the library, `asap`.

Thank you for the great work!