### PR TITLE
fix: ensure to use hyphens where needed

### DIFF
--- a/src/management/__generated/models/index.ts
+++ b/src/management/__generated/models/index.ts
@@ -6200,7 +6200,7 @@ export type PatchBreachedPasswordDetectionRequestMethodEnum =
 export interface PatchBreachedPasswordDetectionRequestStage {
   /**
    */
-  pre_user_registration?: PatchBreachedPasswordDetectionRequestStagePreUserRegistration;
+  'pre-user-registration'?: PatchBreachedPasswordDetectionRequestStagePreUserRegistration;
 }
 /**
  *
@@ -6509,10 +6509,10 @@ export type PatchSuspiciousIpThrottlingRequestShieldsEnum =
 export interface PatchSuspiciousIpThrottlingRequestStage {
   /**
    */
-  pre_login?: PatchSuspiciousIpThrottlingRequestStagePreLogin;
+  'pre-login'?: PatchSuspiciousIpThrottlingRequestStagePreLogin;
   /**
    */
-  pre_user_registration?: PatchSuspiciousIpThrottlingRequestStagePreUserRegistration;
+  'pre-user-registration'?: PatchSuspiciousIpThrottlingRequestStagePreUserRegistration;
 }
 /**
  * Configuration options that apply before every login attempt.


### PR DESCRIPTION
### Changes

Use `'pre-login'` instead of `pre_login`, and `'pre-user-registration'` instead of `pre_user_registration`.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
