### PR TITLE
Handle duplicate user sign up

### DIFF
--- a/src/auth/base-auth-api.ts
+++ b/src/auth/base-auth-api.ts
@@ -37,13 +37,13 @@ function parseErrorBody(body: any): AuthApiErrorResponse {
   const rawData = JSON.parse(body);
   let data: AuthApiErrorResponse;
 
-  if (rawData.code) {
+  if (rawData.error) {
+    data = rawData as AuthApiErrorResponse;
+  } else {
     data = {
       error: rawData.code,
       error_description: rawData.description,
     };
-  } else {
-    data = rawData as AuthApiErrorResponse;
   }
 
   return data;

--- a/src/auth/base-auth-api.ts
+++ b/src/auth/base-auth-api.ts
@@ -33,6 +33,22 @@ export class AuthApiError extends Error {
   }
 }
 
+function parseErrorBody(body: any): AuthApiErrorResponse {
+  const rawData = JSON.parse(body);
+  let data: AuthApiErrorResponse;
+
+  if (rawData.code) {
+    data = {
+      error: rawData.code,
+      error_description: rawData.description,
+    };
+  } else {
+    data = rawData as AuthApiErrorResponse;
+  }
+
+  return data;
+}
+
 async function parseError(response: Response) {
   // Errors typically have a specific format:
   // {
@@ -41,10 +57,10 @@ async function parseError(response: Response) {
   // }
 
   const body = await response.text();
-  let data: AuthApiErrorResponse;
 
   try {
-    data = JSON.parse(body) as AuthApiErrorResponse;
+    const data = parseErrorBody(body);
+
     return new AuthApiError(
       data.error,
       data.error_description,

--- a/test/auth/database.test.ts
+++ b/test/auth/database.test.ts
@@ -1,10 +1,12 @@
 import nock from 'nock';
 import { beforeAll, afterAll } from '@jest/globals';
 import { Database } from '../../src/auth/database';
+import { AuthApiError } from '../../src/auth/base-auth-api';
 
 const { back: nockBack } = nock;
 
 const EMAIL = 'test-email@example.com';
+const DUPLICATE_EMAIL = 'test-email-duplicate@example.com';
 const PASSWORD = 'test-password';
 
 const opts = {
@@ -47,6 +49,30 @@ describe('Database', () => {
           password: PASSWORD,
         } as any)
       ).rejects.toThrow('Required parameter requestParameters.connection was null or undefined.');
+    });
+
+    it('should handle duplicate user error', async () => {
+      const database = new Database(opts);
+      const email = DUPLICATE_EMAIL;
+      let error: AuthApiError | null = null;
+
+      try {
+        await database.signUp({
+          email,
+          password: PASSWORD,
+          connection: 'Username-Password-Authentication',
+        });
+      } catch (e) {
+        error = e as AuthApiError;
+      }
+
+      expect(error).toBeDefined();
+      expect(error).toEqual(
+        expect.objectContaining({
+          error: 'invalid_signup',
+          error_description: 'Invalid sign up',
+        })
+      );
     });
   });
 

--- a/test/auth/fixtures/database.json
+++ b/test/auth/fixtures/database.json
@@ -36,6 +36,23 @@
   {
     "scope": "https://test-domain.auth0.com",
     "method": "POST",
+    "path": "/dbconnections/signup",
+    "body": {
+      "client_id": "test-client-id",
+      "email": "test-email-duplicate@example.com",
+      "password": "test-password",
+      "connection": "Username-Password-Authentication"
+    },
+    "status": 400,
+    "response": {
+      "name": "BadRequestError",
+      "code": "invalid_signup",
+      "description": "Invalid sign up"
+    }
+  },
+  {
+    "scope": "https://test-domain.auth0.com",
+    "method": "POST",
     "path": "/dbconnections/change_password",
     "body": {
       "client_id": "test-client-id",


### PR DESCRIPTION
### Changes

/dbconnections/signup doesn’t always return an error as described in the Errors section of auth api docs. If you’re signing up a duplicate user then it’ll be an error with a shape like so
{"name":"BadRequestError","code":"invalid_signup","description":"Invalid sign up","statusCode":400}

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
