### PR TITLE
Use id instead of action_id as per the mgmt api. 

### DIFF
--- a/src/management/ActionsManager.js
+++ b/src/management/ActionsManager.js
@@ -95,7 +95,7 @@ var ActionsManager = function(options) {
   this.triggersTest = new RetryRestClient(triggersTestRestClient, options.retry);
 
   var executionsRestClient = new Auth0RestClient(
-    options.baseUrl + '/actions/executions/:id',
+    options.baseUrl + '/actions/executions/:execution_id',
     clientOptions,
     options.tokenProvider
   );
@@ -334,7 +334,20 @@ utils.wrapPropertyMethod(ActionsManager, 'getAll', 'resource.getAll');
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(ActionsManager, 'get', 'resource.get');
+ActionsManager.prototype.get = function(params, cb) {
+  params = params || {};
+
+  if (params.action_id) {
+    params.id = params.action_id;
+    delete params.action_id;
+  }
+
+  if (cb && cb instanceof Function) {
+    return this.resource.get(params, cb);
+  }
+
+  return this.resource.get(params);
+};
 
 /**
  * Update an existing action.
@@ -371,7 +384,20 @@ utils.wrapPropertyMethod(ActionsManager, 'get', 'resource.get');
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(ActionsManager, 'update', 'resource.patch');
+ActionsManager.prototype.update = function(params, data, cb) {
+  params = params || {};
+
+  if (params.action_id) {
+    params.id = params.action_id;
+    delete params.action_id;
+  }
+
+  if (cb && cb instanceof Function) {
+    return this.resource.patch(params, data, cb);
+  }
+
+  return this.resource.patch(params, data);
+};
 
 /**
  * Delete an existing action. Deleting an Action deletes all the action's versions
@@ -394,7 +420,20 @@ utils.wrapPropertyMethod(ActionsManager, 'update', 'resource.patch');
  *
  * @return  {Promise|undefined}
  */
-utils.wrapPropertyMethod(ActionsManager, 'delete', 'resource.delete');
+ActionsManager.prototype.delete = function(params, cb) {
+  params = params || {};
+
+  if (params.action_id) {
+    params.id = params.action_id;
+    delete params.action_id;
+  }
+
+  if (cb && cb instanceof Function) {
+    return this.resource.delete(params, cb);
+  }
+
+  return this.resource.delete(params);
+};
 
 /**
  * test an Action.
@@ -421,6 +460,11 @@ utils.wrapPropertyMethod(ActionsManager, 'delete', 'resource.delete');
 ActionsManager.prototype.test = function(params, payload, cb) {
   params = params || {};
   payload = payload || {};
+
+  if (params.action_id) {
+    params.id = params.action_id;
+    delete params.action_id;
+  }
 
   if (cb && cb instanceof Function) {
     return this.actionsTest.create(params, payload, cb);
@@ -453,6 +497,11 @@ ActionsManager.prototype.test = function(params, payload, cb) {
  */
 ActionsManager.prototype.deploy = function(params, cb) {
   params = params || {};
+
+  if (params.action_id) {
+    params.id = params.action_id;
+    delete params.action_id;
+  }
 
   if (cb && cb instanceof Function) {
     return this.actionsDeploy.create(params, {}, cb);
@@ -493,6 +542,11 @@ ActionsManager.prototype.deploy = function(params, cb) {
 ActionsManager.prototype.getVersions = function(params, cb) {
   params = params || {};
 
+  if (params.action_id) {
+    params.id = params.action_id;
+    delete params.action_id;
+  }
+
   if (cb && cb instanceof Function) {
     return this.actionVersions.getAll(params, cb);
   }
@@ -524,6 +578,11 @@ ActionsManager.prototype.getVersions = function(params, cb) {
  */
 ActionsManager.prototype.getVersion = function(params, cb) {
   params = params || {};
+
+  if (params.action_id) {
+    params.id = params.action_id;
+    delete params.action_id;
+  }
 
   if (cb && cb instanceof Function) {
     return this.actionVersions.get(params, cb);
@@ -559,6 +618,11 @@ ActionsManager.prototype.getVersion = function(params, cb) {
 ActionsManager.prototype.createVersion = function(params, data, cb) {
   params = params || {};
 
+  if (params.action_id) {
+    params.id = params.action_id;
+    delete params.action_id;
+  }
+
   if (cb && cb instanceof Function) {
     return this.actionVersions.create(params, data, cb);
   }
@@ -591,6 +655,11 @@ ActionsManager.prototype.createVersion = function(params, data, cb) {
 ActionsManager.prototype.deployVersion = function(params, cb) {
   params = params || {};
 
+  if (params.action_id) {
+    params.id = params.action_id;
+    delete params.action_id;
+  }
+
   if (cb && cb instanceof Function) {
     return this.actionVersionDeploy.create(params, {}, cb);
   }
@@ -605,7 +674,7 @@ ActionsManager.prototype.deployVersion = function(params, cb) {
  * @memberOf  module:management.ActionExecutionsManager.prototype
  *
  * @example
- * management.actions.getExecution({ id: EXECUTION_ID }, function (err, action) {
+ * management.actions.getExecution({ execution_id: EXECUTION_ID }, function (err, action) {
  *   if (err) {
  *     // Handle error.
  *   }

--- a/src/management/ActionsManager.js
+++ b/src/management/ActionsManager.js
@@ -53,21 +53,21 @@ var ActionsManager = function(options) {
    * @type {external:RestClient}
    */
   var auth0RestClient = new Auth0RestClient(
-    options.baseUrl + '/actions/actions/:action_id',
+    options.baseUrl + '/actions/actions/:id',
     clientOptions,
     options.tokenProvider
   );
   this.resource = new RetryRestClient(auth0RestClient, options.retry);
 
   var actionsDeployRestClient = new Auth0RestClient(
-    options.baseUrl + '/actions/actions/:action_id/deploy',
+    options.baseUrl + '/actions/actions/:id/deploy',
     clientOptions,
     options.tokenProvider
   );
   this.actionsDeploy = new RetryRestClient(actionsDeployRestClient, options.retry);
 
   var actionsTestRestClient = new Auth0RestClient(
-    options.baseUrl + '/actions/actions/:action_id/test',
+    options.baseUrl + '/actions/actions/:id/test',
     clientOptions,
     options.tokenProvider
   );
@@ -95,21 +95,21 @@ var ActionsManager = function(options) {
   this.triggersTest = new RetryRestClient(triggersTestRestClient, options.retry);
 
   var executionsRestClient = new Auth0RestClient(
-    options.baseUrl + '/actions/executions/:execution_id',
+    options.baseUrl + '/actions/executions/:id',
     clientOptions,
     options.tokenProvider
   );
   this.executions = new RetryRestClient(executionsRestClient, options.retry);
 
   var actionVersionRestClient = new Auth0RestClient(
-    options.baseUrl + '/actions/actions/:action_id/versions/:version_id',
+    options.baseUrl + '/actions/actions/:id/versions/:version_id',
     clientOptions,
     options.tokenProvider
   );
   this.actionVersions = new RetryRestClient(actionVersionRestClient, options.retry);
 
   var deployActionVersionRestClient = new Auth0RestClient(
-    options.baseUrl + '/actions/actions/:action_id/versions/:version_id/deploy',
+    options.baseUrl + '/actions/actions/:id/versions/:version_id/deploy',
     clientOptions,
     options.tokenProvider
   );
@@ -320,7 +320,7 @@ utils.wrapPropertyMethod(ActionsManager, 'getAll', 'resource.getAll');
  * @memberOf  module:management.ActionsManager.prototype
  *
  * @example
- * management.actions.get({ action_id: ACTION_ID }, function (err, action) {
+ * management.actions.get({ id: ACTION_ID }, function (err, action) {
  *   if (err) {
  *     // Handle error.
  *   }
@@ -329,7 +329,7 @@ utils.wrapPropertyMethod(ActionsManager, 'getAll', 'resource.getAll');
  * });
  *
  * @param   {Object}    params               Action parameters.
- * @param   {String}    params.action_id     Action ID.
+ * @param   {String}    params.id     Action ID.
  * @param   {Function}  [cb]                 Callback function.
  *
  * @return  {Promise|undefined}
@@ -344,7 +344,7 @@ utils.wrapPropertyMethod(ActionsManager, 'get', 'resource.get');
  *
  * @example
  * var data = { name: 'new-name' };
- * var params = { action_id: ACTION_ID };
+ * var params = { id: ACTION_ID };
  *
  * // Using auth0 instance.
  * management.updateAction(params, data, function (err, action) {
@@ -365,7 +365,7 @@ utils.wrapPropertyMethod(ActionsManager, 'get', 'resource.get');
  * });
  *
  * @param   {Object}    params        Action parameters.
- * @param   {String}    params.action_id     Action ID.
+ * @param   {String}    params.id     Action ID.
  * @param   {Object}    data          Updated action data.
  * @param   {Function}  [cb]          Callback function.
  *
@@ -380,7 +380,7 @@ utils.wrapPropertyMethod(ActionsManager, 'update', 'resource.patch');
  * @memberOf  module:management.ActionsManager.prototype
  *
  * @example
- * management.actions.delete({ action_id: ACTION_ID }, function (err) {
+ * management.actions.delete({ id: ACTION_ID }, function (err) {
  *   if (err) {
  *     // Handle error.
  *   }
@@ -389,7 +389,7 @@ utils.wrapPropertyMethod(ActionsManager, 'update', 'resource.patch');
  * });
  *
  * @param   {Object}    params        Action parameters.
- * @param   {String}    params.action_id     Action ID.
+ * @param   {String}    params.id     Action ID.
  * @param   {Function}  [cb]          Callback function.
  *
  * @return  {Promise|undefined}
@@ -403,7 +403,7 @@ utils.wrapPropertyMethod(ActionsManager, 'delete', 'resource.delete');
  * @memberOf  module:management.ActionsManager.prototype
  *
  * @example
- * var params = { action_id: ACTION_ID};
+ * var params = { id: ACTION_ID};
  * management.actions.testAction(params, payload, function (err) {
  *   if (err) {
  *     // Handle error.
@@ -412,7 +412,7 @@ utils.wrapPropertyMethod(ActionsManager, 'delete', 'resource.delete');
  * });
  *
  * @param   {Object}    params                Action parameters.
- * @param   {String}    params.action_id      Action ID.
+ * @param   {String}    params.id      Action ID.
  * @param   {Object}    payload               Payload represents the entire structure necessary to test a particular trigger
  * @param   {Function}  [cb]                  Callback function.
  *
@@ -437,7 +437,7 @@ ActionsManager.prototype.test = function(params, payload, cb) {
  * @memberOf  module:management.ActionsManager.prototype
  *
  * @example
- * var params = { action_id: ACTION_ID};
+ * var params = { id: ACTION_ID};
  * mangement.actions.deploy(params, function (err, actionVersion) {
  *   if (err) {
  *     // Handle error.
@@ -446,7 +446,7 @@ ActionsManager.prototype.test = function(params, payload, cb) {
  * });
  *
  * @param   {Object}    params                Action parameters.
- * @param   {String}    params.action_id      Action ID.
+ * @param   {String}    params.id      Action ID.
  * @param   {Function}  [cb]                  Callback function.
  *
  * @return  {Promise|undefined}
@@ -478,14 +478,14 @@ ActionsManager.prototype.deploy = function(params, cb) {
  *   page: 0
  * };
  *
- * management.actions.getVersions({ action_id: ACTION_ID }, function (err, actionVersions) {
+ * management.actions.getVersions({ id: ACTION_ID }, function (err, actionVersions) {
  *   console.log(actionVersions.length);
  * });
  *
  * @param   {Object}    [params]               ActionVersions parameters.
  * @param   {Number}    [params.per_page]      Number of results per page.
  * @param   {Number}    [params.page]          Page number, zero indexed.
- * @param   {String}    [params.action_id]     Action ID.
+ * @param   {String}    [params.id]     Action ID.
  * @param   {Function}  [cb]                   Callback function.
  *
  * @return  {Promise|undefined}
@@ -507,7 +507,7 @@ ActionsManager.prototype.getVersions = function(params, cb) {
  * @memberOf  module:management.ActionsManager.prototype
  *
  * @example
- * var params = { action_id: ACTION_ID, version_id: VERSION_ID };
+ * var params = { id: ACTION_ID, version_id: VERSION_ID };
  * management.actions.getVersion(params, function (err, actionVersion) {
  *   if (err) {
  *     // Handle error.
@@ -516,7 +516,7 @@ ActionsManager.prototype.getVersions = function(params, cb) {
  * });
  *
  * @param   {Object}    params                Action parameters.
- * @param   {String}    params.action_id      Action ID.
+ * @param   {String}    params.id      Action ID.
  * @param   {String}    params.version_id     ActionVersion ID.
  * @param   {Function}  [cb]                  Callback function.
  *
@@ -542,7 +542,7 @@ ActionsManager.prototype.getVersion = function(params, cb) {
  * @memberOf  module:management.ActionsManager.prototype
  *
  * @example
- * var params = { action_id: ACTION_ID };
+ * var params = { id: ACTION_ID };
  * management.actions.createActionVersion(params, data, function (err, actionVersion) {
  *   if (err) {
  *     // Handle error.
@@ -550,7 +550,7 @@ ActionsManager.prototype.getVersion = function(params, cb) {
  * });
  *
  * @param   {Object}    params                Action parameters.
- * @param   {String}    params.action_id      Action ID.
+ * @param   {String}    params.id      Action ID.
  * @param   {Object}    data                  ActionVersion parameters.
  * @param   {Function}  [cb]                  Callback function.
  *
@@ -573,7 +573,7 @@ ActionsManager.prototype.createVersion = function(params, data, cb) {
  * @memberOf  module:management.ActionsManager.prototype
  *
  * @example
- * var params = { action_id: ACTION_ID, version_id: VERSION_ID };
+ * var params = { id: ACTION_ID, version_id: VERSION_ID };
  * management.actions.deployVersion(params, function (err, actionVersion) {
  *   if (err) {
  *     // Handle error.
@@ -582,7 +582,7 @@ ActionsManager.prototype.createVersion = function(params, data, cb) {
  * });
  *
  * @param   {Object}    params                Action parameters.
- * @param   {String}    params.action_id      Action ID.
+ * @param   {String}    params.id      Action ID.
  * @param   {String}    params.version_id     Action ID.
  * @param   {Function}  [cb]                  Callback function.
  *
@@ -605,7 +605,7 @@ ActionsManager.prototype.deployVersion = function(params, cb) {
  * @memberOf  module:management.ActionExecutionsManager.prototype
  *
  * @example
- * management.actions.getExecution({ execution_id: EXECUTION_ID }, function (err, action) {
+ * management.actions.getExecution({ id: EXECUTION_ID }, function (err, action) {
  *   if (err) {
  *     // Handle error.
  *   }
@@ -614,7 +614,7 @@ ActionsManager.prototype.deployVersion = function(params, cb) {
  * });
  *
  * @param   {Object}    params                  Action Execution parameters.
- * @param   {String}    params.execution_id     Action Execution ID.
+ * @param   {String}    params.id     Action Execution ID.
  * @param   {Function}  [cb]                    Callback function.
  *
  * @return  {Promise|undefined}

--- a/test/management/actions.tests.js
+++ b/test/management/actions.tests.js
@@ -7,7 +7,7 @@ var API_URL = 'https://tenant.auth0.com';
 var ActionsManager = require(SRC_DIR + '/management/ActionsManager');
 var ArgumentError = require('rest-facade').ArgumentError;
 
-describe('ActionsManager', function() {
+describe.only('ActionsManager', function() {
   before(function() {
     this.token = 'TOKEN';
     this.actions = new ActionsManager({
@@ -179,6 +179,12 @@ describe('ActionsManager', function() {
       });
 
       it('should accept a callback', function(done) {
+        var params = { id: this.data.id };
+
+        this.actions.get(params, done.bind(null, null));
+      });
+
+      it('should be backwards compatible with action_id', function(done) {
         var params = { action_id: this.data.id };
 
         this.actions.get(params, done.bind(null, null));
@@ -186,7 +192,7 @@ describe('ActionsManager', function() {
 
       it('should return a promise if no callback is given', function(done) {
         this.actions
-          .get({ action_id: this.data.id })
+          .get({ id: this.data.id })
           .then(done.bind(null, null))
           .catch(done.bind(null, null));
       });
@@ -194,7 +200,7 @@ describe('ActionsManager', function() {
       it('should perform a GET request', function(done) {
         var request = this.request;
 
-        this.actions.get({ action_id: this.data.id }).then(function() {
+        this.actions.get({ id: this.data.id }).then(function() {
           expect(request.isDone()).to.be.true;
 
           done();
@@ -208,7 +214,7 @@ describe('ActionsManager', function() {
           .get('/actions/actions' + this.data.id)
           .reply(500);
 
-        this.actions.get({ action_id: this.data.id }).catch(function(err) {
+        this.actions.get({ id: this.data.id }).catch(function(err) {
           expect(err).to.exist;
 
           done();
@@ -223,7 +229,7 @@ describe('ActionsManager', function() {
           .matchHeader('Authorization', 'Bearer ' + this.token)
           .reply(200);
 
-        this.actions.get({ action_id: this.data.id }).then(function() {
+        this.actions.get({ id: this.data.id }).then(function() {
           expect(request.isDone()).to.be.true;
 
           done();
@@ -314,16 +320,16 @@ describe('ActionsManager', function() {
 
     describe('#update', function() {
       beforeEach(function() {
-        this.data = { action_id: 'ACTION_ID' };
+        this.data = { id: 'ACTION_ID' };
 
         this.request = nock(API_URL)
-          .patch('/actions/actions/' + this.data.action_id, { name: 'my-new-action-name' })
+          .patch('/actions/actions/' + this.data.id, { name: 'my-new-action-name' })
           .reply(200, this.data);
       });
 
       it('should accept a callback', function(done) {
         this.actions.update(
-          { action_id: 'ACTION_ID' },
+          { id: 'ACTION_ID' },
           { name: 'my-new-action-name' },
           done.bind(null, null)
         );
@@ -331,7 +337,7 @@ describe('ActionsManager', function() {
 
       it('should return a promise if no callback is given', function(done) {
         this.actions
-          .update({ action_id: 'ACTION_ID' }, { name: 'my-new-action-name' })
+          .update({ id: 'ACTION_ID' }, { name: 'my-new-action-name' })
           .then(done.bind(null, null))
           .catch(done.bind(null, null));
       });
@@ -339,29 +345,25 @@ describe('ActionsManager', function() {
       it('should perform a PATCH request', function(done) {
         var request = this.request;
 
-        this.actions
-          .update({ action_id: 'ACTION_ID' }, { name: 'my-new-action-name' })
-          .then(function() {
-            expect(request.isDone()).to.be.true;
+        this.actions.update({ id: 'ACTION_ID' }, { name: 'my-new-action-name' }).then(function() {
+          expect(request.isDone()).to.be.true;
 
-            done();
-          });
+          done();
+        });
       });
 
       it('should include the new data in the body of the request', function(done) {
         nock.cleanAll();
 
         var request = nock(API_URL)
-          .patch('/actions/actions/' + this.data.action_id, { name: 'my-new-action-name' })
+          .patch('/actions/actions/' + this.data.id, { name: 'my-new-action-name' })
           .reply(200);
 
-        this.actions
-          .update({ action_id: 'ACTION_ID' }, { name: 'my-new-action-name' })
-          .then(function() {
-            expect(request.isDone()).to.be.true;
+        this.actions.update({ id: 'ACTION_ID' }, { name: 'my-new-action-name' }).then(function() {
+          expect(request.isDone()).to.be.true;
 
-            done();
-          });
+          done();
+        });
       });
 
       it('should pass any errors to the promise catch handler', function(done) {
@@ -372,7 +374,7 @@ describe('ActionsManager', function() {
           .reply(500);
 
         this.actions
-          .update({ action_id: this.data.id }, { name: 'my-new-action-name' })
+          .update({ id: this.data.id }, { name: 'my-new-action-name' })
           .catch(function(err) {
             expect(err).to.exist;
 
@@ -569,14 +571,14 @@ describe('ActionsManager', function() {
       });
 
       it('should accept a callback', function(done) {
-        var params = { action_id: this.data.id };
+        var params = { id: this.data.id };
 
         this.actions.getVersions(params, done.bind(null, null));
       });
 
       it('should return a promise if no callback is given', function(done) {
         this.actions
-          .get({ action_id: this.data.id })
+          .get({ id: this.data.id })
           .then(done.bind(null, null))
           .catch(done.bind(null, null));
       });
@@ -584,7 +586,7 @@ describe('ActionsManager', function() {
       it('should perform a GET request', function(done) {
         var request = this.request;
 
-        this.actions.getVersions({ action_id: this.data.id }).then(function() {
+        this.actions.getVersions({ id: this.data.id }).then(function() {
           expect(request.isDone()).to.be.true;
 
           done();
@@ -598,7 +600,7 @@ describe('ActionsManager', function() {
           .get('/actions/actions/' + this.data.id + '/versions')
           .reply(500);
 
-        this.actions.getVersions({ action_id: this.data.id }).catch(function(err) {
+        this.actions.getVersions({ id: this.data.id }).catch(function(err) {
           expect(err).to.exist;
 
           done();
@@ -613,7 +615,7 @@ describe('ActionsManager', function() {
           .matchHeader('Authorization', 'Bearer ' + this.token)
           .reply(200);
 
-        this.actions.getVersions({ action_id: this.data.id }).then(function() {
+        this.actions.getVersions({ id: this.data.id }).then(function() {
           expect(request.isDone()).to.be.true;
 
           done();
@@ -636,14 +638,14 @@ describe('ActionsManager', function() {
       });
 
       it('should accept a callback', function(done) {
-        var params = { action_id: this.data.id, version_id: this.data.versionId };
+        var params = { id: this.data.id, version_id: this.data.versionId };
 
         this.actions.getVersion(params, done.bind(null, null));
       });
 
       it('should return a promise if no callback is given', function(done) {
         this.actions
-          .get({ action_id: this.data.id, version_id: this.data.versionId })
+          .get({ id: this.data.id, version_id: this.data.versionId })
           .then(done.bind(null, null))
           .catch(done.bind(null, null));
       });
@@ -652,7 +654,7 @@ describe('ActionsManager', function() {
         var request = this.request;
 
         this.actions
-          .getVersion({ action_id: this.data.id, version_id: this.data.versionId })
+          .getVersion({ id: this.data.id, version_id: this.data.versionId })
           .then(function() {
             expect(request.isDone()).to.be.true;
 
@@ -668,7 +670,7 @@ describe('ActionsManager', function() {
           .reply(500);
 
         this.actions
-          .getVersion({ action_id: this.data.id, version_id: this.data.versionId })
+          .getVersion({ id: this.data.id, version_id: this.data.versionId })
           .catch(function(err) {
             expect(err).to.exist;
 
@@ -685,7 +687,7 @@ describe('ActionsManager', function() {
           .reply(200);
 
         this.actions
-          .getVersion({ action_id: this.data.id, version_id: this.data.versionId })
+          .getVersion({ id: this.data.id, version_id: this.data.versionId })
           .then(function() {
             expect(request.isDone()).to.be.true;
 
@@ -708,14 +710,14 @@ describe('ActionsManager', function() {
       });
 
       it('should accept a callback', function(done) {
-        var params = { action_id: this.data.id };
+        var params = { id: this.data.id };
 
         this.actions.createVersion(params, this.data, done.bind(null, null));
       });
 
       it('should return a promise if no callback is given', function(done) {
         this.actions
-          .createVersion({ action_id: this.data.id }, {})
+          .createVersion({ id: this.data.id }, {})
           .then(done.bind(null, null))
           .catch(done.bind(null, null));
       });
@@ -723,7 +725,7 @@ describe('ActionsManager', function() {
       it('should perform a POST request', function(done) {
         var request = this.request;
 
-        this.actions.createVersion({ action_id: this.data.id }, {}).then(function() {
+        this.actions.createVersion({ id: this.data.id }, {}).then(function() {
           expect(request.isDone()).to.be.true;
 
           done();
@@ -737,7 +739,7 @@ describe('ActionsManager', function() {
           .post('/actions/actions/' + this.data.id + '/versions')
           .reply(500);
 
-        this.actions.createVersion({ action_id: this.data.id }, {}).catch(function(err) {
+        this.actions.createVersion({ id: this.data.id }, {}).catch(function(err) {
           expect(err).to.exist;
 
           done();
@@ -752,7 +754,7 @@ describe('ActionsManager', function() {
           .matchHeader('Authorization', 'Bearer ' + this.token)
           .reply(200);
 
-        this.actions.createVersion({ action_id: this.data.id }, {}).then(function() {
+        this.actions.createVersion({ id: this.data.id }, {}).then(function() {
           expect(request.isDone()).to.be.true;
 
           done();

--- a/test/management/actions.tests.js
+++ b/test/management/actions.tests.js
@@ -7,7 +7,7 @@ var API_URL = 'https://tenant.auth0.com';
 var ActionsManager = require(SRC_DIR + '/management/ActionsManager');
 var ArgumentError = require('rest-facade').ArgumentError;
 
-describe.only('ActionsManager', function() {
+describe('ActionsManager', function() {
   before(function() {
     this.token = 'TOKEN';
     this.actions = new ActionsManager({


### PR DESCRIPTION
### Changes

Updated API to use id instead of ~trigger_id~ action_id so it repesents the management API. 

