### PR TITLE
signIn method should provide using audience prop in userData

### DIFF
--- a/src/auth/PasswordlessAuthenticator.js
+++ b/src/auth/PasswordlessAuthenticator.js
@@ -104,6 +104,7 @@ class PasswordlessAuthenticator {
    * @param   {object}    userData              User credentials object.
    * @param   {string}    userData.username     The user's phone number if realm=sms, or the user's email if realm=email
    * @param   {string}    userData.otp        The user's verification code. Required
+   * @param   {string}    [userData.audience]     API Identifier of the API for which you want to get an Access Token.
    * @param   {string}    [userData.realm=sms]  Realm string: "sms" or "email".
    * @param   {string}    [userData.password]     [DEPRECATED] Password required if using legacy /oauth/ro endpoint
    * @param   {string}    [userData.connection=sms] [DEPRECATED] Connection string: "sms" or "email".

--- a/test/auth/passwordless.tests.js
+++ b/test/auth/passwordless.tests.js
@@ -465,6 +465,29 @@ describe('PasswordlessAuthenticator', () => {
           })
           .catch(done);
       });
+
+      it('should make it possible to use audience property', function (done) {
+        nock.cleanAll();
+
+        const request = nock(API_URL)
+          .post(path, (body) => body.audience === 'TEST_AUDIENCE')
+          .reply(200);
+
+        this.authenticator
+          .signIn(
+            {
+              ...userData,
+              audience: 'TEST_AUDIENCE',
+            },
+            options
+          )
+          .then(() => {
+            expect(request.isDone()).to.be.true;
+
+            done();
+          })
+          .catch(done);
+      });
     });
   });
 


### PR DESCRIPTION
### Changes

According to the [documentation](https://auth0.com/docs/api/authentication?http#get-code-or-link) we can use `audience` property in API call to specify identifier of the API we are trying to use. So in this PR the prop has been added to the documentation and tests.

### References

Please include relevant links supporting this change such as a:

- https://auth0.com/docs/api/authentication?http#get-code-or-link

### Testing

- [ ] This change adds unit test coverage
- [x] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
