### PR TITLE
Middleware fixes

### DIFF
--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -162,7 +162,7 @@ export interface ErrorContext {
 }
 
 export interface Middleware {
-  pre?(context: RequestContext): Promise<FetchParams | void>;
-  post?(context: ResponseContext): Promise<Response | void>;
-  onError?(context: ErrorContext): Promise<Response | void>;
+  pre?(context: RequestContext): Promise<FetchParams | void> | FetchParams | void;
+  post?(context: ResponseContext): Promise<Response | void> | Response | void;
+  onError?(context: ErrorContext): Promise<Response | void> | Response | void;
 }

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -107,20 +107,6 @@ export class VoidApiResponse implements ApiResponse<undefined> {
   }
 }
 
-export class BlobApiResponse implements ApiResponse<Blob> {
-  constructor(
-    public data: Blob,
-    public headers: Headers,
-    readonly status: number,
-    readonly statusText: string
-  ) {}
-
-  static async fromResponse(raw: Response) {
-    const value = await raw.blob();
-    return new BlobApiResponse(value, raw.headers, raw.status, raw.statusText);
-  }
-}
-
 export class TextApiResponse implements ApiResponse<string> {
   constructor(
     public data: string,

--- a/test/management/token-provider-middleware.test.ts
+++ b/test/management/token-provider-middleware.test.ts
@@ -1,0 +1,91 @@
+import nock from 'nock';
+import { jest } from '@jest/globals';
+import { RequestInit, Response } from 'node-fetch';
+import { TokenProvider } from '../../src/management/token-provider';
+import { RequestOpts, InitOverrideFunction } from '../../src/lib';
+import { BaseAPI } from '../../src/lib/runtime';
+import { TokenProviderMiddleware } from '../../src/management/token-provider-middleware';
+
+const domain = 'test-domain.auth0.com';
+
+const opts = {
+  baseUrl: `https://${domain}`,
+  clientId: 'test-client-id',
+  clientSecret: 'test-client-secret',
+  audience: 'my-api',
+  parseError: async (response: Response) => {
+    return new Error(`${response.status}`);
+  },
+};
+
+export class TestClient extends BaseAPI {
+  public async testRequest(
+    context: RequestOpts,
+    initOverrides?: RequestInit | InitOverrideFunction
+  ): Promise<Response> {
+    return this.request(context, initOverrides);
+  }
+}
+
+describe('TokenProviderMiddleware', () => {
+  const spy = jest.fn();
+  let clientSecretClient: TestClient;
+  let tokenClient: TestClient;
+
+  beforeEach(() => {
+    nock(opts.baseUrl)
+      .persist()
+      .post(
+        '/oauth/token',
+        `client_id=${opts.clientId}&audience=${opts.audience}&client_secret=${opts.clientSecret}&grant_type=client_credentials`
+      )
+      .reply(200, {
+        access_token: 'my-access-token',
+        expires_in: 86400,
+        token_type: 'Bearer',
+      });
+    nock(opts.baseUrl)
+      .get('/foo')
+      .reply(200, function (y) {
+        spy(this.req.headers);
+        return {};
+      });
+    clientSecretClient = new TestClient({
+      ...opts,
+      middleware: [new TokenProviderMiddleware({ ...opts, domain })],
+    });
+    const { clientSecret, ...optsNoSecret } = opts;
+    tokenClient = new TestClient({
+      ...opts,
+      middleware: [new TokenProviderMiddleware({ ...optsNoSecret, domain, token: 'token' })],
+    });
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('should use provided access token', async () => {
+    await expect(tokenClient.testRequest({ path: '/foo', method: 'GET' })).resolves.toMatchObject(
+      {}
+    );
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorization: 'Bearer token',
+      })
+    );
+  });
+
+  it('should use provided clientSecret', async () => {
+    await expect(
+      clientSecretClient.testRequest({ path: '/foo', method: 'GET' })
+    ).resolves.toMatchObject({});
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorization: 'Bearer my-access-token',
+      })
+    );
+  });
+});


### PR DESCRIPTION
Noticed a couple of issues with middleware

- `onError` doesn't run when you get a 4xx/5xx response
- Middleware handlers should be able to be run synchronously

Also added some tests for the token provider middleware