### PR TITLE
chore: run ci on node 20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ workflows:
       - build-and-test:
           matrix:
             parameters:
-              node-version: ["16.18", "18.12"]
+              node-version: ["16.18", "18.12", "20.0"]
       - ship/node-publish:
           requires:
             - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
         default: "16.18"
     docker:
       - image: cimg/node:<< parameters.node-version >>
+    resource_class: xlarge
     environment:
       LANG: en_US.UTF-8
     steps:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "mocha && npm run test:jest",
+    "test": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' mocha && npm run test:jest",
     "test:jest": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest",
     "test:ci": "c8 npm run test",
     "test:watch": "cross-env NODE_ENV=test mocha --timeout 5000 './test/**/*.tests.js' './test/*.tests.js' --watch",


### PR DESCRIPTION
### Changes

With node 20 now being released, be good to run the CI on node 20.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
