### PR TITLE
Rename fetch option, add request examples

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -10,7 +10,7 @@
   - [Paginate through a list of users](#paginate-through-a-list-of-users)
   - [Paginate through a list of logs using checkpoint pagination](#paginate-through-a-list-of-logs-using-checkpoint-pagination)
   - [Import users from a JSON file](#import-users-from-a-json-file)
-  - [Update a user's user_metadata](#update-a-user-s-user-metadata)
+  - [Update a user's user_metadata](#update-a-users-user_metadata)
 - [Customizing the request](#customizing-the-request)
   - [Passing custom options to fetch](#passing-custom-options-to-fetch)
   - [Using middleware](#using-middleware)

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -13,7 +13,6 @@
   - [Update a user's user_metadata](#update-a-users-user_metadata)
 - [Customizing the request](#customizing-the-request)
   - [Passing custom options to fetch](#passing-custom-options-to-fetch)
-  - [Using middleware](#using-middleware)
   - [Overriding `fetch`](#overriding-fetch)
 
 ## Authentication Client
@@ -253,59 +252,6 @@ const management = new ManagementClient({
 });
 
 await management.users.get({ id: '{user id}' }, { headers: { 'bar': 'applied to this request' } });
-```
-
-### Using middleware
-
-```js
-import { ManagementClient } from 'auth0';
-
-const management = new ManagementClient({
-  domain: '{YOUR_TENANT_AND REGION}.auth0.com',
-  clientId: '{YOUR_CLIENT_ID}',
-  clientSecret: '{YOUR_CLIENT_SECRET}',
-  middleware: [
-    {
-      async pre({ url, init }) {
-        // Run some code before every request
-        log(url, init.method);
-        // optionally modify the url of fetchoptions
-        return { url, init: { ...init, priority: 'high' } };
-      },
-    },
-    {
-      // Runs after all retries, before reading the response
-      async post({ response }) {
-        // Run some code after every request
-        log(url, init.method, response);
-        // Optionall modify the response
-        const json = await response.json();
-        return Response.json({ ...json, foo: 'bar' });
-      },
-    },
-    {
-      // Runs after all retries, before reading the response
-      async onError({ fetch, url, init, error, response }) {
-        // Run some code when the request fails.
-        log(error);
-        // Optionally return a backup response
-        return Response.json({ foo: 'bar' });
-      },
-    },
-    {
-      async onError({ fetch, url, init, error, response }) {
-        if (response.status === 429) {
-          // Retry the response using your own retry logic (rather than the SDK's exponential backoff)
-          return fetch(url, init);
-        }
-        // throw a custom error
-        throw new Error('foo');
-      },
-    },
-  ],
-});
-
-await management.users.get({ id: '{user id}' });
 ```
 
 ### Overriding `fetch`

--- a/src/auth/base-auth-api.ts
+++ b/src/auth/base-auth-api.ts
@@ -12,6 +12,7 @@ import {
 } from './client-authentication.js';
 import { IDTokenValidator } from './id-token-validator.js';
 import { GrantOptions, TokenSet } from './oauth.js';
+import { TelemetryMiddleware } from '../lib/middleware/telemetry-middleware.js';
 
 export interface AuthenticationClientOptions extends ClientOptions {
   domain: string;
@@ -96,6 +97,7 @@ export class BaseAuthAPI extends BaseAPI {
     super({
       ...options,
       baseUrl: `https://${options.domain}`,
+      middleware: options.telemetry !== false ? [new TelemetryMiddleware(options)] : [],
       parseError,
       retry: { enabled: false, ...options.retry },
     });

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,4 +1,3 @@
-import { TelemetryMiddleware } from '../lib/middleware/telemetry-middleware.js';
 import { AuthenticationClientOptions } from './base-auth-api.js';
 import { Database } from './database.js';
 import { OAuth } from './oauth.js';
@@ -16,10 +15,6 @@ export class AuthenticationClient {
   passwordless: Passwordless;
 
   constructor(options: AuthenticationClientOptions) {
-    if (options.telemetry !== false) {
-      options.middleware = [...(options.middleware || []), new TelemetryMiddleware(options)];
-    }
-
     this.database = new Database(options);
     this.oauth = new OAuth(options);
     this.passwordless = new Passwordless(options);

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -5,7 +5,8 @@ import { RetryConfiguration } from './retry.js';
  */
 export type FetchAPI = (url: URL | RequestInfo, init?: RequestInit) => Promise<Response>;
 
-export interface ClientOptions extends Omit<Configuration, 'baseUrl' | 'parseError'> {
+export interface ClientOptions
+  extends Omit<Configuration, 'baseUrl' | 'parseError' | 'middleware'> {
   telemetry?: boolean;
   clientInfo?: { name: string; [key: string]: unknown };
 }

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -16,7 +16,7 @@ export interface Configuration {
   /**
    * Provide your own fetch implementation.
    */
-  fetchApi?: FetchAPI;
+  fetch?: FetchAPI;
   /**
    * Provide a middleware that will run either before the request, after the request or when the request fails.
    */

--- a/src/lib/runtime.ts
+++ b/src/lib/runtime.ts
@@ -31,7 +31,7 @@ export class BaseAPI {
     }
 
     this.middleware = configuration.middleware || [];
-    this.fetchApi = configuration.fetchApi || fetch;
+    this.fetchApi = configuration.fetch || fetch;
     this.parseError = configuration.parseError;
     this.timeoutDuration =
       typeof configuration.timeoutDuration === 'number' ? configuration.timeoutDuration : 10000;

--- a/src/management/management-client.ts
+++ b/src/management/management-client.ts
@@ -70,7 +70,6 @@ export class ManagementClient extends ManagementClientBase {
       ...options,
       baseUrl: `https://${options.domain}/api/v2`,
       middleware: [
-        ...(options.middleware || []),
         new TokenProviderMiddleware(options),
         ...(options.telemetry !== false ? [new TelemetryMiddleware(options)] : []),
       ],

--- a/src/userinfo/index.ts
+++ b/src/userinfo/index.ts
@@ -81,10 +81,7 @@ export class UserInfoClient extends BaseAPI {
     super({
       ...options,
       baseUrl: `https://${options.domain}`,
-      middleware: [
-        ...(options.middleware || []),
-        ...(options.telemetry !== false ? [new TelemetryMiddleware(options)] : []),
-      ],
+      middleware: options.telemetry !== false ? [new TelemetryMiddleware(options)] : [],
       parseError,
     });
   }


### PR DESCRIPTION
### Changes

- Change `fetchAPI` config option to `fetch`
- Add some examples for customizing the request
