### PR TITLE
Drop node-fetch and only use native fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1394,27 +1394,13 @@
       "dev": true
     },
     "node_modules/@types/node-fetch": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.3.tgz",
-      "integrity": "sha512-ETTL1mOEdq/sxUtgtOhKjyB2Irra4cjxksvcMUR5Zr4n+PxVhsCD9WS46oPbHL3et9Zde7CNRr+WUNlcHvsX+w==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
+      "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
         "form-data": "^3.0.0"
-      }
-    },
-    "node_modules/@types/node-fetch/node_modules/form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -3250,6 +3236,28 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -3331,6 +3339,20 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -3340,28 +3362,6 @@
       },
       "engines": {
         "node": ">=12.20.0"
-      }
-    },
-    "node_modules/formdata-polyfill/node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/fs.realpath": {
@@ -5359,9 +5359,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
-      "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -5373,28 +5373,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/node-fetch/node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/node-int64": {
@@ -8390,26 +8368,13 @@
       "dev": true
     },
     "@types/node-fetch": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.3.tgz",
-      "integrity": "sha512-ETTL1mOEdq/sxUtgtOhKjyB2Irra4cjxksvcMUR5Zr4n+PxVhsCD9WS46oPbHL3et9Zde7CNRr+WUNlcHvsX+w==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
+      "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        }
       }
     },
     "@types/normalize-package-data": {
@@ -9758,6 +9723,15 @@
         "bser": "2.1.1"
       }
     },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -9821,23 +9795,23 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
     "formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "requires": {
         "fetch-blob": "^3.1.2"
-      },
-      "dependencies": {
-        "fetch-blob": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-          "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-          "requires": {
-            "node-domexception": "^1.0.0",
-            "web-streams-polyfill": "^3.0.3"
-          }
-        }
       }
     },
     "fs.realpath": {
@@ -11305,24 +11279,13 @@
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
     },
     "node-fetch": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
-      "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "requires": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
         "formdata-polyfill": "^4.0.10"
-      },
-      "dependencies": {
-        "fetch-blob": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-          "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-          "requires": {
-            "node-domexception": "^1.0.0",
-            "web-streams-polyfill": "^3.0.3"
-          }
-        }
       }
     },
     "node-int64": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   "homepage": "https://github.com/auth0/node-auth0",
   "dependencies": {
     "jose": "^4.13.2",
-    "node-fetch": "^3.3.1",
     "uuid": "^9.0.0"
   },
   "devDependencies": {
@@ -72,6 +71,7 @@
     "husky": "^3.0.1",
     "jest": "^29.5.0",
     "nock": "^13.2.7",
+    "node-fetch": "^3.3.1",
     "prettier": "^2.8.7",
     "pretty-quick": "^1.11.1",
     "ts-jest": "^29.1.0",

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -3,18 +3,14 @@ import { FetchAPI } from './models.js';
 /**
  * @private
  */
-export const fetch = (...args: Parameters<FetchAPI>) =>
-  (globalThis.fetch && globalThis.fetch(...args)) ||
-  import('node-fetch').then(({ default: fetch }) => (fetch as FetchAPI)(...args));
+export const fetch = (...args: Parameters<FetchAPI>) => globalThis.fetch(...args);
 
 /**
  * @private
  */
-export const getFormDataCls = async () =>
-  globalThis.FormData || import('node-fetch').then(({ FormData }) => FormData);
+export const getFormDataCls = async () => globalThis.FormData;
 
 /**
  * @private
  */
-export const getBlobCls = async () =>
-  globalThis.Blob || import('node-fetch').then(({ Blob }) => Blob);
+export const getBlobCls = async () => globalThis.Blob;

--- a/test/lib/runtime.test.ts
+++ b/test/lib/runtime.test.ts
@@ -11,7 +11,6 @@ import {
 } from '../../src/index.js';
 import { InitOverrideFunction, RequestOpts } from '../../src/lib/models.js';
 import { BaseAPI, applyQueryParams } from '../../src/lib/runtime.js';
-import { Response as NodeResponse } from 'node-fetch';
 
 import * as utils from '../../src/utils.js';
 import { base64url } from 'jose';
@@ -296,7 +295,7 @@ describe('Runtime', () => {
       middleware: [
         {
           onError() {
-            return new NodeResponse(undefined, { status: 418 }) as Response;
+            return new Response(undefined, { status: 418 }) as Response;
           },
         },
       ],
@@ -320,7 +319,7 @@ describe('Runtime', () => {
       middleware: [
         {
           post() {
-            return new NodeResponse(JSON.stringify({ bar: 'foo' }), {
+            return new Response(JSON.stringify({ bar: 'foo' }), {
               status: 200,
             }) as Response;
           },

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,10 +1,11 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
 import nock from 'nock';
+import fetch from 'node-fetch';
 
 const { back: nockBack } = nock;
 
 nockBack.fixtures = path.dirname(fileURLToPath(import.meta.url));
 
-// @ts-expect-error Falling back to node-fetch because nock doesn't work with native fetch.
-delete globalThis.fetch;
+// Falling back to node-fetch because nock doesn't work with native fetch.
+globalThis.fetch = fetch as any;


### PR DESCRIPTION
### Changes

Builds on top of #906 to drop node-fetch altogether given we will only support node18+, which supports native fetch.

Additionally, [given nock does not support native fetch](https://github.com/nock/nock/issues/2397), we still use node-fetch when running our tests that rely on nock.

### References

https://github.com/nock/nock/issues/2397

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
