### PR TITLE
Mark package as side effect free

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.35.1",
   "description": "SDK for Auth0 API v2",
   "main": "src/index.js",
+  "sideEffects": false,
   "files": [
     "src"
   ],


### PR DESCRIPTION
Webpack introduced a convention of being able mark a package as side effect free so it can be tree shaken. This is safe as long as importing the module doesn't have side effects.

### Changes

When using tools like esbuild to bundle node modules into the main package you get the advantage of tree-shaking and not needing to ship the package and it's dependencies in node_modules. This is particularly handy in AWS lambda where keeping the amount of code parsed during cold starts to a minimum.

In my case, I have a common library which one of the modules imports the auth0 library. I'm not using that module in one of my lambdas but I have to ship auth0 in node_modules because the import of auth0 cannot be tree shaken.

### References

https://webpack.js.org/guides/tree-shaking/
https://esbuild.github.io/api/#conditionally-injecting-a-file

### Testing

The change is only a hint to bundlers. As long as `import 'auth0'` has no side effects (like running an iife which initialises some state) then this change is safe. It will also only be used when the nodejs code is being bundled

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
