### PR TITLE
Add method to verify OTP received via email

### DIFF
--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -207,7 +207,7 @@ AuthenticationClient.prototype.requestEmailCode = function(data, cb) {
  * </caption>
  *
  * var data = {
- *   username: '{EMAIL}'
+ *   email: '{EMAIL}',
  *   otp: '{VERIFICATION_CODE}'
  * };
  *
@@ -236,7 +236,7 @@ AuthenticationClient.prototype.requestEmailCode = function(data, cb) {
  */
 AuthenticationClient.prototype.verifyEmailCode = function(data, cb) {
   var translatedData = {
-    username: data.email || data.username,
+    username: data.email,
     realm: 'email',
     otp: data.otp
   };

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -194,6 +194,57 @@ AuthenticationClient.prototype.requestEmailCode = function(data, cb) {
 };
 
 /**
+ * Verify the given OTP which was sent on the given email.
+ *
+ * @method    verifyEmailCode
+ * @memberOf  module:auth.AuthenticationClient.prototype
+ *
+ * @example <caption>
+ *   Given the user credentials (`email` and `otp`), authenticates
+ *   with the provider using the `/oauth/token` endpoint. Upon successful
+ *   authentication, returns a JSON object containing the `access_token` and
+ *   `id_token`.
+ * </caption>
+ *
+ * var data = {
+ *   username: '{EMAIL}'
+ *   otp: '{VERIFICATION_CODE}'
+ * };
+ *
+ * auth0.verifyEmailCode(data, function (err) {
+ *   if (err) {
+ *     // Handle error.
+ *   }
+ * });
+ *
+ * @example <caption>
+ *   The user data object has the following structure.
+ * </caption>
+ *
+ * {
+ *   id_token: String,
+ *   access_token: String,
+ *   token_type: String
+ * }
+ *
+ * @param   {Object}    data              Credentials object.
+ * @param   {String}    data.email        Email.
+ * @param   {String}    data.otp          Verification code.
+ * @param   {Function}  [cb]              Method callback.
+ *
+ * @return  {Promise|undefined}
+ */
+AuthenticationClient.prototype.verifyEmailCode = function(data, cb) {
+  var translatedData = {
+    username: data.email || data.username,
+    realm: 'email',
+    otp: data.otp
+  };
+
+  return this.passwordless.signIn(translatedData, cb);
+};
+
+/**
  * Start passwordless flow sending an SMS.
  *
  * @method    requestSMSCode

--- a/test/auth/authentication-client.tests.js
+++ b/test/auth/authentication-client.tests.js
@@ -221,4 +221,40 @@ describe('AuthenticationClient', function() {
       this.client.verifySMSCode({ phone_number: '123', password: 'code' }, this.callback);
     });
   });
+
+  describe(`verifyEmailCode`, () => {
+    before(function() {
+      this.client = new AuthenticationClient({ token: 'token', domain: 'auth0.com' });
+      this.passwordlessMock = sinon.mock(this.client.passwordless);
+      this.callback = function() {};
+    });
+    it('should call signIn with otp if provided', function() {
+      this.passwordlessMock
+        .expects('signIn')
+        .once()
+        .withExactArgs(
+          {
+            username: '123',
+            realm: 'email',
+            otp: 'code'
+          },
+          this.callback
+        );
+      this.client.verifyEmailCode({ email: '123', otp: 'code' }, this.callback);
+    });
+    it('should call signIn with otp if provided', function() {
+      this.passwordlessMock
+        .expects('signIn')
+        .once()
+        .withExactArgs(
+          {
+            username: '123',
+            realm: 'email',
+            otp: 'code'
+          },
+          this.callback
+        );
+      this.client.verifyEmailCode({ username: '123', otp: 'code' }, this.callback);
+    });
+  });
 });

--- a/test/auth/authentication-client.tests.js
+++ b/test/auth/authentication-client.tests.js
@@ -242,19 +242,5 @@ describe('AuthenticationClient', function() {
         );
       this.client.verifyEmailCode({ email: '123', otp: 'code' }, this.callback);
     });
-    it('should call signIn with otp if provided', function() {
-      this.passwordlessMock
-        .expects('signIn')
-        .once()
-        .withExactArgs(
-          {
-            username: '123',
-            realm: 'email',
-            otp: 'code'
-          },
-          this.callback
-        );
-      this.client.verifyEmailCode({ username: '123', otp: 'code' }, this.callback);
-    });
   });
 });


### PR DESCRIPTION
### Changes

This PR adds a new method to verify OTP received via email.

### References

Should resolve #148.

### Testing

```js
const client = new AuthenticationClient({
  domain: "your_domain",
  clientId: "your_client_id",
})

await client.requestEmailCode({
  email: "mail@example.com",
})

// Wait for OTP

await client.verifyEmailCode({
  email: "mail@example.com",
  otp: "123456"
})
```

I added tests for this method as well.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
