### PR TITLE
Drop support for node 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     parameters:
       node-version:
         type: string
-        default: "16.18"
+        default: "18.17"
     docker:
       - image: cimg/node:<< parameters.node-version >>
     resource_class: xlarge
@@ -36,7 +36,7 @@ workflows:
       - build-and-test:
           matrix:
             parameters:
-              node-version: ["16.18", "18.17", "20.3"]
+              node-version: ["18.17", "20.3"]
       - ship/node-publish:
           publish-command: npm run build && npm publish --tag beta
           requires:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 This library supports the following tooling versions:
 
-- Node.js: `>=16`
+- Node.js: `>=18`
 
 ### Installation
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/auth0/node-auth0"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "keywords": [
     "auth0",

--- a/v4_MIGRATION_GUIDE.md
+++ b/v4_MIGRATION_GUIDE.md
@@ -18,9 +18,9 @@ Guide to migrating from `3.x` to `4.x`
 
 ## General
 
-### Node 16 or newer is required
+### Node 18 or newer is required
 
-Node 16 LTS and newer LTS releases are supported.
+Node 18 LTS and newer LTS releases are supported.
 
 ### Callbacks are no longer supported
 


### PR DESCRIPTION
### Changes

With node16 going EOL on September 11 (see https://nodejs.org/en/blog/announcements/nodejs16-eol), it makes sense to drop support for node16 in the new major version.

### References

https://nodejs.org/en/blog/announcements/nodejs16-eol

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
