### PR TITLE
feat: add retry to BaseAPI

### DIFF
--- a/src/management/management-client.ts
+++ b/src/management/management-client.ts
@@ -11,6 +11,7 @@ export class ManagementClient extends ManagementClientBase {
     options: ManagementClientOptionsWithToken | ManagementClientOptionsWithClientCredentials
   ) {
     super({
+      ...options,
       baseUrl: `https://${options.domain}/api/v2`,
       middleware: [
         ...(options.middleware || []),

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,11 +1,17 @@
 import fetch, { RequestInit, RequestInfo, Response } from 'node-fetch';
+import { retry } from './retry';
 
+export interface RetryConfiguration {
+  enabled?: boolean;
+  maxRetries?: number;
+}
 export interface Configuration {
   baseUrl: string; // override base path
   fetchApi?: FetchAPI; // override for fetch implementation
   middleware?: Middleware[]; // middleware to apply before/after fetch requests
   queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
   headers?: HTTPHeaders; //header params we want to use on every request
+  retry?: RetryConfiguration;
 }
 
 /**
@@ -100,7 +106,12 @@ export class BaseAPI {
     }
     let response: Response | undefined = undefined;
     try {
-      response = await this.fetchApi(fetchParams.url, fetchParams.init);
+      response =
+        this.configuration.retry?.enabled !== false
+          ? await retry(() => this.fetchApi(fetchParams.url, fetchParams.init), {
+              ...this.configuration.retry,
+            })
+          : await this.fetchApi(fetchParams.url, fetchParams.init);
     } catch (e) {
       for (const middleware of this.middleware) {
         if (middleware.onError) {

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,10 +1,6 @@
 import fetch, { RequestInit, RequestInfo, Response } from 'node-fetch';
-import { retry } from './retry';
+import { RetryConfiguration, retry } from './retry';
 
-export interface RetryConfiguration {
-  enabled?: boolean;
-  maxRetries?: number;
-}
 export interface Configuration {
   baseUrl: string; // override base path
   fetchApi?: FetchAPI; // override for fetch implementation

--- a/src/runtime/retry.ts
+++ b/src/runtime/retry.ts
@@ -42,10 +42,10 @@ export interface RetryConfiguration {
    */
   maxRetries?: number;
   /**
-   * Status Code on which the SDK should trigger retries.
-   * Defaults to 429.
+   * Status Codes on which the SDK should trigger retries.
+   * Defaults to [429].
    */
-  retryWhen?: number;
+  retryWhen?: number[];
 }
 
 /**
@@ -64,7 +64,7 @@ export function retry(
 
     result = await action();
 
-    if (result.status === (retryWhen || 429) && nrOfTries < nrOfTriesToAttempt) {
+    if ((retryWhen || [429]).includes(result.status) && nrOfTries < nrOfTriesToAttempt) {
       nrOfTries++;
 
       let wait = BASE_DELAY * Math.pow(2, nrOfTries - 1);

--- a/src/runtime/retry.ts
+++ b/src/runtime/retry.ts
@@ -8,6 +8,7 @@ const MAX_NUMBER_RETRIES = 10;
 const BASE_DELAY = 250;
 
 /**
+ * @private
  * Function that returns a random int between a configurable min and max.
  * @param min The min value
  * @param max  The max value

--- a/src/runtime/retry.ts
+++ b/src/runtime/retry.ts
@@ -1,0 +1,62 @@
+import { Response } from 'node-fetch';
+
+const MAX_REQUEST_RETRY_JITTER = 250;
+const MAX_REQUEST_RETRY_DELAY = 1000;
+const MIN_REQUEST_RETRY_DELAY = 250;
+const DEFAULT_NUMBER_RETRIES = 3;
+const MAX_NUMBER_RETRIES = 10;
+const BASE_DELAY = 250;
+
+/**
+ * Function that returns a random int between a configurable min and max.
+ * @param min The min value
+ * @param max  The max value
+ * @returns {number} The random generated value
+ */
+function getRandomInt(min: number, max: number) {
+  min = Math.ceil(min);
+  max = Math.floor(max);
+  return Math.floor(Math.random() * (max - min) + min); // The maximum is exclusive and the minimum is inclusive
+}
+
+/**
+ * @private
+ * Function that returns a promise which resolves after a configurable amount of milliseconds
+ * @param delay value to be used for the delay
+ * @returns {Promise} A delayed promise
+ */
+async function pause(delay: number) {
+  return new Promise((resolve) => setTimeout(resolve, delay));
+}
+
+/**
+ * @private
+ * Function that retries the provided action callback for a configurable amount of time, defaults to 3.
+ */
+export function retry(action: () => Promise<Response>, { maxRetries }: { maxRetries?: number }) {
+  const nrOfTriesToAttempt = Math.min(MAX_NUMBER_RETRIES, maxRetries ?? DEFAULT_NUMBER_RETRIES);
+  let nrOfTries = 0;
+
+  const retryAndWait = async () => {
+    let result: Response;
+
+    result = await action();
+
+    if (result.status === 429 && nrOfTries < nrOfTriesToAttempt) {
+      nrOfTries++;
+
+      let wait = BASE_DELAY * Math.pow(2, nrOfTries - 1);
+      wait = getRandomInt(wait + 1, wait + MAX_REQUEST_RETRY_JITTER);
+      wait = Math.min(wait, MAX_REQUEST_RETRY_DELAY);
+      wait = Math.max(wait, MIN_REQUEST_RETRY_DELAY);
+
+      await pause(wait);
+
+      result = await retryAndWait();
+    }
+
+    return result;
+  };
+
+  return retryAndWait();
+}

--- a/test/runtime/runtime.test.ts
+++ b/test/runtime/runtime.test.ts
@@ -1,0 +1,282 @@
+import nock from 'nock';
+import { jest } from '@jest/globals';
+import { AuthenticationClient, ManagementClient } from '../../src';
+import { BaseAPI, InitOverrideFunction, RequestOpts, ResponseError } from '../../src/runtime';
+import { RequestInit, Response } from 'node-fetch';
+
+export class TestClient extends BaseAPI {
+  public async testRequest(
+    context: RequestOpts,
+    initOverrides?: RequestInit | InitOverrideFunction
+  ): Promise<Response> {
+    return this.request(context, initOverrides);
+  }
+}
+
+describe('Runtime', () => {
+  const URL = 'https://tenant.auth0.com/api/v2';
+
+  afterEach(() => {
+    nock.cleanAll();
+    jest.clearAllMocks();
+  });
+
+  it('should retry 429 until getting a succesful response', async () => {
+    const request = nock(URL, { encodedQueryParams: true })
+      .get('/clients')
+      .times(2)
+      .reply(429)
+      .get('/clients')
+      .reply(200, [{ client_id: '123' }]);
+
+    const client = new TestClient({
+      baseUrl: URL,
+    });
+
+    const response = await client.testRequest({
+      path: `/clients`,
+      method: 'GET',
+    });
+
+    const data = (await response.json()) as Array<{ client_id: string }>;
+
+    expect(data[0].client_id).toBe('123');
+    expect(request.isDone()).toBe(true);
+  });
+
+  it('should only retry until default configured attempts', async () => {
+    const request = nock(URL, { encodedQueryParams: true })
+      .get('/clients')
+      .times(4)
+      .reply(429)
+      .get('/clients')
+      .reply(200, [{ client_id: '123' }]);
+
+    const client = new TestClient({
+      baseUrl: URL,
+    });
+
+    try {
+      await client.testRequest({
+        path: `/clients`,
+        method: 'GET',
+      });
+      // Should not reach this
+      expect(true).toBeFalsy();
+    } catch (e: any) {
+      if (e instanceof ResponseError) {
+        expect(e.response.status).toBe(429);
+        expect(request.isDone()).toBe(false);
+      } else {
+        expect(e).toBeInstanceOf(ResponseError);
+      }
+    }
+  });
+
+  it('should retry 429 the configured amount of times', async () => {
+    const request = nock(URL, { encodedQueryParams: true })
+      .get('/clients')
+      .times(4)
+      .reply(429)
+      .get('/clients')
+      .reply(200, [{ client_id: '123' }]);
+
+    const client = new TestClient({
+      baseUrl: URL,
+      retry: {
+        maxRetries: 4,
+      },
+    });
+
+    const response = await client.testRequest({
+      path: `/clients`,
+      method: 'GET',
+    });
+
+    const data = (await response.json()) as Array<{ client_id: string }>;
+
+    expect(data[0].client_id).toBe('123');
+    expect(request.isDone()).toBe(true);
+  });
+
+  it('should not retry if not 429', async () => {
+    const request = nock(URL, { encodedQueryParams: true })
+      .get('/clients')
+      .reply(428)
+      .get('/clients')
+      .reply(200, [{ client_id: '123' }]);
+
+    const client = new TestClient({
+      baseUrl: URL,
+    });
+
+    try {
+      await client.testRequest({
+        path: `/clients`,
+        method: 'GET',
+      });
+      // Should not reach this
+      expect(true).toBeFalsy();
+    } catch (e: any) {
+      if (e instanceof ResponseError) {
+        expect(e.response.status).toBe(428);
+        expect(request.isDone()).toBe(false);
+      } else {
+        expect(e).toBeInstanceOf(ResponseError);
+      }
+    }
+  });
+
+  it('should not retry if not enabled', async () => {
+    const request = nock(URL, { encodedQueryParams: true })
+      .get('/clients')
+      .reply(429)
+      .get('/clients')
+      .reply(200, [{ client_id: '123' }]);
+
+    const client = new TestClient({
+      baseUrl: URL,
+      retry: {
+        enabled: false,
+      },
+    });
+
+    try {
+      await client.testRequest({
+        path: `/clients`,
+        method: 'GET',
+      });
+
+      // Should not reach this
+      expect(true).toBeFalsy();
+    } catch (e: any) {
+      if (e instanceof ResponseError) {
+        expect(e.response.status).toBe(429);
+        expect(request.isDone()).toBe(false);
+      } else {
+        expect(e).toBeInstanceOf(ResponseError);
+      }
+    }
+  });
+});
+
+describe('Runtime for ManagementClient', () => {
+  const URL = 'https://tenant.auth0.com/api/v2';
+
+  afterEach(() => {
+    nock.cleanAll();
+    jest.clearAllMocks();
+  });
+
+  it('should retry if enabled', async () => {
+    const request = nock(URL, { encodedQueryParams: true })
+      .get('/clients')
+      .times(2)
+      .reply(429)
+      .get('/clients')
+      .reply(200, [{ client_id: '123' }]);
+
+    const token = 'TOKEN';
+    const client = new ManagementClient({
+      domain: 'tenant.auth0.com',
+      token: token,
+    });
+    const response = await client.clients.getAll();
+
+    expect(response.data[0].client_id).toBe('123');
+    expect(request.isDone()).toBe(true);
+  });
+
+  it('should not retry if not enabled', async () => {
+    const request = nock(URL, { encodedQueryParams: true })
+      .get('/clients')
+      .reply(429)
+      .get('/clients')
+      .reply(200, [{ client_id: '123' }]);
+
+    const token = 'TOKEN';
+    const client = new ManagementClient({
+      domain: 'tenant.auth0.com',
+      token: token,
+      retry: {
+        enabled: false,
+      },
+    });
+
+    try {
+      await client.clients.getAll();
+
+      // Should not reach this
+      expect(true).toBeFalsy();
+    } catch (e: any) {
+      if (e instanceof ResponseError) {
+        expect(e.response.status).toBe(429);
+        expect(request.isDone()).toBe(false);
+      } else {
+        expect(e).toBeInstanceOf(ResponseError);
+      }
+    }
+  });
+});
+
+describe('Runtime for AuthenticationClient', () => {
+  const URL = 'https://tenant.auth0.com';
+  afterEach(() => {
+    nock.cleanAll();
+    jest.clearAllMocks();
+  });
+
+  it('should retry if enabled', async () => {
+    const request = nock(URL, { encodedQueryParams: true })
+      .post('/oauth/token')
+      .times(2)
+      .reply(429)
+      .post('/oauth/token')
+      .reply(200, { access_token: '123' });
+
+    const client = new AuthenticationClient({
+      domain: 'tenant.auth0.com',
+      clientId: '123',
+      clientSecret: '123',
+    });
+    const response = await client.oauth.clientCredentialsGrant({
+      audience: '123',
+    });
+
+    expect(response.data.access_token).toBe('123');
+    expect(request.isDone()).toBe(true);
+  });
+
+  it('should not retry if not enabled', async () => {
+    const request = nock(URL, { encodedQueryParams: true })
+      .post('/oauth/token')
+      .reply(429)
+      .post('/oauth/token')
+      .reply(200, { access_token: '123' });
+
+    const client = new AuthenticationClient({
+      domain: 'tenant.auth0.com',
+      clientId: '123',
+      clientSecret: '123',
+      retry: {
+        enabled: false,
+      },
+    });
+
+    try {
+      await client.oauth.clientCredentialsGrant({
+        audience: '123',
+      });
+
+      // Should not reach this
+      expect(true).toBeFalsy();
+    } catch (e: any) {
+      if (e instanceof ResponseError) {
+        expect(e.response.status).toBe(429);
+        expect(request.isDone()).toBe(false);
+      } else {
+        expect(e).toBeInstanceOf(ResponseError);
+      }
+    }
+  });
+});

--- a/test/runtime/runtime.test.ts
+++ b/test/runtime/runtime.test.ts
@@ -127,7 +127,7 @@ describe('Runtime', () => {
     }
   });
 
-  it('should retry using a configrable status code', async () => {
+  it('should retry using a configurable status code', async () => {
     const request = nock(URL, { encodedQueryParams: true })
       .get('/clients')
       .times(2)
@@ -138,7 +138,7 @@ describe('Runtime', () => {
     const client = new TestClient({
       baseUrl: URL,
       retry: {
-        retryWhen: 428,
+        retryWhen: [428],
       },
     });
 
@@ -151,6 +151,67 @@ describe('Runtime', () => {
 
     expect(data[0].client_id).toBe('123');
     expect(request.isDone()).toBe(true);
+  });
+
+  it('should retry using multiple configurable status code', async () => {
+    const request = nock(URL, { encodedQueryParams: true })
+      .get('/clients')
+      .reply(428)
+      .get('/clients')
+      .reply(429)
+      .get('/clients')
+      .reply(200, [{ client_id: '123' }]);
+
+    const client = new TestClient({
+      baseUrl: URL,
+      retry: {
+        retryWhen: [428, 429],
+      },
+    });
+
+    const response = await client.testRequest({
+      path: `/clients`,
+      method: 'GET',
+    });
+
+    const data = (await response.json()) as Array<{ client_id: string }>;
+
+    expect(data[0].client_id).toBe('123');
+    expect(request.isDone()).toBe(true);
+  });
+
+  it('should only retry configured status codes', async () => {
+    const request = nock(URL, { encodedQueryParams: true })
+      .get('/clients')
+      .reply(428)
+      .get('/clients')
+      .reply(429)
+      .get('/clients')
+      .reply(200, [{ client_id: '123' }]);
+
+    const client = new TestClient({
+      baseUrl: URL,
+      retry: {
+        retryWhen: [428],
+      },
+    });
+
+    try {
+      await client.testRequest({
+        path: `/clients`,
+        method: 'GET',
+      });
+
+      // Should not reach this
+      expect(true).toBeFalsy();
+    } catch (e: any) {
+      if (e instanceof ResponseError) {
+        expect(e.response.status).toBe(429);
+        expect(request.isDone()).toBe(false);
+      } else {
+        expect(e).toBeInstanceOf(ResponseError);
+      }
+    }
   });
 
   it('should not retry if not enabled', async () => {


### PR DESCRIPTION
### Changes

Adds retry functionality to BaseAPI using exponential backoff.

The SDK takes a configuration object to allow configuring the retry behavior using:

```js
{
  enabled: false, // defaults to true
  maxRetries: 4, // defaults to 3
  retryWhen: 401 // defaults to 429
}
```

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
