### PR TITLE
Support custom parameters with Authorization Code and Refresh Token grant

### DIFF
--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -70,6 +70,11 @@ export interface AuthorizationCodeGrantRequest extends ClientCredentials {
    *	This is required only if it was set at the `/authorize` endpoint. The values must match.
    */
   redirect_uri?: string;
+
+  /**
+   * Allow for any custom property to be sent to Auth0
+   */
+  [key: string]: any;
 }
 
 export interface AuthorizationCodeGrantWithPKCERequest extends AuthorizationCodeGrantRequest {
@@ -133,6 +138,11 @@ export interface RefreshTokenGrantRequest extends ClientCredentials {
    * If not sent, the original scopes will be used; otherwise you can request a reduced set of scopes.
    */
   scope?: string;
+
+  /**
+   * Allow for any custom property to be sent to Auth0
+   */
+  [key: string]: any;
 }
 
 export interface RevokeRefreshTokenRequest extends ClientCredentials {

--- a/test/auth/fixtures/oauth.json
+++ b/test/auth/fixtures/oauth.json
@@ -17,6 +17,20 @@
     "scope": "https://test-domain.auth0.com",
     "method": "POST",
     "path": "/oauth/token",
+    "body": "client_id=test-client-id&code=test-valid-code&redirect_uri=https%3A%2F%2Fexample.com&my_param=test&client_secret=test-client-secret&grant_type=authorization_code",
+    "status": 200,
+    "response": {
+      "access_token": "my-access-token",
+      "expires_in": 86400,
+      "token_type": "Bearer",
+      "id_token": "my-id-token",
+      "scope": "openid profile email address phone"
+    }
+  },
+  {
+    "scope": "https://test-domain.auth0.com",
+    "method": "POST",
+    "path": "/oauth/token",
     "body": "client_id=test-client-id&code=test-invalid-code&redirect_uri=https%3A%2F%2Fexample.com&client_secret=test-client-secret&grant_type=authorization_code",
     "status": 403,
     "response": {
@@ -29,6 +43,20 @@
     "method": "POST",
     "path": "/oauth/token",
     "body": "client_id=test-client-id&code=test-code&code_verifier=test-valid-code-verifier&redirect_uri=https%3A%2F%2Fexample.com&client_secret=test-client-secret&grant_type=authorization_code",
+    "status": 200,
+    "response": {
+      "access_token": "my-access-token",
+      "expires_in": 86400,
+      "token_type": "Bearer",
+      "id_token": "my-id-token",
+      "scope": "openid profile email address phone"
+    }
+  },
+  {
+    "scope": "https://test-domain.auth0.com",
+    "method": "POST",
+    "path": "/oauth/token",
+    "body": "client_id=test-client-id&code=test-code&code_verifier=test-valid-code-verifier&redirect_uri=https%3A%2F%2Fexample.com&my_param=test&client_secret=test-client-secret&grant_type=authorization_code",
     "status": 200,
     "response": {
       "access_token": "my-access-token",
@@ -94,6 +122,20 @@
     "method": "POST",
     "path": "/oauth/token",
     "body": "client_id=test-client-id&refresh_token=test-refresh-token&client_secret=test-client-secret&grant_type=refresh_token",
+    "status": 200,
+    "response": {
+      "access_token": "my-access-token",
+      "expires_in": 86400,
+      "token_type": "Bearer",
+      "id_token": "my-id-token",
+      "scope": "openid profile email address phone offline_access"
+    }
+  },
+  {
+    "scope": "https://test-domain.auth0.com",
+    "method": "POST",
+    "path": "/oauth/token",
+    "body": "client_id=test-client-id&refresh_token=test-refresh-token&my_param=test&client_secret=test-client-secret&grant_type=refresh_token",
     "status": 200,
     "response": {
       "access_token": "my-access-token",

--- a/test/auth/oauth.test.ts
+++ b/test/auth/oauth.test.ts
@@ -56,6 +56,23 @@ describe('OAuth', () => {
       });
     });
 
+    it('should send custom parameters', async () => {
+      const oauth = new OAuth(opts);
+      await expect(
+        oauth.authorizationCodeGrant({
+          code: 'test-valid-code',
+          redirect_uri: 'https://example.com',
+          my_param: 'test',
+        })
+      ).resolves.toMatchObject({
+        data: {
+          access_token: 'my-access-token',
+          expires_in: 86400,
+          token_type: 'Bearer',
+        },
+      });
+    });
+
     it('should throw for invalid code', async () => {
       const oauth = new OAuth(opts);
       await expect(
@@ -113,6 +130,24 @@ describe('OAuth', () => {
           body: expect.anything(),
         })
       );
+    });
+
+    it('should send custom parameters', async () => {
+      const oauth = new OAuth(opts);
+      await expect(
+        oauth.authorizationCodeGrantWithPKCE({
+          code: 'test-code',
+          code_verifier: 'test-valid-code-verifier',
+          redirect_uri: 'https://example.com',
+          my_param: 'test',
+        })
+      ).resolves.toMatchObject({
+        data: {
+          access_token: 'my-access-token',
+          expires_in: 86400,
+          token_type: 'Bearer',
+        },
+      });
     });
   });
 
@@ -191,6 +226,24 @@ describe('OAuth', () => {
       const oauth = new OAuth(opts);
       await expect(
         oauth.refreshTokenGrant({ refresh_token: 'test-refresh-token' })
+      ).resolves.toMatchObject({
+        data: {
+          access_token: 'my-access-token',
+          expires_in: 86400,
+          token_type: 'Bearer',
+          id_token: expect.any(String),
+          scope: 'openid profile email address phone offline_access',
+        },
+      });
+    });
+
+    it('should send custom parameters', async () => {
+      const oauth = new OAuth(opts);
+      await expect(
+        oauth.refreshTokenGrant({
+          refresh_token: 'test-refresh-token',
+          my_param: 'test',
+        })
       ).resolves.toMatchObject({
         data: {
           access_token: 'my-access-token',


### PR DESCRIPTION
### Changes

Authorization Code (with and without PKCE) and Refresh Token Grants should accept custom parameters.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
