### PR TITLE
Add support for proxy in AuthenticationClient

### DIFF
--- a/src/auth/DatabaseAuthenticator.js
+++ b/src/auth/DatabaseAuthenticator.js
@@ -10,6 +10,7 @@ class DatabaseAuthenticator {
    * @param  {object}              options            Authenticator options.
    * @param  {string}              options.baseUrl    The auth0 account URL.
    * @param  {string}              [options.clientId] Default client ID.
+   * @param   {string}             [options.proxy]    Add the `superagent-proxy` dependency and specify a proxy url eg 'https://myproxy.com:1234'
    * @param  {OAuthAuthenticator}  oauth              OAuthAuthenticator instance.
    */
   constructor(options, oauth) {
@@ -29,6 +30,7 @@ class DatabaseAuthenticator {
     const clientOptions = {
       errorFormatter: { message: 'message', name: 'error' },
       headers: options.headers,
+      proxy: options.proxy,
     };
 
     this.oauth = oauth;

--- a/src/auth/OAuthAuthenticator.js
+++ b/src/auth/OAuthAuthenticator.js
@@ -35,6 +35,7 @@ class OAuthAuthenticator {
    * @param  {string}              [options.clientAssertionSigningKey] Private key used to sign the client assertion JWT.
    * @param  {string}              [options.clientAssertionSigningAlg] Default 'RS256'.
    * @param  {boolean}             [options.__bypassIdTokenValidation] Whether the id_token should be validated or not
+   * @param   {string}             [options.proxy]                     Add the `superagent-proxy` dependency and specify a proxy url eg 'https://myproxy.com:1234'
    */
   constructor(options) {
     if (!options) {
@@ -54,6 +55,7 @@ class OAuthAuthenticator {
       errorCustomizer: SanitizedError,
       errorFormatter: { message: 'message', name: 'error' },
       headers: options.headers,
+      proxy: options.proxy,
     };
 
     this.oauth = new RestClient(`${options.baseUrl}/oauth/:type`, clientOptions);

--- a/src/auth/PasswordlessAuthenticator.js
+++ b/src/auth/PasswordlessAuthenticator.js
@@ -29,6 +29,7 @@ class PasswordlessAuthenticator {
    * @param  {string}              [options.clientSecret] Default client secret.
    * @param  {string}              [options.clientAssertionSigningKey] Private key used to sign the client assertion JWT.
    * @param  {string}              [options.clientAssertionSigningAlg] Default 'RS256'.
+   * @param   {string}             [options.proxy]    Add the `superagent-proxy` dependency and specify a proxy url eg 'https://myproxy.com:1234'
    * @param  {OAuthAuthenticator}  oauth              OAuthAuthenticator instance.
    */
   constructor(options, oauth) {
@@ -48,6 +49,7 @@ class PasswordlessAuthenticator {
     const clientOptions = {
       errorFormatter: { message: 'message', name: 'error' },
       headers: options.headers,
+      proxy: options.proxy,
     };
 
     this.oauth = oauth;

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -42,6 +42,7 @@ class AuthenticationClient {
    * @param   {string}  [options.supportedAlgorithms]     Algorithms that your application expects to receive
    * @param  {boolean}  [options.__bypassIdTokenValidation] Whether the id_token should be validated or not
    * @param   {object}  [options.headers]                 Additional headers that will be added to the outgoing requests.
+   * @param   {string}  [options.proxy]                   Add the `superagent-proxy` dependency and specify a proxy url eg 'https://myproxy.com:1234'
    */
   constructor(options) {
     if (!options || typeof options !== 'object') {
@@ -67,6 +68,7 @@ class AuthenticationClient {
       baseUrl: util.format(BASE_URL_FORMAT, options.domain),
       supportedAlgorithms: options.supportedAlgorithms,
       __bypassIdTokenValidation: options.__bypassIdTokenValidation,
+      proxy: options.proxy,
     };
 
     if (options.telemetry !== false) {

--- a/src/management/ManagementTokenProvider.js
+++ b/src/management/ManagementTokenProvider.js
@@ -19,6 +19,7 @@ class ManagementTokenProvider {
    * @param {boolean} [options.enableCache=true]      Enabled or Disable Cache
    * @param {number}  [options.cacheTTLInSeconds]     By default the `expires_in` value will be used to determine the cached time of the token, this can be overridden.
    * @param {object}  [options.headers]               Additional headers that will be added to the outgoing requests.
+   * @param {string}  [options.proxy]                 Add the `superagent-proxy` dependency and specify a proxy url eg 'https://myproxy.com:1234'
    */
   constructor(options) {
     if (!options || typeof options !== 'object') {
@@ -74,6 +75,7 @@ class ManagementTokenProvider {
       telemetry: this.options.telemetry,
       clientInfo: this.options.clientInfo,
       headers: this.options.headers,
+      proxy: this.options.proxy,
     };
     this.authenticationClient = new AuthenticationClient(authenticationClientOptions);
 

--- a/test/auth/database-auth.tests.js
+++ b/test/auth/database-auth.tests.js
@@ -1,5 +1,8 @@
 const { expect } = require('chai');
 const nock = require('nock');
+const sinon = require('sinon');
+const { Client } = require('rest-facade');
+const proxyquire = require('proxyquire');
 
 const DOMAIN = 'tenant.auth0.com';
 const API_URL = `https://${DOMAIN}`;
@@ -181,6 +184,41 @@ describe('DatabaseAuthenticator', () => {
       await this.authenticator.signIn(userData);
       expect(request.isDone()).to.be.true;
     });
+
+    it('should make request with proxy', async () => {
+      nock.cleanAll();
+
+      const spy = sinon.spy();
+
+      class MockClient extends Client {
+        constructor(...args) {
+          spy(...args);
+          super(...args);
+        }
+      }
+      const MockAuthenticator = proxyquire(`../../src/auth/DatabaseAuthenticator`, {
+        'rest-facade': {
+          Client: MockClient,
+        },
+      });
+
+      const request = nock(API_URL).post(path).reply(200);
+
+      const authenticator = new MockAuthenticator(
+        {
+          ...validOptions,
+          proxy: 'http://proxy',
+        },
+        new OAuth(validOptions)
+      );
+
+      return authenticator.signIn(userData).then(() => {
+        sinon.assert.calledWithMatch(spy, API_URL, {
+          proxy: 'http://proxy',
+        });
+        expect(request.isDone()).to.be.true;
+      });
+    });
   });
 
   describe('#signUp', () => {
@@ -272,6 +310,38 @@ describe('DatabaseAuthenticator', () => {
 
       await this.authenticator.signUp(userData);
       expect(request.isDone()).to.be.true;
+    });
+
+    it('should make request with proxy', async () => {
+      nock.cleanAll();
+
+      const spy = sinon.spy();
+
+      class MockClient extends Client {
+        constructor(...args) {
+          spy(...args);
+          super(...args);
+        }
+      }
+      const MockAuthenticator = proxyquire(`../../src/auth/DatabaseAuthenticator`, {
+        'rest-facade': {
+          Client: MockClient,
+        },
+      });
+
+      const request = nock(API_URL).post(path).reply(200);
+
+      const authenticator = new MockAuthenticator(
+        { ...validOptions, proxy: 'http://proxy' },
+        new OAuth(validOptions)
+      );
+
+      return authenticator.signUp(userData).then(() => {
+        sinon.assert.calledWithMatch(spy, API_URL, {
+          proxy: 'http://proxy',
+        });
+        expect(request.isDone()).to.be.true;
+      });
     });
   });
 
@@ -368,6 +438,38 @@ describe('DatabaseAuthenticator', () => {
       await this.authenticator.changePassword(userData);
       expect(request.isDone()).to.be.true;
     });
+
+    it('should make request with proxy', async () => {
+      nock.cleanAll();
+
+      const spy = sinon.spy();
+
+      class MockClient extends Client {
+        constructor(...args) {
+          spy(...args);
+          super(...args);
+        }
+      }
+      const MockAuthenticator = proxyquire(`../../src/auth/DatabaseAuthenticator`, {
+        'rest-facade': {
+          Client: MockClient,
+        },
+      });
+
+      const request = nock(API_URL).post(path).reply(200);
+
+      const authenticator = new MockAuthenticator(
+        { ...validOptions, proxy: 'http://proxy' },
+        new OAuth(validOptions)
+      );
+
+      return authenticator.changePassword(userData).then(() => {
+        sinon.assert.calledWithMatch(spy, API_URL, {
+          proxy: 'http://proxy',
+        });
+        expect(request.isDone()).to.be.true;
+      });
+    });
   });
 
   describe('#requestChangePasswordEmail', () => {
@@ -449,6 +551,38 @@ describe('DatabaseAuthenticator', () => {
 
       await this.authenticator.requestChangePasswordEmail(userData);
       expect(request.isDone()).to.be.true;
+    });
+
+    it('should make request with proxy', async () => {
+      nock.cleanAll();
+
+      const spy = sinon.spy();
+
+      class MockClient extends Client {
+        constructor(...args) {
+          spy(...args);
+          super(...args);
+        }
+      }
+      const MockAuthenticator = proxyquire(`../../src/auth/DatabaseAuthenticator`, {
+        'rest-facade': {
+          Client: MockClient,
+        },
+      });
+
+      const request = nock(API_URL).post(path).reply(200);
+
+      const authenticator = new MockAuthenticator(
+        { ...validOptions, proxy: 'http://proxy' },
+        new OAuth(validOptions)
+      );
+
+      return authenticator.requestChangePasswordEmail(userData).then(() => {
+        sinon.assert.calledWithMatch(spy, API_URL, {
+          proxy: 'http://proxy',
+        });
+        expect(request.isDone()).to.be.true;
+      });
     });
   });
 });

--- a/test/auth/oauth.tests.js
+++ b/test/auth/oauth.tests.js
@@ -1,6 +1,8 @@
 const { expect } = require('chai');
 const nock = require('nock');
 const sinon = require('sinon');
+const { Client } = require('rest-facade');
+const proxyquire = require('proxyquire');
 
 const DOMAIN = 'tenant.auth0.com';
 const API_URL = `https://${DOMAIN}`;
@@ -246,6 +248,35 @@ describe('OAuthAuthenticator', () => {
         })
         .catch(done);
     });
+
+    it('should make request with proxy', async () => {
+      nock.cleanAll();
+
+      const spy = sinon.spy();
+
+      class MockClient extends Client {
+        constructor(...args) {
+          spy(...args);
+          super(...args);
+        }
+      }
+      const MockAuthenticator = proxyquire(`../../src/auth/OAuthAuthenticator`, {
+        'rest-facade': {
+          Client: MockClient,
+        },
+      });
+
+      const request = nock(API_URL).post(path).reply(200);
+
+      const authenticator = new MockAuthenticator({ ...validOptions, proxy: 'http://proxy' });
+
+      return authenticator.signIn(userData).then(() => {
+        sinon.assert.calledWithMatch(spy, API_URL, {
+          proxy: 'http://proxy',
+        });
+        expect(request.isDone()).to.be.true;
+      });
+    });
   });
 
   describe('#passwordGrant', () => {
@@ -431,6 +462,35 @@ describe('OAuthAuthenticator', () => {
         })
         .catch(done);
     });
+
+    it('should make request with proxy', async () => {
+      nock.cleanAll();
+
+      const spy = sinon.spy();
+
+      class MockClient extends Client {
+        constructor(...args) {
+          spy(...args);
+          super(...args);
+        }
+      }
+      const MockAuthenticator = proxyquire(`../../src/auth/OAuthAuthenticator`, {
+        'rest-facade': {
+          Client: MockClient,
+        },
+      });
+
+      const request = nock(API_URL).post(path).reply(200);
+
+      const authenticator = new MockAuthenticator({ ...validOptions, proxy: 'http://proxy' });
+
+      return authenticator.passwordGrant(userData).then(() => {
+        sinon.assert.calledWithMatch(spy, API_URL, {
+          proxy: 'http://proxy',
+        });
+        expect(request.isDone()).to.be.true;
+      });
+    });
   });
 
   describe('#refreshToken', () => {
@@ -528,6 +588,35 @@ describe('OAuthAuthenticator', () => {
           done();
         })
         .catch(done);
+    });
+
+    it('should make request with proxy', async () => {
+      nock.cleanAll();
+
+      const spy = sinon.spy();
+
+      class MockClient extends Client {
+        constructor(...args) {
+          spy(...args);
+          super(...args);
+        }
+      }
+      const MockAuthenticator = proxyquire(`../../src/auth/OAuthAuthenticator`, {
+        'rest-facade': {
+          Client: MockClient,
+        },
+      });
+
+      const request = nock(API_URL).post(path).reply(200);
+
+      const authenticator = new MockAuthenticator({ ...validOptions, proxy: 'http://proxy' });
+
+      return authenticator.refreshToken(userData).then(() => {
+        sinon.assert.calledWithMatch(spy, API_URL, {
+          proxy: 'http://proxy',
+        });
+        expect(request.isDone()).to.be.true;
+      });
     });
   });
 
@@ -651,6 +740,35 @@ describe('OAuthAuthenticator', () => {
         expect(request.isDone()).to.be.true;
 
         done();
+      });
+    });
+
+    it('should make request with proxy', async () => {
+      nock.cleanAll();
+
+      const spy = sinon.spy();
+
+      class MockClient extends Client {
+        constructor(...args) {
+          spy(...args);
+          super(...args);
+        }
+      }
+      const MockAuthenticator = proxyquire(`../../src/auth/OAuthAuthenticator`, {
+        'rest-facade': {
+          Client: MockClient,
+        },
+      });
+
+      const request = nock(API_URL).post(path).reply(200);
+
+      const authenticator = new MockAuthenticator({ ...validOptions, proxy: 'http://proxy' });
+
+      return authenticator.socialSignIn(userData).then(() => {
+        sinon.assert.calledWithMatch(spy, API_URL, {
+          proxy: 'http://proxy',
+        });
+        expect(request.isDone()).to.be.true;
       });
     });
   });
@@ -783,6 +901,35 @@ describe('OAuthAuthenticator', () => {
       return this.authenticator.clientCredentialsGrant(options).catch((err) => {
         const originalRequestData = err.originalError.response.request._data;
         expect(originalRequestData.client_secret).to.not.equal(CLIENT_SECRET);
+      });
+    });
+
+    it('should make request with proxy', async () => {
+      nock.cleanAll();
+
+      const spy = sinon.spy();
+
+      class MockClient extends Client {
+        constructor(...args) {
+          spy(...args);
+          super(...args);
+        }
+      }
+      const MockAuthenticator = proxyquire(`../../src/auth/OAuthAuthenticator`, {
+        'rest-facade': {
+          Client: MockClient,
+        },
+      });
+
+      const request = nock(API_URL).post(path).reply(200);
+
+      const authenticator = new MockAuthenticator({ ...validOptions, proxy: 'http://proxy' });
+
+      return authenticator.clientCredentialsGrant(options).then(() => {
+        sinon.assert.calledWithMatch(spy, API_URL, {
+          proxy: 'http://proxy',
+        });
+        expect(request.isDone()).to.be.true;
       });
     });
   });
@@ -928,6 +1075,35 @@ describe('OAuthAuthenticator', () => {
           done();
         })
         .catch(done);
+    });
+
+    it('should make request with proxy', async () => {
+      nock.cleanAll();
+
+      const spy = sinon.spy();
+
+      class MockClient extends Client {
+        constructor(...args) {
+          spy(...args);
+          super(...args);
+        }
+      }
+      const MockAuthenticator = proxyquire(`../../src/auth/OAuthAuthenticator`, {
+        'rest-facade': {
+          Client: MockClient,
+        },
+      });
+
+      const request = nock(API_URL).post(path).reply(200);
+
+      const authenticator = new MockAuthenticator({ ...validOptions, proxy: 'http://proxy' });
+
+      return authenticator.authorizationCodeGrant(data).then(() => {
+        sinon.assert.calledWithMatch(spy, API_URL, {
+          proxy: 'http://proxy',
+        });
+        expect(request.isDone()).to.be.true;
+      });
     });
   });
 });

--- a/test/auth/passwordless.tests.js
+++ b/test/auth/passwordless.tests.js
@@ -1,5 +1,8 @@
 const { expect } = require('chai');
 const nock = require('nock');
+const sinon = require('sinon');
+const { Client } = require('rest-facade');
+const proxyquire = require('proxyquire');
 
 const DOMAIN = 'tenant.auth0.com';
 const API_URL = `https://${DOMAIN}`;
@@ -254,6 +257,38 @@ describe('PasswordlessAuthenticator', () => {
           })
           .catch(done);
       });
+
+      it('should make request with proxy', async () => {
+        nock.cleanAll();
+
+        const spy = sinon.spy();
+
+        class MockClient extends Client {
+          constructor(...args) {
+            spy(...args);
+            super(...args);
+          }
+        }
+        const MockAuthenticator = proxyquire(`../../src/auth/PasswordlessAuthenticator`, {
+          'rest-facade': {
+            Client: MockClient,
+          },
+        });
+
+        const request = nock(API_URL).post(path).reply(200);
+
+        const authenticator = new MockAuthenticator(
+          { ...validOptions, proxy: 'http://proxy' },
+          new OAuth(validOptions)
+        );
+
+        return authenticator.signIn(userData, options).then(() => {
+          sinon.assert.calledWithMatch(spy, API_URL, {
+            proxy: 'http://proxy',
+          });
+          expect(request.isDone()).to.be.true;
+        });
+      });
     });
 
     describe('/oauth/token', () => {
@@ -488,6 +523,38 @@ describe('PasswordlessAuthenticator', () => {
           })
           .catch(done);
       });
+
+      it('should make request with proxy', async () => {
+        nock.cleanAll();
+
+        const spy = sinon.spy();
+
+        class MockClient extends Client {
+          constructor(...args) {
+            spy(...args);
+            super(...args);
+          }
+        }
+        const MockAuthenticator = proxyquire(`../../src/auth/PasswordlessAuthenticator`, {
+          'rest-facade': {
+            Client: MockClient,
+          },
+        });
+
+        const request = nock(API_URL).post(path).reply(200);
+
+        const authenticator = new MockAuthenticator(
+          { ...validOptions, proxy: 'http://proxy' },
+          new OAuth(validOptions)
+        );
+
+        return authenticator.signIn(userData, options).then(() => {
+          sinon.assert.calledWithMatch(spy, API_URL, {
+            proxy: 'http://proxy',
+          });
+          expect(request.isDone()).to.be.true;
+        });
+      });
     });
   });
 
@@ -668,6 +735,38 @@ describe('PasswordlessAuthenticator', () => {
         })
         .catch(done);
     });
+
+    it('should make request with proxy', async () => {
+      nock.cleanAll();
+
+      const spy = sinon.spy();
+
+      class MockClient extends Client {
+        constructor(...args) {
+          spy(...args);
+          super(...args);
+        }
+      }
+      const MockAuthenticator = proxyquire(`../../src/auth/PasswordlessAuthenticator`, {
+        'rest-facade': {
+          Client: MockClient,
+        },
+      });
+
+      const request = nock(API_URL).post(path).reply(200);
+
+      const authenticator = new MockAuthenticator(
+        { ...validOptions, proxy: 'http://proxy' },
+        new OAuth(validOptions)
+      );
+
+      return authenticator.sendEmail(userData, options).then(() => {
+        sinon.assert.calledWithMatch(spy, API_URL, {
+          proxy: 'http://proxy',
+        });
+        expect(request.isDone()).to.be.true;
+      });
+    });
   });
 
   describe('#sendSMS', () => {
@@ -815,6 +914,38 @@ describe('PasswordlessAuthenticator', () => {
           done();
         })
         .catch(done);
+    });
+
+    it('should make request with proxy', async () => {
+      nock.cleanAll();
+
+      const spy = sinon.spy();
+
+      class MockClient extends Client {
+        constructor(...args) {
+          spy(...args);
+          super(...args);
+        }
+      }
+      const MockAuthenticator = proxyquire(`../../src/auth/PasswordlessAuthenticator`, {
+        'rest-facade': {
+          Client: MockClient,
+        },
+      });
+
+      const request = nock(API_URL).post(path).reply(200);
+
+      const authenticator = new MockAuthenticator(
+        { ...validOptions, proxy: 'http://proxy' },
+        new OAuth(validOptions)
+      );
+
+      return authenticator.sendSMS(userData, options).then(() => {
+        sinon.assert.calledWithMatch(spy, API_URL, {
+          proxy: 'http://proxy',
+        });
+        expect(request.isDone()).to.be.true;
+      });
     });
   });
 });


### PR DESCRIPTION
### Changes

This PR adds a `proxy` option to the `AuthenticationClient` in the same way as we have one for `ManagementClient`:

```ts
const client = new AuthenticationClient({ proxy: 'https://proxy:1234' });
```

On top of that, since there are a couple of places that use Axios, it's required to also set the corresponding environment variables as you'd typically do with Node:

```
HTTP_PROXY=http://proxy.com:1234
HTTPS_PROXY=https://proxy.com:1234
```

### Testing

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
