### PR TITLE
Add missing superagent-proxy dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "jwks-rsa": "^1.12.1",
     "lru-memoizer": "^2.1.4",
     "rest-facade": "^1.13.1",
-    "retry": "^0.13.1"
+    "retry": "^0.13.1",
+    "superagent-proxy": "^3.0.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
### Changes

Rest-facade now [includes superagent-proxy as a peer dependency](https://github.com/ngonzalvez/rest-facade#proxy-support) to reduce build size when possible. This commit adds superagent-proxy as a project dependency to fix this.

### References
Fixes issue #663

### Testing

Using the library shouldn't raise a "Cannot find module" error.

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
