### PR TITLE
docs: correct `jobs.verifyEmail` arguments example

### DIFF
--- a/src/management/JobsManager.js
+++ b/src/management/JobsManager.js
@@ -324,7 +324,7 @@ class JobsManager {
    * 	user_id: '{USER_ID}'
    * };
    *
-   * management.jobs.verifyEmail(function (err) {
+   * management.jobs.verifyEmail(params, function (err) {
    *   if (err) {
    *     // Handle error.
    *   }


### PR DESCRIPTION
Documentation example for `jobs.verifyEmail` was missing the `params` argument.

### Changes

This is a small change to the JSDoc details of the verifyEmail job. The error caused confusion with novice users (me!)

### Testing

No testing was done.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] ~~All existing and new tests complete without errors~~ I've done no testing
