### PR TITLE
Add typescript compiler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,9 @@ jobs:
           name: ESLint
           command: yarn lint
       - run:
+          name: Build
+          command: yarn build
+      - run:
           name: Tests
           command: yarn test:ci
       - when:

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ build
 out/
 test-results.xml
 .nyc_output
+dist/
 
 
 # npm

--- a/package.json
+++ b/package.json
@@ -2,13 +2,22 @@
   "name": "auth0",
   "version": "3.3.0",
   "description": "SDK for Auth0 API v2",
-  "main": "src/index.js",
-  "module": "src/index.mjs",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/typings/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/typings/index.d.ts"
+    }
+  },
   "sideEffects": false,
   "files": [
-    "src"
+    "dist"
   ],
   "scripts": {
+    "build": "tsc",
     "test": "mocha --reporter spec './test/**/*.tests.js'",
     "test:ci": "nyc npm run test -- --forbid-only --reporter mocha-junit-reporter",
     "test:watch": "cross-env NODE_ENV=test mocha --timeout 5000 './test/**/*.tests.js' './test/*.tests.js' --watch",
@@ -44,6 +53,7 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
+    "@types/lru-cache": "4.1.1",
     "chai": "^4.2.0",
     "cross-env": "^5.2.0",
     "eslint": "^8.16.0",
@@ -67,6 +77,7 @@
     "sinon": "^14.0.0",
     "string-replace-webpack-plugin": "0.1.3",
     "superagent-proxy": "^3.0.0",
+    "typescript": "4.9.5",
     "webpack": "^4.36.1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "allowJs": true,
+    "target": "ES2017",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "sourceMap": true,
+    "declaration": true,
+    "declarationDir": "./dist/typings",
+    "moduleResolution": "node"
+  },
+  "exclude": ["./test", "./dist/typings"],
+  "include": ["./src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -292,6 +292,11 @@
   resolved "https://registry.yarnpkg.com/@types/linkify-it/-/linkify-it-3.0.2.tgz#fd2cd2edbaa7eaac7e7f3c1748b52a19143846c9"
   integrity sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==
 
+"@types/lru-cache@4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-4.1.1.tgz#b2d87a5e3df8d4b18ca426c5105cd701c2306d40"
+  integrity sha512-8mNEUG6diOrI6pMqOHrHPDBB1JsrpedeMK9AWGzVCQ7StRRribiT9BRvUmF8aUws9iBbVlgVekOT5Sgzc1MTKw==
+
 "@types/markdown-it@^12.2.3":
   version "12.2.3"
   resolved "https://registry.yarnpkg.com/@types/markdown-it/-/markdown-it-12.2.3.tgz#0d6f6e5e413f8daaa26522904597be3d6cd93b51"
@@ -5215,6 +5220,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
+
+typescript@4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
### Changes

Adds basic typescript compilation as a first step to include typescript, also ensures tsc runs on Circle CI.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
