### PR TITLE
Prevent calling the callback more than once

### DIFF
--- a/src/Auth0RestClient.js
+++ b/src/Auth0RestClient.js
@@ -73,9 +73,12 @@ class Auth0RestClient {
       this.restClient[method](...args, (err, data, headers) => {
         const payload = { data, headers };
         if (err) {
-          (callback && callback(err)) || reject(err);
+          if (callback) callback(err);
+          else reject(err);
+          return;
         }
-        (callback && callback(null, payload)) || resolve(payload);
+        if (callback) callback(null, payload);
+        else resolve(payload);
       });
     });
   }

--- a/test/auth0-rest-client.tests.js
+++ b/test/auth0-rest-client.tests.js
@@ -186,6 +186,29 @@ describe('Auth0RestClient', () => {
     });
   });
 
+  it('should accept a callback and handle errors with response headers', (done) => {
+    const providerMock = {
+      async getAccessToken() {
+        return 'fake-token';
+      },
+    };
+
+    const errorBody = { error: 'message' };
+    nock(API_URL).get('/some-resource').reply(500, errorBody);
+
+    const options = {
+      headers: {},
+      includeResponseHeaders: true,
+    };
+    const client = new Auth0RestClient(`${API_URL}/some-resource`, options, providerMock);
+    client.getAll((err) => {
+      expect(err).to.not.null;
+      expect(err.message).to.be.equal(JSON.stringify(errorBody));
+      done();
+      nock.cleanAll();
+    });
+  });
+
   it('should set access token as Authorization header in options object', async function () {
     nock(API_URL).get('/some-resource').reply(200);
 


### PR DESCRIPTION
### Changes

During the login in `Auth0RestClient._request`:

* If the callback is passed, do not call resolve or reject as calling reject will invoke the callback again
* if there is an error, return after handling the error instead of invoking the callback again

### References

Fixes #758 

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
