### PR TITLE
[SDK-4463] Retry config

### DIFF
--- a/src/auth/base-auth-api.ts
+++ b/src/auth/base-auth-api.ts
@@ -85,7 +85,12 @@ export class BaseAuthAPI extends BaseAPI {
   clientAssertionSigningAlg?: string;
 
   constructor(options: AuthenticationClientOptions) {
-    super({ ...options, baseUrl: `https://${options.domain}`, parseError });
+    super({
+      ...options,
+      baseUrl: `https://${options.domain}`,
+      parseError,
+      retry: { enabled: false, ...options.retry },
+    });
 
     this.domain = options.domain;
     this.clientId = options.clientId;

--- a/src/lib/retry.ts
+++ b/src/lib/retry.ts
@@ -35,7 +35,7 @@ async function pause(delay: number) {
 export interface RetryConfiguration {
   /**
    * Configure the usage of retries.
-   * Defaults to true.
+   * Defaults to true on the Management Client and false on the Authentication Client.
    */
   enabled?: boolean;
   /**

--- a/test/lib/runtime.test.ts
+++ b/test/lib/runtime.test.ts
@@ -583,6 +583,9 @@ describe('Runtime for AuthenticationClient', () => {
       domain: 'tenant.auth0.com',
       clientId: '123',
       clientSecret: '123',
+      retry: {
+        enabled: true,
+      },
     });
     const response = await client.oauth.clientCredentialsGrant({
       audience: '123',
@@ -603,9 +606,6 @@ describe('Runtime for AuthenticationClient', () => {
       domain: 'tenant.auth0.com',
       clientId: '123',
       clientSecret: '123',
-      retry: {
-        enabled: false,
-      },
     });
 
     try {


### PR DESCRIPTION
Default `retry` to `false` on Authentication Client, to match v3