### PR TITLE
[SDK-2666] Update endpoint methods to document allowance of 'from' and 'take' checkpoint pagination parameters

### DIFF
--- a/src/management/LogsManager.js
+++ b/src/management/LogsManager.js
@@ -82,6 +82,8 @@ var LogsManager = function(options) {
  * @param   {String}    [params.fields]         A comma separated list of fields to include or exclude
  * @param   {Boolean}   [params.include_fields] true if the fields specified are to be included in the result, false otherwise.
  * @param   {Boolean}   [params.include_totals] true if a query summary must be included in the result, false otherwise. Default false
+ * @param   {String}    [params.from]           For checkpoint pagination, log event Id from which to start selection from.
+ * @param   {Number}    [params.take]           When using the `from` parameter, the number of entries to retrieve. Default 50, max 100.
  * @param   {Function}  [cb]                    Callback function.
  *
  * @return  {Promise|undefined}

--- a/src/management/OrganizationsManager.js
+++ b/src/management/OrganizationsManager.js
@@ -140,6 +140,8 @@ utils.wrapPropertyMethod(OrganizationsManager, 'create', 'organizations.create')
  * @param   {Object}    [params]          Organizations parameters.
  * @param   {Number}    [params.per_page] Number of results per page.
  * @param   {Number}    [params.page]     Page number, zero indexed.
+ * @param   {String}    [params.from]     For checkpoint pagination, the Id from which to start selection from.
+ * @param   {Number}    [params.take]     For checkpoint pagination, the number of entries to retrieve. Default 50.
  * @param   {Function}  [cb]              Callback function.
  *
  * @return  {Promise|undefined}
@@ -455,6 +457,8 @@ OrganizationsManager.prototype.updateEnabledConnection = function(params, data, 
  * });
  *
  * @param   {String}    [params.id]   Organization ID
+ * @param   {String}    [params.from] For checkpoint pagination, the Id from which to start selection from.
+ * @param   {Number}    [params.take] For checkpoint pagination, the number of entries to retrieve. Default 50.
  * @param   {Function}  [cb]          Callback function.
  *
  * @return  {Promise|undefined}

--- a/src/management/RolesManager.js
+++ b/src/management/RolesManager.js
@@ -351,8 +351,8 @@ RolesManager.prototype.removePermissions = function(params, data, cb) {
  * @param   {String}    [roleId]          Id of the role
  * @param   {Number}    [params.per_page] Number of results per page.
  * @param   {Number}    [params.page]     Page number, zero indexed.
- * @param   {String}    [params.from]     Optional id from which to start selection.
- * @param   {Number}    [params.take]     The total amount of entries to retrieve when using the from parameter. Defaults to 50.
+ * @param   {String}    [params.from]     For checkpoint pagination, the Id from which to start selection from.
+ * @param   {Number}    [params.take]     For checkpoint pagination, the number of entries to retrieve. Default 50.
  * @param   {Function}  [cb]              Callback function.
  *
  * @return  {Promise|undefined}


### PR DESCRIPTION
### Changes

This PR includes method documentation (docblock) updates to reflect the availability of checkpoint pagination parameters on supported endpoints. It does not add any new functionality or require new tests.

### References

- Please see the internal Jira tickets SDK-2666 and related epic SDK-2653 for details on this initiative.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
