### PR TITLE
[SDK-3030] Wrong url when doing assign users with a callback

### DIFF
--- a/src/management/RolesManager.js
+++ b/src/management/RolesManager.js
@@ -355,7 +355,7 @@ class RolesManager {
     }
 
     if (cb && cb instanceof Function) {
-      return this.permissions.create(params, data, cb);
+      return this.users.create(params, data, cb);
     }
 
     return this.users.create(params, data);

--- a/test/management/roles.tests.js
+++ b/test/management/roles.tests.js
@@ -671,6 +671,16 @@ describe('RolesManager', () => {
       });
     });
 
+    it('should perform a POST request to /api/v2/roles/rol_ID/users with a callback', function (done) {
+      const { request } = this;
+
+      this.roles.assignUsers(this.data, {}, () => {
+        expect(request.isDone()).to.be.true;
+
+        done();
+      });
+    });
+
     it('should pass the data in the body of the request', function (done) {
       nock.cleanAll();
 


### PR DESCRIPTION
### Changes

Fix issue where `assignUsers` was using the wrong URL when being supplied by a callback

### Testing

- [x] This change adds unit test coverage