### PR TITLE
update docs to include note about https for managment client

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -17,6 +17,8 @@ var auth0 = new ManagementClient({
 
 > Make sure your `clientId` is allowed to request tokens from Management API in [Auth0 Dashboard](https://manage.auth0.com/#/apis)
 
+> Note: The domain should not include `https://` the ManagementClient will prepend that to the string.
+
 ### Obtaining Management API Token from Node.js backend
 
 To obtain a Management API token from your node backend, you can use Client Credentials Grant using your registered Auth0 Non Interactive Clients

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ var management = new ManagementClient({
 });
 ```
 
+> Note: The domain should not include `https://` the ManagementClient will prepend that to the string.
+
 For other examples see the [EXAMPLES.md](https://github.com/auth0/node-auth0/blob/master/EXAMPLES.md) document.
 
 ## API Reference


### PR DESCRIPTION
### Changes

This is a small note to not include `https://` when instantiating the management client. I know the docs do not include it, but I spent a while troubleshooting this issue since I was just using the full domain including https. I have an express app also using the `express-oauth2-jwt-bearer` where you do use the full url. So, I just was like oh I don't need to use a separate variable for this.

The http client in nodejs was just failing with the error `'APIError: getaddrinfo ENOTFOUND https\n' ` which was confusing to try and troubleshoot until I went into the code to find out how the URLs are being formatted.

This may not be worth changing. I am opening this pr to potentially help other folks who may have this same issue.

### Testing

This is mostly about clarity in the docs.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
