### PR TITLE
Update `setUniversalLoginTemplate` example to correctly reflect documentation

### DIFF
--- a/src/management/BrandingManager.js
+++ b/src/management/BrandingManager.js
@@ -73,7 +73,7 @@ var BrandingManager = function(options) {
  * @memberOf  module:management.BrandingManager.prototype
  *
  * @example
- * management.branding.updateSettings(data, function (err, branding) {
+ * management.branding.updateSettings(params, data, function (err, branding) {
  *   if (err) {
  *     // Handle error.
  *   }
@@ -82,7 +82,7 @@ var BrandingManager = function(options) {
  *    console.log(branding);
  * });
  *
- * @param   {Object}    params            Branding parameters.
+ * @param   {Object}    params            Branding parameters (leavy empty).
  * @param   {Object}    data              Updated branding data.
  * @param   {Function}  [cb]              Callback function.
  *

--- a/src/management/BrandingManager.js
+++ b/src/management/BrandingManager.js
@@ -145,7 +145,7 @@ utils.wrapPropertyMethod(BrandingManager, 'getUniversalLoginTemplate', 'branding
  * @memberOf  module:management.BrandingManager.prototype
  *
  * @example
- * management.branding.setUniversalLoginTemplate({ }, { template: "a template" }, function (err) {
+ * management.branding.setUniversalLoginTemplate(params, data, function (err) {
  *   if (err) {
  *     // Handle error.
  *   }

--- a/src/management/BrandingManager.js
+++ b/src/management/BrandingManager.js
@@ -145,7 +145,7 @@ utils.wrapPropertyMethod(BrandingManager, 'getUniversalLoginTemplate', 'branding
  * @memberOf  module:management.BrandingManager.prototype
  *
  * @example
- * management.branding.setUniversalLoginTemplate({ template: "a template" }, function (err) {
+ * management.branding.setUniversalLoginTemplate({ }, { template: "a template" }, function (err) {
  *   if (err) {
  *     // Handle error.
  *   }

--- a/src/management/PromptsManager.js
+++ b/src/management/PromptsManager.js
@@ -77,7 +77,7 @@ var PromptsManager = function(options) {
  * @memberOf  module:management.PromptsManager.prototype
  *
  * @example
- * management.prompts.updateSettings(data, function (err, prompts) {
+ * management.prompts.updateSettings(params, data, function (err, prompts) {
  *   if (err) {
  *     // Handle error.
  *   }


### PR DESCRIPTION
### Changes

Updating the documentation to correctly reflect that an empty `{ }` is needed when calling `setUniversalLoginTemplate()` in the branding manager. 

### References

Issue #623


### Testing

I ran npm test and the tests passed
I ran `npm run jsdoc:generate` and viewed the output files, and the example updates correctly

![image](https://user-images.githubusercontent.com/746276/119351672-a721e780-bc98-11eb-92cd-612a823391c1.png)



### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
