### PR TITLE
Update jsDoc for ConnectionsManager.getAll()

### DIFF
--- a/src/management/ConnectionsManager.js
+++ b/src/management/ConnectionsManager.js
@@ -72,10 +72,15 @@ class ConnectionsManager extends BaseManager {
    * management.connections.getAll(params, function (err, connections) {
    *   console.log(connections.length);
    * });
-   * @param   {object}    [params]          Connections params.
-   * @param   {number}    [params.per_page] Number of results per page.
-   * @param   {number}    [params.page]     Page number, zero indexed.
-   * @param   {Function}  [cb]              Callback function.
+   * @param   {object}    [params]                Connections params.
+   * @param   {number}    [params.per_page]       Number of results per page.
+   * @param   {number}    [params.page]           Page number, zero indexed.
+   * @param   {string[]}  [params.fields]         List of fields to include or exclude
+   * @param   {boolean}   [params.include_fields] true if the fields specified are to be included in the result, false otherwise. Default true
+   * @param   {boolean}   [params.include_totals] true if a query summary must be included in the result, false otherwise. Default false
+   * @param   {string}    [params.strategy]       Provide strategies to only retrieve connections with such strategies 
+   * @param   {string}    [params.name]           Provide the name of the connection to retrieve
+   * @param   {Function}  [cb]                    Callback function.
    * @returns  {Promise|undefined}
    */
   getAll(...args) {


### PR DESCRIPTION
This PR adds missing parameters to the documentation for `ConnectionsManager.getAll()`: `fields`, `include_fields`, `include_totals`, `strategy`, `name`. These params already work when passed into the function, but are undocumented.

see
https://auth0.com/docs/api/management/v2#!/Connections/get_connections

### Changes

Please describe both what is changing and why this is important. Include:

- JSDoc updated for `ConnectionsManager.getAll()`

### References

N/A. I ran into this problem while working on an internal project using the node-auth0 SDK and needing to list connections by strategy and name. The SDK allows this by passing in params

```{ strategy: 'auth0', name: 'ConnectionName'}```

But this is not mentioned in the docs

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

Inspect the generated documentation

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
