### PR TITLE
Fix wrong property in `assignRolestoUser`

### DIFF
--- a/src/management/index.js
+++ b/src/management/index.js
@@ -231,7 +231,7 @@ class ManagementClient {
      * Simple abstraction for performing CRUD operations on the
      * blacklisted tokens endpoint.
      *
-     * @type {BlacklistedtokensManager}
+     * @type {BlacklistedTokensManager}
      */
     this.blacklistedTokens = new BlacklistedTokensManager(managerOptions);
 
@@ -328,7 +328,7 @@ class ManagementClient {
      * Simple abstraction for performing CRUD operations on the
      * branding endpoint.
      *
-     * @type {HooksManager}
+     * @type {BrandingManager}
      */
     this.branding = new BrandingManager(managerOptions);
 
@@ -1287,7 +1287,7 @@ class ManagementClient {
    * @returns  {Promise|undefined}
    */
   assignRolestoUser(...args) {
-    return this.roles.assignRoles(...args);
+    return this.users.assignRoles(...args);
   }
 
   /**

--- a/test/management/management-client.tests.js
+++ b/test/management/management-client.tests.js
@@ -933,5 +933,12 @@ describe('ManagementClient', () => {
         expect(this.client[method]).to.exist.to.be.an.instanceOf(Function);
       });
     });
+
+    it('should assign roles to a user', function () {
+      sinon.stub(this.client.users, 'assignRoles');
+      this.client.assignRolestoUser();
+      expect(this.client.users.assignRoles.called).ok;
+      this.client.users.assignRoles.reset();
+    });
   });
 });


### PR DESCRIPTION
`assignRolestoUser` was calling `roles.assignRoles`, when it should have been calling `users.assignRoles`


### References

fixes #698 

### Testing

- [x] This change adds unit test coverage
