### PR TITLE
Support Organization Name

### DIFF
--- a/src/auth/id-token-validator.ts
+++ b/src/auth/id-token-validator.ts
@@ -115,7 +115,7 @@ export class IDTokenValidator {
           );
         }
 
-        if (payload.org_name.toLowerCase() !== organization.toLowerCase()) {
+        if (payload.org_name !== organization.toLowerCase()) {
           throw new Error(
             `Organization Name (org_name) claim value mismatch in the ID token; expected "${organization}", found "${payload.org_name}"'`
           );

--- a/src/auth/id-token-validator.ts
+++ b/src/auth/id-token-validator.ts
@@ -96,16 +96,30 @@ export class IDTokenValidator {
 
     // Organization
     if (organization) {
-      if (!payload.org_id || typeof payload.org_id !== 'string') {
-        throw new IdTokenValidatorError(
-          'Organization Id (org_id) claim must be a string present in the ID token'
-        );
-      }
+      if (organization.indexOf('org_') === 0) {
+        if (!payload.org_id || typeof payload.org_id !== 'string') {
+          throw new Error(
+            'Organization Id (org_id) claim must be a string present in the ID token'
+          );
+        }
 
-      if (payload.org_id !== organization) {
-        throw new IdTokenValidatorError(
-          `Organization Id (org_id) claim value mismatch in the ID token; expected "${organization}", found "${payload.org_id}"'`
-        );
+        if (payload.org_id !== organization) {
+          throw new Error(
+            `Organization Id (org_id) claim value mismatch in the ID token; expected "${organization}", found "${payload.org_id}"'`
+          );
+        }
+      } else {
+        if (!payload.org_name || typeof payload.org_name !== 'string') {
+          throw new Error(
+            'Organization Name (org_name) claim must be a string present in the ID token'
+          );
+        }
+
+        if (payload.org_name.toLowerCase() !== organization.toLowerCase()) {
+          throw new Error(
+            `Organization Name (org_name) claim value mismatch in the ID token; expected "${organization}", found "${payload.org_name}"'`
+          );
+        }
       }
     }
 

--- a/test/auth/id-token-validator.test.ts
+++ b/test/auth/id-token-validator.test.ts
@@ -348,4 +348,84 @@ describe('id-token-validator', () => {
       /\(auth_time\) claim must be a number present in the ID token/
     );
   });
+
+  it('should throw when organization id is in options, but org_id missing from claim', async () => {
+    const idTokenValidator = new IDTokenValidator({
+      domain: DOMAIN,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    });
+
+    const jwt = await sign({ payload: { org_id: undefined } });
+
+    expect(idTokenValidator.validate(jwt, { organization: 'org_123' })).rejects.toThrow(
+      'Organization Id (org_id) claim must be a string present in the ID token'
+    );
+  });
+
+  it('should throw when organization name is in options, but org_name missing from claim', async () => {
+    const idTokenValidator = new IDTokenValidator({
+      domain: DOMAIN,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    });
+
+    const jwt = await sign({ payload: { org_name: undefined } });
+
+    expect(idTokenValidator.validate(jwt, { organization: 'testorg' })).rejects.toThrow(
+      'Organization Name (org_name) claim must be a string present in the ID token'
+    );
+  });
+
+  it('should throw when org id claim doesnt match org expected', async () => {
+    const idTokenValidator = new IDTokenValidator({
+      domain: DOMAIN,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    });
+
+    const jwt = await sign({ payload: { org_id: 'org_1234' } });
+
+    expect(idTokenValidator.validate(jwt, { organization: 'org_123' })).rejects.toThrow(
+      'Organization Id (org_id) claim value mismatch in the ID token; expected "org_123", found "org_1234'
+    );
+  });
+
+  it('should throw when org name claim doesnt match org expected', async () => {
+    const idTokenValidator = new IDTokenValidator({
+      domain: DOMAIN,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    });
+
+    const jwt = await sign({ payload: { org_name: 'notExpectedOrg' } });
+
+    expect(idTokenValidator.validate(jwt, { organization: 'testorg' })).rejects.toThrow(
+      'Organization Name (org_name) claim value mismatch in the ID token; expected "testorg", found "notExpectedOrg'
+    );
+  });
+
+  it('should NOT throw when org_id matches expected organization', async () => {
+    const idTokenValidator = new IDTokenValidator({
+      domain: DOMAIN,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    });
+
+    const jwt = await sign({ payload: { org_id: 'org_123' } });
+
+    expect(idTokenValidator.validate(jwt, { organization: 'org_123' })).resolves.not.toThrow();
+  });
+
+  it('should NOT throw when org_name matches expected organization', async () => {
+    const idTokenValidator = new IDTokenValidator({
+      domain: DOMAIN,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    });
+
+    const jwt = await sign({ payload: { org_name: 'testorg' } });
+
+    expect(idTokenValidator.validate(jwt, { organization: 'testorg' })).resolves.not.toThrow();
+  });
 });

--- a/test/auth/id-token-validator.test.ts
+++ b/test/auth/id-token-validator.test.ts
@@ -426,6 +426,6 @@ describe('id-token-validator', () => {
 
     const jwt = await sign({ payload: { org_name: 'testorg' } });
 
-    expect(idTokenValidator.validate(jwt, { organization: 'testorg' })).resolves.not.toThrow();
+    expect(idTokenValidator.validate(jwt, { organization: 'testOrg' })).resolves.not.toThrow();
   });
 });

--- a/test/auth/oauth.test.ts
+++ b/test/auth/oauth.test.ts
@@ -263,20 +263,37 @@ describe('OAuth (with ID Token validation)', () => {
     nockDone();
   });
 
-  it('should throw for invalid organization', async () => {
+  it('should throw for invalid organization id', async () => {
     const { nockDone } = await nockBack('auth/fixtures/oauth.json', {
       before: await withIdToken({
         ...opts,
-        payload: { org_id: 'foo' },
+        payload: { org_id: 'org_123' },
       }),
     });
     const oauth = new OAuth(opts);
     await expect(
       oauth.refreshTokenGrant(
         { refresh_token: 'test-refresh-token' },
-        { idTokenValidateOptions: { organization: 'bar' } }
+        { idTokenValidateOptions: { organization: 'org_1235' } }
       )
     ).rejects.toThrowError(/\(org_id\) claim value mismatch in the ID token/);
+    nockDone();
+  });
+
+  it('should throw for invalid organization name', async () => {
+    const { nockDone } = await nockBack('auth/fixtures/oauth.json', {
+      before: await withIdToken({
+        ...opts,
+        payload: { org_name: 'org123' },
+      }),
+    });
+    const oauth = new OAuth(opts);
+    await expect(
+      oauth.refreshTokenGrant(
+        { refresh_token: 'test-refresh-token' },
+        { idTokenValidateOptions: { organization: 'org1235' } }
+      )
+    ).rejects.toThrowError(/\(org_name\) claim value mismatch in the ID token/);
     nockDone();
   });
 });


### PR DESCRIPTION
### Changes

Adds support for the organization name by extending the ID Token validation as follows:

- If organization is set and has the `org_` prefix, we expect an org_id claim
- If organization is set and does not have the `org_` prefix, we expect an org_name claim

### Testing

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
