### PR TITLE
feat: consistency between delete and remove

### DIFF
--- a/src/management/__generated/managers/OrganizationsManager.ts
+++ b/src/management/__generated/managers/OrganizationsManager.ts
@@ -58,7 +58,7 @@ export class OrganizationsManager extends BaseAPI {
    *
    * @throws {RequiredError}
    */
-  async removeEnabledConnection(
+  async deleteEnabledConnection(
     requestParameters: DeleteEnabledConnectionsByConnectionIdRequest,
     initOverrides?: InitOverride
   ): Promise<ApiResponse<void>> {

--- a/src/management/__generated/managers/RolesManager.ts
+++ b/src/management/__generated/managers/RolesManager.ts
@@ -38,7 +38,7 @@ export class RolesManager extends BaseAPI {
    *
    * @throws {RequiredError}
    */
-  async removePermissions(
+  async deletePermissions(
     requestParameters: DeleteRolePermissionAssignmentRequest,
     bodyParameters: PostRolePermissionAssignmentRequest,
     initOverrides?: InitOverride

--- a/test/management/organizations.tests.ts
+++ b/test/management/organizations.tests.ts
@@ -660,7 +660,7 @@ describe('OrganizationsManager', () => {
     });
   });
 
-  describe('#removeEnabledConnection', () => {
+  describe('#deleteEnabledConnection', () => {
     const data = {
       id: 'org_123',
       connectionId: '123',
@@ -675,7 +675,7 @@ describe('OrganizationsManager', () => {
     });
 
     it('should validate empty organizationId', () => {
-      expect(organizations.removeEnabledConnection({} as any, {} as any)).to.be.rejectedWith(
+      expect(organizations.deleteEnabledConnection({} as any, {} as any)).to.be.rejectedWith(
         RequiredError,
         `Required parameter requestParameters.id was null or undefined.`
       );
@@ -683,7 +683,7 @@ describe('OrganizationsManager', () => {
 
     it('should validate empty connectionId', function () {
       expect(
-        organizations.removeEnabledConnection({ id: '123' } as any, {} as any)
+        organizations.deleteEnabledConnection({ id: '123' } as any, {} as any)
       ).to.be.rejectedWith(
         RequiredError,
         `Required parameter requestParameters.connectionId was null or undefined.`
@@ -692,7 +692,7 @@ describe('OrganizationsManager', () => {
 
     it('should return a promise if no callback is given', function (done) {
       organizations
-        .removeEnabledConnection(data)
+        .deleteEnabledConnection(data)
         .then(done.bind(null, null))
         .catch(done.bind(null, null));
     });
@@ -704,7 +704,7 @@ describe('OrganizationsManager', () => {
         .delete(`/organizations/${data.id}/enabled_connections/${data.connectionId}`)
         .reply(500);
 
-      organizations.removeEnabledConnection(data, {}).catch((err) => {
+      organizations.deleteEnabledConnection(data, {}).catch((err) => {
         expect(err).to.exist;
 
         done();
@@ -712,7 +712,7 @@ describe('OrganizationsManager', () => {
     });
 
     it('should perform a DELETE request to /api/v2/organizations/organization_id/enabled_connections/connection_id', function (done) {
-      organizations.removeEnabledConnection(data).then(() => {
+      organizations.deleteEnabledConnection(data).then(() => {
         expect(request.isDone()).to.be.true;
 
         done();
@@ -727,7 +727,7 @@ describe('OrganizationsManager', () => {
         .matchHeader('Authorization', `Bearer ${token}`)
         .reply(200);
 
-      organizations.removeEnabledConnection(data, {}).then(() => {
+      organizations.deleteEnabledConnection(data, {}).then(() => {
         expect(request.isDone()).to.be.true;
 
         done();

--- a/test/management/roles.tests.ts
+++ b/test/management/roles.tests.ts
@@ -416,7 +416,7 @@ describe('RolesManager', () => {
     });
   });
 
-  describe('#removePermissions', () => {
+  describe('#deletePermissions', () => {
     const data = {
       id: 'rol_ID',
     };
@@ -432,14 +432,14 @@ describe('RolesManager', () => {
     });
 
     it('should validate empty roleId', function () {
-      expect(roles.removePermissions({} as any, body)).to.be.rejectedWith(
+      expect(roles.deletePermissions({} as any, body)).to.be.rejectedWith(
         RequiredError,
         `Required parameter requestParameters.id was null or undefined.`
       );
     });
 
     it('should return a promise if no callback is given', function (done) {
-      roles.removePermissions(data, body).then(done.bind(null, null)).catch(done.bind(null, null));
+      roles.deletePermissions(data, body).then(done.bind(null, null)).catch(done.bind(null, null));
     });
 
     it('should pass any errors to the promise catch handler', function (done) {
@@ -447,7 +447,7 @@ describe('RolesManager', () => {
 
       nock(API_URL).post(`/roles/${data.id}/permissions`).reply(500);
 
-      roles.removePermissions(data, body).catch((err) => {
+      roles.deletePermissions(data, body).catch((err) => {
         expect(err).to.exist;
 
         done();
@@ -455,7 +455,7 @@ describe('RolesManager', () => {
     });
 
     it('should perform a DELETE request to /api/v2/roles/rol_ID/permissions', function (done) {
-      roles.removePermissions(data, body).then(() => {
+      roles.deletePermissions(data, body).then(() => {
         expect(request.isDone()).to.be.true;
 
         done();
@@ -467,7 +467,7 @@ describe('RolesManager', () => {
 
       const request = nock(API_URL).delete(`/roles/${data.id}/permissions`, body).reply(200);
 
-      roles.removePermissions(data, body).then(() => {
+      roles.deletePermissions(data, body).then(() => {
         expect(request.isDone()).to.be.true;
 
         done();
@@ -482,7 +482,7 @@ describe('RolesManager', () => {
         .matchHeader('Authorization', `Bearer ${token}`)
         .reply(200);
 
-      roles.removePermissions(data, body).then(() => {
+      roles.deletePermissions(data, body).then(() => {
         expect(request.isDone()).to.be.true;
 
         done();

--- a/test/management/users.tests.ts
+++ b/test/management/users.tests.ts
@@ -1099,7 +1099,7 @@ describe('UsersManager', () => {
     });
   });
 
-  describe('#removePermissions', () => {
+  describe('#deletePermissions', () => {
     const data = {
       id: 'user_id',
     };


### PR DESCRIPTION
### Changes

Most methods are called `delete`, while two were named `remove`. 
This PR ensures we use `delete` instead of `remove` where applicable.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
