### PR TITLE
docs: correct `idToken.validate` JSDoc detail

### DIFF
--- a/src/auth/idToken.js
+++ b/src/auth/idToken.js
@@ -27,7 +27,7 @@ var DEFAULT_LEEWAY = 60; //default clock-skew, in seconds
  * Validator for ID Tokens following OIDC spec.
  * @param token the string token to verify
  * @param options the options required to run this verification
- * @returns A promise containing the decoded token payload, or throws an exception if validation failed
+ * @returns The decoded token payload, or throws an exception if validation failed
  */
 var validate = function(token, options) {
   if (!token) {


### PR DESCRIPTION
The return type is not a promise, it's a decoded token payload. This JSDoc detail introduces confusion
for the first-time users.

Thanks!

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
