### PR TITLE
Support ESM and CJS

### DIFF
--- a/.shiprc
+++ b/.shiprc
@@ -1,3 +1,6 @@
 {
-    "postbump": "npm run docs"
+  "files": {
+    "src/version.ts": []
+  },
+  "postbump": "npm run docs"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "jose": "^4.13.2",
-        "node-fetch": "^3.3.1",
+        "node-fetch": "^2.6.7",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -2534,14 +2534,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -3439,28 +3431,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -3563,17 +3533,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -5829,39 +5788,23 @@
         "node": ">= 10.13"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
     "node_modules/node-fetch": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
-      "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
+        "whatwg-url": "^5.0.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": "4.x || >=6.0.0"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-int64": {
@@ -7349,6 +7292,11 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/ts-jest": {
       "version": "29.1.0",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.0.tgz",
@@ -7731,12 +7679,18 @@
         "makeerror": "1.0.12"
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-      "engines": {
-        "node": ">= 8"
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "import": "./dist/esm/index.js",
       "types": "./dist/typings/index.d.ts"
     }
   },
@@ -17,7 +17,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
+    "prebuild": "rm -rf dist",
+    "build": "tsc -b ./tsconfig.cjs.json ./tsconfig.esm.json ./tsconfig.types.json && echo '{\"type\": \"commonjs\"}'> dist/cjs/package.json",
     "docs": "typedoc --options typedoc.cjs",
     "test": "npm run test:mocha && npm run test:jest",
     "test:mocha": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' mocha",
@@ -46,7 +47,7 @@
   "homepage": "https://github.com/auth0/node-auth0",
   "dependencies": {
     "jose": "^4.13.2",
-    "node-fetch": "^3.3.1",
+    "node-fetch": "^2.6.7",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/playground/handlers.ts
+++ b/playground/handlers.ts
@@ -160,7 +160,7 @@ export async function branding() {
     },
     widget: {
       logo_position: 'center',
-      logo_url: '',
+      logo_url: 'https://cdn.auth0.com/website/bob/press/shield-dark.png',
       logo_height: 52,
       header_text_alignment: 'center',
       social_buttons_layout: 'bottom',
@@ -634,12 +634,9 @@ export async function jobs() {
   });
 
   const usersFilePath = path.join(__dirname, '../test/data/users.json');
-  const usersFileData = fs.readFileSync(usersFilePath, 'utf-8');
 
   const { data: createImportJob } = await mgmntClient.jobs.importUsers({
-    users: new Blob([usersFileData], {
-      type: 'application/json',
-    }),
+    users: fs.createReadStream(usersFilePath),
     connection_id: connection.id as string,
   });
 

--- a/src/auth/base-auth-api.ts
+++ b/src/auth/base-auth-api.ts
@@ -1,9 +1,9 @@
 import { ResponseError } from '../lib/errors';
 import { BaseAPI, ClientOptions } from '../lib/runtime';
 import { AddClientAuthenticationPayload, addClientAuthentication } from './client-authentication';
-import { Response, Headers } from 'node-fetch';
+import type { Response, Headers } from 'node-fetch';
 
-export interface Options extends ClientOptions {
+export interface AuthenticationClientOptions extends ClientOptions {
   domain: string;
   clientId: string;
   clientSecret?: string;
@@ -66,7 +66,7 @@ export class BaseAuthAPI extends BaseAPI {
   clientAssertionSigningKey?: string;
   clientAssertionSigningAlg?: string;
 
-  constructor(options: Options) {
+  constructor(options: AuthenticationClientOptions) {
     super({ ...options, baseUrl: `https://${options.domain}`, parseError });
 
     this.domain = options.domain;

--- a/src/auth/id-token-validator.ts
+++ b/src/auth/id-token-validator.ts
@@ -1,5 +1,5 @@
 import * as jose from 'jose';
-import { Options } from './base-auth-api';
+import { AuthenticationClientOptions } from './base-auth-api';
 
 const DEFAULT_CLOCK_TOLERANCE = 60; // secs
 
@@ -31,7 +31,7 @@ export class IDTokenValidator {
     timeoutDuration,
     idTokenSigningAlg = 'RS256',
     clockTolerance = DEFAULT_CLOCK_TOLERANCE,
-  }: Options) {
+  }: AuthenticationClientOptions) {
     this.jwks = jose.createRemoteJWKSet(new URL(`https://${domain}/.well-known/jwks.json`), {
       timeoutDuration,
       agent,

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,5 +1,5 @@
 import { TelemetryMiddleware } from '../lib/middleware/telemetry-middleware';
-import { Options } from './base-auth-api';
+import { AuthenticationClientOptions } from './base-auth-api';
 import { Database } from './database';
 import { OAuth } from './oauth';
 import { Passwordless } from './passwordless';
@@ -8,14 +8,14 @@ export * from './database';
 export * from './oauth';
 export * from './passwordless';
 export { IDTokenValidateOptions, IdTokenValidatorError } from './id-token-validator';
-export { AuthApiError, Options } from './base-auth-api';
+export { AuthApiError, AuthenticationClientOptions } from './base-auth-api';
 
 export class AuthenticationClient {
   database: Database;
   oauth: OAuth;
   passwordless: Passwordless;
 
-  constructor(options: Options) {
+  constructor(options: AuthenticationClientOptions) {
     if (options.telemetry !== false) {
       options.middleware = [...(options.middleware || []), new TelemetryMiddleware(options)];
     }

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -4,7 +4,7 @@ import {
   VoidApiResponse,
   validateRequiredRequestParams,
 } from '../lib/runtime';
-import { BaseAuthAPI, Options } from './base-auth-api';
+import { BaseAuthAPI, AuthenticationClientOptions } from './base-auth-api';
 import { IDTokenValidateOptions, IDTokenValidator } from './id-token-validator';
 
 export interface TokenSet {
@@ -176,7 +176,7 @@ export interface TokenExchangeGrantRequest {
  */
 export class OAuth extends BaseAuthAPI {
   private idTokenValidator: IDTokenValidator;
-  constructor(options: Options) {
+  constructor(options: AuthenticationClientOptions) {
     super(options);
     this.idTokenValidator = new IDTokenValidator(options);
   }

--- a/src/auth/passwordless.ts
+++ b/src/auth/passwordless.ts
@@ -4,7 +4,7 @@ import {
   VoidApiResponse,
   validateRequiredRequestParams,
 } from '../lib/runtime';
-import { BaseAuthAPI, Options } from './base-auth-api';
+import { BaseAuthAPI, AuthenticationClientOptions } from './base-auth-api';
 import { OAuth, ClientCredentials, GrantOptions, TokenSet } from './oauth';
 
 export interface SendEmailLinkRequest {
@@ -76,7 +76,7 @@ export interface LoginWithSMSRequest extends Omit<LoginWithEmailRequest, 'email'
  */
 export class Passwordless extends BaseAuthAPI {
   private oauth: OAuth;
-  constructor(configuration: Options) {
+  constructor(configuration: AuthenticationClientOptions) {
     super(configuration);
     this.oauth = new OAuth(configuration);
   }

--- a/src/index.mts
+++ b/src/index.mts
@@ -1,7 +1,0 @@
-import { ManagementClient as _ManagementClient } from './management';
-import { AuthenticationClient as _AuthenticationClient } from './auth';
-
-export const ManagementClient = _ManagementClient;
-export const AuthenticationClient = _AuthenticationClient;
-
-export default { ManagementClient, AuthenticationClient };

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,3 +1,4 @@
+import type { Headers } from 'node-fetch';
 /**
  * Error thrown when the API returns an error response that can't be parsed to a more specific Error instance.
  */

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,4 +1,4 @@
-import { RequestInit, RequestInfo, Response } from 'node-fetch';
+import type { RequestInit, RequestInfo, Response, Headers } from 'node-fetch';
 import { RetryConfiguration } from './retry';
 
 /**

--- a/src/lib/retry.ts
+++ b/src/lib/retry.ts
@@ -1,4 +1,4 @@
-import { Response } from 'node-fetch';
+import type { Response } from 'node-fetch';
 
 const MAX_REQUEST_RETRY_JITTER = 250;
 const MAX_REQUEST_RETRY_DELAY = 10000;

--- a/src/lib/runtime.ts
+++ b/src/lib/runtime.ts
@@ -1,4 +1,5 @@
-import fetch, { RequestInit, RequestInfo, Response, Blob, FormData, AbortError } from 'node-fetch';
+import type { RequestInit, RequestInfo } from 'node-fetch';
+import { Response } from 'node-fetch';
 import { retry } from './retry';
 import { FetchError, RequiredError, TimeoutError } from './errors';
 import {
@@ -9,8 +10,16 @@ import {
   Middleware,
   FetchAPI,
 } from './models';
+import fetch from 'node-fetch';
+import { AbortSignal } from 'node-fetch/externals';
+import FormData from 'form-data';
 
-export { Blob, FormData } from 'node-fetch';
+// const { constructor: _Blob } = await new Response().blob();
+// TODO: We need to figure out the correct type here.
+// Using any for now, as it does work at run-time.
+export const Blob = {} as any;
+
+export { FormData };
 export * from './models';
 
 /**
@@ -104,9 +113,9 @@ export class BaseAPI {
       controller.abort();
     }, this.timeoutDuration);
     try {
-      return await this.fetchApi(url, { signal: controller.signal, ...init });
-    } catch (e) {
-      if (e instanceof AbortError) {
+      return await this.fetchApi(url, { signal: controller.signal as AbortSignal, ...init });
+    } catch (e: any) {
+      if (e.name === 'AbortError') {
         throw new TimeoutError();
       }
       throw e;

--- a/src/management/__generated/managers/jobs-manager.ts
+++ b/src/management/__generated/managers/jobs-manager.ts
@@ -112,23 +112,33 @@ export class JobsManager extends BaseAPI {
     }
 
     if (bodyParameters.users !== undefined) {
-      formParams.append('users', bodyParameters.users as any);
+      let value = bodyParameters.users as any;
+      value = typeof value == 'number' || typeof value == 'boolean' ? '' + value : value;
+      formParams.append('users', value);
     }
 
     if (bodyParameters.connection_id !== undefined) {
-      formParams.append('connection_id', bodyParameters.connection_id as any);
+      let value = bodyParameters.connection_id as any;
+      value = typeof value == 'number' || typeof value == 'boolean' ? '' + value : value;
+      formParams.append('connection_id', value);
     }
 
     if (bodyParameters.upsert !== undefined) {
-      formParams.append('upsert', bodyParameters.upsert as any);
+      let value = bodyParameters.upsert as any;
+      value = typeof value == 'number' || typeof value == 'boolean' ? '' + value : value;
+      formParams.append('upsert', value);
     }
 
     if (bodyParameters.external_id !== undefined) {
-      formParams.append('external_id', bodyParameters.external_id as any);
+      let value = bodyParameters.external_id as any;
+      value = typeof value == 'number' || typeof value == 'boolean' ? '' + value : value;
+      formParams.append('external_id', value);
     }
 
     if (bodyParameters.send_completion_email !== undefined) {
-      formParams.append('send_completion_email', bodyParameters.send_completion_email as any);
+      let value = bodyParameters.send_completion_email as any;
+      value = typeof value == 'number' || typeof value == 'boolean' ? '' + value : value;
+      formParams.append('send_completion_email', value);
     }
 
     const response = await this.request(

--- a/src/management/management-client.ts
+++ b/src/management/management-client.ts
@@ -5,7 +5,7 @@ import {
 } from './management-client.options';
 import { TokenProviderMiddleware } from './token-provider-middleware';
 import { ResponseError } from '../lib';
-import { Response, Headers } from 'node-fetch';
+import type { Response, Headers } from 'node-fetch';
 import { TelemetryMiddleware } from '../lib/middleware/telemetry-middleware';
 
 interface ManagementApiErrorResponse {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,11 @@
-import pkg from '../package.json' assert { type: 'json' };
+import { version } from './version';
 
 /**
  * @private
  */
 export const generateClientInfo = () => ({
   name: 'node-auth0',
-  version: pkg.version,
+  version: version,
   env: {
     node: process.version.replace('v', ''),
   },

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,1 @@
+export const version = '4.0.0-beta.0';

--- a/test/management/token-provider-middleware.test.ts
+++ b/test/management/token-provider-middleware.test.ts
@@ -1,6 +1,6 @@
 import nock from 'nock';
 import { jest } from '@jest/globals';
-import { RequestInit, Response } from 'node-fetch';
+import type { RequestInit, Response } from 'node-fetch';
 import { TokenProvider } from '../../src/management/token-provider';
 import { RequestOpts, InitOverrideFunction } from '../../src/lib';
 import { BaseAPI } from '../../src/lib/runtime';

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/cjs",
+    "module": "CommonJS"
+  },
+  "include": ["./src"]
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/esm",
+    "module": "ESNext"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "outDir": "./dist",
     "allowJs": true,
     "target": "ES2017",
     "allowSyntheticDefaultImports": true,
@@ -11,8 +10,7 @@
     "moduleResolution": "node",
     "skipLibCheck": true,
     "module": "ESNext",
-    "strict": true,
-    "resolveJsonModule": true
+    "strict": true
   },
-  "include": ["src"]
+  "include": ["./src"]
 }

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/types",
+    "declaration": true,
+    "emitDeclarationOnly": true
+  }
+}


### PR DESCRIPTION
### Changes

This PR ensures we support both ESM and CJS. To achieve that, we downgraded node-fetch to v2. As a consequence of that, we had to juggle a little with the types.

You'll notice there is still an `any` involved with the `users` property on the payload to import users. It works, but we will need to figure out the types.

On top of that, there are also a couple of minor changes.

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
