### PR TITLE
feat: add support for starting passwordless flows

### DIFF
--- a/src/auth/Passwordless.ts
+++ b/src/auth/Passwordless.ts
@@ -87,7 +87,7 @@ export default class Passwordless extends BaseAuthAPI {
         },
         body: (await this.addClientAuthentication(
           { connection: 'email', ...bodyParameters },
-          true
+          false
         )) as Record<string, string>,
       },
       initOverrides
@@ -127,7 +127,7 @@ export default class Passwordless extends BaseAuthAPI {
         },
         body: (await this.addClientAuthentication(
           { connection: 'sms', ...bodyParameters },
-          true
+          false
         )) as Record<string, string>,
       },
       initOverrides

--- a/src/auth/Passwordless.ts
+++ b/src/auth/Passwordless.ts
@@ -1,0 +1,138 @@
+import { InitOverride, VoidApiResponse, validateRequiredRequestParams } from '../runtime';
+import BaseAuthAPI from './BaseAuthApi';
+
+export interface SendEmailLinkRequest {
+  /**
+   * The user's email address
+   */
+  email: string;
+  /**
+   * Use `link` to send a link or `code` to send a verification code.
+   * If omitted, a `link` will be sent.
+   */
+  send?: 'link';
+  /**
+   * Append or override the link parameters (like `scope`, `redirect_uri`, `protocol`, `response_type`),
+   * when you send a link using email.
+   */
+  authParams?: Record<string, unknown>;
+}
+
+export interface SendEmailCodeRequest {
+  /**
+   * The user's email address
+   */
+  email: string;
+  /**
+   * Use `link` to send a link or `code` to send a verification code.
+   * If omitted, a `link` will be sent.
+   */
+  send?: 'code';
+}
+
+export type SendEmailRequest = SendEmailLinkRequest | SendEmailCodeRequest;
+
+export interface SendSmsRequest {
+  phone_number: string;
+}
+
+/**
+ * Handles passwordless flows using Email and SMS.
+ */
+export default class Passwordless extends BaseAuthAPI {
+  /**
+   * Start passwordless flow sending an email.
+   *
+   * @example <caption>
+   *   Given the user `email` address, it will send an email with:
+   *
+   *   <ul>
+   *     <li>A link (default, `send:"link"`). You can then authenticate with this
+   *       user opening the link and he will be automatically logged in to the
+   *       application. Optionally, you can append/override parameters to the link
+   *       (like `scope`, `redirect_uri`, `protocol`, `response_type`, etc.) using
+   *       `authParams` object.
+   *     </li>
+   *     <li>
+   *       A verification code (`send:"code"`). You can then authenticate with
+   *       this user using the `/oauth/ro` endpoint specifying `email` as
+   *       `username` and `code` as `password`.
+   *     </li>
+   *   </ul>
+   *
+   *   Find more information in the
+   *   <a href="https://auth0.com/docs/auth-api#!#post--with_email">API Docs</a>
+   * </caption>
+   *
+   * var data = {
+   *   email: '{EMAIL}',
+   *   send: 'link',
+   *   authParams: {} // Optional auth params.
+   * };
+   *
+   * auth0.passwordless.sendEmail(data);
+   */
+  async sendEmail(
+    bodyParameters: SendEmailRequest,
+    initOverrides?: InitOverride
+  ): Promise<VoidApiResponse> {
+    validateRequiredRequestParams(bodyParameters, ['email']);
+
+    const response = await this.request(
+      {
+        path: '/passwordless/start',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: (await this.addClientAuthentication(
+          { connection: 'email', ...bodyParameters },
+          true
+        )) as Record<string, string>,
+      },
+      initOverrides
+    );
+
+    return VoidApiResponse.fromResponse(response);
+  }
+
+  /**
+   * Start passwordless flow sending an SMS.
+   *
+   * @example <caption>
+   *   Given the user `phone_number`, it will send a SMS message with a
+   *   verification code. You can then authenticate with this user using the
+   *   `/oauth/ro` endpoint specifying `phone_number` as `username` and `code` as
+   *   `password`:
+   * </caption>
+   *
+   * const data = {
+   *   phone_number: '{PHONE}'
+   * };
+   *
+   * auth0.passwordless.sendSMS(data);
+   */
+  async sendSMS(
+    bodyParameters: SendSmsRequest,
+    initOverrides?: InitOverride
+  ): Promise<VoidApiResponse> {
+    validateRequiredRequestParams(bodyParameters, ['phone_number']);
+
+    const response = await this.request(
+      {
+        path: '/passwordless/start',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: (await this.addClientAuthentication(
+          { connection: 'sms', ...bodyParameters },
+          true
+        )) as Record<string, string>,
+      },
+      initOverrides
+    );
+
+    return VoidApiResponse.fromResponse(response);
+  }
+}

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,9 +1,13 @@
 import { Configuration } from './BaseAuthApi';
 import OAuth from './OAuth';
+import Passwordless from './Passwordless';
 
 export class AuthenticationClient {
   oauth: OAuth;
+  passwordless: Passwordless;
+
   constructor(options: Configuration) {
     this.oauth = new OAuth(options);
+    this.passwordless = new Passwordless(options);
   }
 }

--- a/test/auth/fixtures/passwordless.json
+++ b/test/auth/fixtures/passwordless.json
@@ -5,7 +5,6 @@
     "path": "/passwordless/start",
     "body": {
       "client_id": "test-client-id",
-      "client_secret": "test-client-secret",
       "email": "test-email@example.com",
       "connection": "email"
     },
@@ -20,7 +19,6 @@
     "path": "/passwordless/start",
     "body": {
       "client_id": "test-client-id",
-      "client_secret": "test-client-secret",
       "phone_number": "01234",
       "connection": "sms"
     },

--- a/test/auth/fixtures/passwordless.json
+++ b/test/auth/fixtures/passwordless.json
@@ -1,0 +1,32 @@
+[
+  {
+    "scope": "https://test-domain.auth0.com",
+    "method": "POST",
+    "path": "/passwordless/start",
+    "body": {
+      "client_id": "test-client-id",
+      "client_secret": "test-client-secret",
+      "email": "test-email@example.com",
+      "connection": "email"
+    },
+    "status": 200,
+    "response": {},
+    "rawHeaders": [],
+    "responseIsBinary": false
+  },
+  {
+    "scope": "https://test-domain.auth0.com",
+    "method": "POST",
+    "path": "/passwordless/start",
+    "body": {
+      "client_id": "test-client-id",
+      "client_secret": "test-client-secret",
+      "phone_number": "01234",
+      "connection": "sms"
+    },
+    "status": 200,
+    "response": {},
+    "rawHeaders": [],
+    "responseIsBinary": false
+  }
+]

--- a/test/auth/passwordless.test.ts
+++ b/test/auth/passwordless.test.ts
@@ -1,0 +1,120 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { v4 as uuid } from 'uuid';
+import nock from 'nock';
+import { beforeAll, afterAll } from '@jest/globals';
+import Passwordless from '../../src/auth/Passwordless';
+
+const { back: nockBack } = nock;
+
+nockBack.fixtures = `${path.dirname(fileURLToPath(import.meta.url))}/fixtures`;
+
+const DOMAIN = 'test-domain.auth0.com';
+const CLIENT_ID = 'test-client-id';
+const CLIENT_SECRET = 'test-client-secret';
+const EMAIL = 'test-email@example.com';
+const PHONE_NUMBER = '01234';
+
+if (process.env.RECORD) {
+  nockBack.setMode('update');
+} else {
+  nockBack.setMode('lockdown');
+}
+
+const baseUrl = `https://${DOMAIN}`;
+
+const opts = {
+  domain: process.env.TEST_DOMAIN || DOMAIN,
+  baseUrl,
+  clientId: process.env.TEST_CLIENT_ID || CLIENT_ID,
+  clientSecret: process.env.TEST_CLIENT_SECRET || CLIENT_SECRET,
+};
+
+const sanitizeFixture: any = (fixture: any, overrides = {}) => {
+  const sanitized = {
+    client_id: CLIENT_ID,
+    email: EMAIL,
+    phone_number: PHONE_NUMBER,
+    rawHeaders: [],
+    ...(fixture?.body && { body: sanitizeFixture(fixture.body, overrides) }),
+    ...(fixture?.response &&
+      typeof fixture.response !== 'string' && {
+        response: sanitizeFixture(fixture.response, overrides),
+      }),
+    ...overrides,
+  };
+
+  return Object.fromEntries(
+    Object.entries(fixture).reduce((memo, [key, value]) => {
+      return [...memo, [key, sanitized[key] || value]];
+    }, [] as any)
+  );
+};
+
+const getEmail = () => {
+  if (process.env.RECORD) {
+    return `${uuid()}@example.com`;
+  }
+  return EMAIL;
+};
+
+const getPhoneNumber = () => {
+  if (process.env.RECORD) {
+    return uuid();
+  }
+  return PHONE_NUMBER;
+};
+
+describe('Passwordless', () => {
+  let nockDone: () => void;
+
+  beforeAll(async () => {
+    ({ nockDone } = await nockBack('passwordless.json', {
+      afterRecord(fixtures) {
+        return fixtures.map((fixture) => sanitizeFixture(fixture));
+      },
+    }));
+  });
+
+  afterAll(() => {
+    nockDone();
+  });
+
+  describe('#sendEmail', () => {
+    it('should start passwordless using an email', async () => {
+      const passwordless = new Passwordless(opts);
+      const email = getEmail();
+      const response = await passwordless.sendEmail({
+        email,
+      });
+
+      expect(response.status).toBe(200);
+    });
+
+    it('should require email', async () => {
+      const passwordless = new Passwordless(opts);
+      await expect(passwordless.sendEmail({} as any)).rejects.toThrow(
+        'Required parameter requestParameters.email was null or undefined.'
+      );
+    });
+  });
+
+  describe('#sendSMS', () => {
+    it('should start passwordless using an SMS', async () => {
+      const passwordless = new Passwordless(opts);
+      const phone_number = getPhoneNumber();
+      const response = await passwordless.sendSMS({
+        phone_number,
+      });
+
+      expect(response.status).toBe(200);
+    });
+
+    it('should require phone_number', async () => {
+      const passwordless = new Passwordless(opts);
+      await expect(passwordless.sendEmail({} as any)).rejects.toThrow(
+        'Required parameter requestParameters.email was null or undefined.'
+      );
+    });
+  });
+});

--- a/test/auth/passwordless.test.ts
+++ b/test/auth/passwordless.test.ts
@@ -11,7 +11,6 @@ nockBack.fixtures = `${path.dirname(fileURLToPath(import.meta.url))}/fixtures`;
 
 const DOMAIN = 'test-domain.auth0.com';
 const CLIENT_ID = 'test-client-id';
-const CLIENT_SECRET = 'test-client-secret';
 const EMAIL = 'test-email@example.com';
 const PHONE_NUMBER = '01234';
 
@@ -27,7 +26,6 @@ const opts = {
   domain: process.env.TEST_DOMAIN || DOMAIN,
   baseUrl,
   clientId: process.env.TEST_CLIENT_ID || CLIENT_ID,
-  clientSecret: process.env.TEST_CLIENT_SECRET || CLIENT_SECRET,
 };
 
 const sanitizeFixture: any = (fixture: any, overrides = {}) => {


### PR DESCRIPTION
### Changes

Adds support for starting the passwordless flows using email or code.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
