### PR TITLE
Add option to pass x-request-language header for passwordless

### DIFF
--- a/src/auth/PasswordlessAuthenticator.js
+++ b/src/auth/PasswordlessAuthenticator.js
@@ -8,9 +8,10 @@ function getParamsFromOptions(options) {
   if (!options || typeof options !== 'object') {
     return params;
   }
-  if (options.forwardedFor) {
+  if (options.forwardedFor || options.requestLanguage) {
     params._requestCustomizer = function (req) {
-      req.set('auth0-forwarded-for', options.forwardedFor);
+      options.forwardedFor && req.set('auth0-forwarded-for', options.forwardedFor);
+      options.requestLanguage && req.set('x-request-language', options.requestLanguage);
     };
   }
   return params;
@@ -214,6 +215,7 @@ class PasswordlessAuthenticator {
    * @param   {string}    userData.send           The type of email to be sent.
    * @param   {object}    [options]              Additional options.
    * @param   {string}    [options.forwardedFor] Value to be used for auth0-forwarded-for header
+   * @param   {string}    [options.requestLanguage] Specify a language for the message area.
    * @param   {Function}  [cb]                    Method callback.
    * @returns  {Promise|undefined}
    */
@@ -270,6 +272,7 @@ class PasswordlessAuthenticator {
    * @param   {string}    userData.phone_number   User phone number.
    * @param   {object}    [options]              Additional options.
    * @param   {string}    [options.forwardedFor] Value to be used for auth0-forwarded-for header
+   * @param   {string}    [options.requestLanguage] Specify a language for the message area.
    * @param   {Function}  [cb]                    Method callback.
    * @returns  {Promise|undefined}
    */

--- a/test/auth/passwordless.tests.js
+++ b/test/auth/passwordless.tests.js
@@ -736,6 +736,25 @@ describe('PasswordlessAuthenticator', () => {
         .catch(done);
     });
 
+    it('should make it possible to pass x-request-language header', function (done) {
+      nock.cleanAll();
+
+      const request = nock(API_URL)
+        .post(path, function () {
+          return this.headers['x-request-language'] === 'fr';
+        })
+        .reply(200);
+
+      this.authenticator
+        .sendEmail(userData, { requestLanguage: 'fr' })
+        .then(() => {
+          expect(request.isDone()).to.be.true;
+
+          done();
+        })
+        .catch(done);
+    });
+
     it('should make request with proxy', async () => {
       nock.cleanAll();
 
@@ -908,6 +927,25 @@ describe('PasswordlessAuthenticator', () => {
 
       this.authenticator
         .sendSMS(userData, options)
+        .then(() => {
+          expect(request.isDone()).to.be.true;
+
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should make it possible to pass x-request-language header', function (done) {
+      nock.cleanAll();
+
+      const request = nock(API_URL)
+        .post(path, function () {
+          return this.headers['x-request-language'] === 'fr';
+        })
+        .reply(200);
+
+      this.authenticator
+        .sendSMS(userData, { requestLanguage: 'fr' })
         .then(() => {
           expect(request.isDone()).to.be.true;
 


### PR DESCRIPTION
### Changes

Add option to pass `x-request-language` header for Passwordless

### References

See https://auth0.com/docs/authenticate/passwordless/authentication-methods/email-magic-link#multi-language-support
Replaces #870 

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
