### PR TITLE
feat: update retry defaults to max 5 and max 10000 delay

### DIFF
--- a/src/lib/retry.ts
+++ b/src/lib/retry.ts
@@ -1,9 +1,9 @@
 import { Response } from 'node-fetch';
 
 const MAX_REQUEST_RETRY_JITTER = 250;
-const MAX_REQUEST_RETRY_DELAY = 1000;
+const MAX_REQUEST_RETRY_DELAY = 10000;
 const MIN_REQUEST_RETRY_DELAY = 250;
-const DEFAULT_NUMBER_RETRIES = 3;
+const DEFAULT_NUMBER_RETRIES = 5;
 const MAX_NUMBER_RETRIES = 10;
 const BASE_DELAY = 250;
 
@@ -42,7 +42,7 @@ export interface RetryConfiguration {
   enabled?: boolean;
   /**
    * Configure the max amount of retries the SDK should do.
-   * Defaults to 3.
+   * Defaults to 5.
    */
   maxRetries?: number;
   /**

--- a/test/runtime/runtime.test.ts
+++ b/test/runtime/runtime.test.ts
@@ -70,7 +70,7 @@ describe('Runtime', () => {
   it('should only retry until default configured attempts', async () => {
     const request = nock(URL, { encodedQueryParams: true })
       .get('/clients')
-      .times(4)
+      .times(6)
       .reply(429)
       .get('/clients')
       .reply(200, [{ client_id: '123' }]);
@@ -108,7 +108,7 @@ describe('Runtime', () => {
   it('should retry 429 the configured amount of times', async () => {
     const request = nock(URL, { encodedQueryParams: true })
       .get('/clients')
-      .times(4)
+      .times(6)
       .reply(429)
       .get('/clients')
       .reply(200, [{ client_id: '123' }]);
@@ -125,7 +125,7 @@ describe('Runtime', () => {
         );
       },
       retry: {
-        maxRetries: 4,
+        maxRetries: 6,
       },
     });
 


### PR DESCRIPTION
### Changes

Increasing the defaults slightly to reduce chances having to manually change them.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
