### PR TITLE
Fix issue with TS rewriting fetch dynamic imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build": "tsc -b ./tsconfig.cjs.json ./tsconfig.esm.json ./tsconfig.types.json && echo '{\"type\": \"commonjs\"}'> dist/cjs/package.json",
     "docs": "typedoc --options typedoc.cjs",
     "test": "npm run test:mocha && npm run test:jest",
-    "test:mocha": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' mocha",
+    "test:mocha": "TS_NODE_COMPILER_OPTIONS='{\"moduleResolution\":\"node\"}' NODE_OPTIONS='--experimental-vm-modules --no-warnings' mocha",
     "test:jest": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest",
     "test:ci": "c8 npm run test",
     "precommit": "pretty-quick --staged",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "esModuleInterop": true,
     "sourceMap": true,
     "declaration": false,
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "skipLibCheck": true,
     "module": "ESNext",
     "strict": true


### PR DESCRIPTION
### Changes

https://github.com/auth0/node-auth0/releases/tag/v4.0.0-beta.4 broke the CJS version of the Beta because TypeScript was rewriting the `node-fetch@3` dynamic imports. (see https://github.com/microsoft/TypeScript/issues/43329)

[The suggestion](https://github.com/microsoft/TypeScript/issues/43329#issuecomment-1276000768) to use `moduleResolution: node16` works (have `npm pack`d and tested native esm and cjs) - I've diffed the build and the only differences are the removal of transpiled imports.

Will add some automated tests to make sure we don't break the exports again... 🤦 