### PR TITLE
Change client id params to client_id

### DIFF
--- a/src/management/__generated/managers/clients-manager.ts
+++ b/src/management/__generated/managers/clients-manager.ts
@@ -35,11 +35,14 @@ export class ClientsManager extends BaseAPI {
     requestParameters: DeleteClientsByIdRequest,
     initOverrides?: InitOverride
   ): Promise<ApiResponse<void>> {
-    runtime.validateRequiredRequestParams(requestParameters, ['id']);
+    runtime.validateRequiredRequestParams(requestParameters, ['client_id']);
 
     const response = await this.request(
       {
-        path: `/clients/{id}`.replace('{id}', encodeURIComponent(String(requestParameters.id))),
+        path: `/clients/{client_id}`.replace(
+          '{client_id}',
+          encodeURIComponent(String(requestParameters.client_id))
+        ),
         method: 'DELETE',
       },
       initOverrides
@@ -194,7 +197,7 @@ export class ClientsManager extends BaseAPI {
     requestParameters: GetClientsByIdRequest,
     initOverrides?: InitOverride
   ): Promise<ApiResponse<Client>> {
-    runtime.validateRequiredRequestParams(requestParameters, ['id']);
+    runtime.validateRequiredRequestParams(requestParameters, ['client_id']);
 
     const queryParameters = runtime.applyQueryParams(requestParameters, [
       {
@@ -209,7 +212,10 @@ export class ClientsManager extends BaseAPI {
 
     const response = await this.request(
       {
-        path: `/clients/{id}`.replace('{id}', encodeURIComponent(String(requestParameters.id))),
+        path: `/clients/{client_id}`.replace(
+          '{client_id}',
+          encodeURIComponent(String(requestParameters.client_id))
+        ),
         method: 'GET',
         query: queryParameters,
       },
@@ -291,7 +297,7 @@ export class ClientsManager extends BaseAPI {
     bodyParameters: ClientUpdate,
     initOverrides?: InitOverride
   ): Promise<ApiResponse<Client>> {
-    runtime.validateRequiredRequestParams(requestParameters, ['id']);
+    runtime.validateRequiredRequestParams(requestParameters, ['client_id']);
 
     const headerParameters: runtime.HTTPHeaders = {};
 
@@ -299,7 +305,10 @@ export class ClientsManager extends BaseAPI {
 
     const response = await this.request(
       {
-        path: `/clients/{id}`.replace('{id}', encodeURIComponent(String(requestParameters.id))),
+        path: `/clients/{client_id}`.replace(
+          '{client_id}',
+          encodeURIComponent(String(requestParameters.client_id))
+        ),
         method: 'PATCH',
         headers: headerParameters,
         body: bodyParameters,
@@ -429,13 +438,13 @@ export class ClientsManager extends BaseAPI {
     requestParameters: PostRotateSecretRequest,
     initOverrides?: InitOverride
   ): Promise<ApiResponse<Client>> {
-    runtime.validateRequiredRequestParams(requestParameters, ['id']);
+    runtime.validateRequiredRequestParams(requestParameters, ['client_id']);
 
     const response = await this.request(
       {
-        path: `/clients/{id}/rotate-secret`.replace(
-          '{id}',
-          encodeURIComponent(String(requestParameters.id))
+        path: `/clients/{client_id}/rotate-secret`.replace(
+          '{client_id}',
+          encodeURIComponent(String(requestParameters.client_id))
         ),
         method: 'POST',
       },

--- a/src/management/__generated/models/index.ts
+++ b/src/management/__generated/models/index.ts
@@ -154,7 +154,7 @@ export interface Client {
    * Metadata associated with the client, in the form of an object with string values (max 255 chars).  Maximum of 10 metadata properties allowed.  Field names (max 255 chars) are alphanumeric and may only include the following special characters:  :,-+=_*?"/\()<>@	[Tab] [Space]
    *
    */
-  client_metadata: object;
+  client_metadata: { [key: string]: any };
   /**
    */
   mobile: ClientMobile;
@@ -982,7 +982,7 @@ export interface ClientCreate {
    * Metadata associated with the client, in the form of an object with string values (max 255 chars).  Maximum of 10 metadata properties allowed.  Field names (max 255 chars) are alphanumeric and may only include the following special characters:  :,-+=_*?"/\()<>@	[Tab] [Space]
    *
    */
-  client_metadata?: object;
+  client_metadata?: { [key: string]: any };
   /**
    */
   mobile?: ClientCreateMobile;
@@ -2207,7 +2207,7 @@ export interface ClientUpdate {
    * Metadata associated with the client, in the form of an object with string values (max 255 chars).  Maximum of 10 metadata properties allowed.  Field names (max 255 chars) are alphanumeric and may only include the following special characters:  :,-+=_*?"/\()<>@	[Tab] [Space]
    *
    */
-  client_metadata?: object;
+  client_metadata?: { [key: string]: any };
   /**
    */
   mobile?: ClientUpdateMobile | null;
@@ -12244,7 +12244,7 @@ export interface DeleteClientsByIdRequest {
    * ID of the client to delete.
    *
    */
-  id: string;
+  client_id: string;
 }
 /**
  *
@@ -12314,7 +12314,7 @@ export interface GetClientsByIdRequest {
    * ID of the client to retrieve.
    *
    */
-  id: string;
+  client_id: string;
   /**
    * Comma-separated list of fields to include or exclude (based on value provided for include_fields) in the result. Leave empty to retrieve all fields.
    *
@@ -12359,7 +12359,7 @@ export interface PatchClientsByIdRequest {
    * ID of the client to update.
    *
    */
-  id: string;
+  client_id: string;
 }
 /**
  *
@@ -12394,7 +12394,7 @@ export interface PostRotateSecretRequest {
    * ID of the client that will rotate secrets.
    *
    */
-  id: string;
+  client_id: string;
 }
 /**
  *

--- a/test/management/client.test.ts
+++ b/test/management/client.test.ts
@@ -252,13 +252,13 @@ describe('ClientsManager', () => {
 
     it('should return a promise if no callback is given', (done) => {
       clients
-        .get({ id: response.client_id as string })
+        .get({ client_id: response.client_id as string })
         .then(done.bind(null, null))
         .catch(done.bind(null, null));
     });
 
     it('should perform a POST request to /api/v2/clients/5', (done) => {
-      clients.get({ id: response.client_id as string }).then(() => {
+      clients.get({ client_id: response.client_id as string }).then(() => {
         expect(request.isDone()).toBe(true);
 
         done();
@@ -266,7 +266,7 @@ describe('ClientsManager', () => {
     });
 
     it('should pass the body of the response to the "then" handler', (done) => {
-      clients.get({ id: response.client_id as string }).then((client) => {
+      clients.get({ client_id: response.client_id as string }).then((client) => {
         expect(client.data.client_id).toBe(response.client_id);
         expect(client.data.name).toBe(response.name);
         expect(client.data.description).toBe(response.description);
@@ -305,13 +305,13 @@ describe('ClientsManager', () => {
 
     it('should return a promise if no callback is given', (done) => {
       clients
-        .update({ id: response.client_id as string }, {})
+        .update({ client_id: response.client_id as string }, {})
         .then(done.bind(null, null))
         .catch(done.bind(null, null));
     });
 
     it('should perform a PATCH request to /api/v2/clients/5', (done) => {
-      clients.update({ id: response.client_id as string }, {}).then(() => {
+      clients.update({ client_id: response.client_id as string }, {}).then(() => {
         expect(request.isDone()).toBe(true);
 
         done();
@@ -325,7 +325,7 @@ describe('ClientsManager', () => {
         .patch(`/clients/${response.client_id as string}`, data as any)
         .reply(200, response);
 
-      clients.update({ id: response.client_id as string }, data as any).then(() => {
+      clients.update({ client_id: response.client_id as string }, data as any).then(() => {
         expect(request.isDone()).toBe(true);
 
         done();
@@ -333,7 +333,7 @@ describe('ClientsManager', () => {
     });
 
     it('should pass the body of the response to the "then" handler', (done) => {
-      clients.update({ id: response.client_id as string }, data as any).then((client) => {
+      clients.update({ client_id: response.client_id as string }, data as any).then((client) => {
         expect(client.data.client_id).toBe(response.client_id);
         expect(client.data.name).toBe(response.name);
         expect(client.data.description).toBe(response.description);
@@ -356,11 +356,11 @@ describe('ClientsManager', () => {
     });
 
     it('should return a promise when no callback is given', (done) => {
-      clients.delete({ id }).then(done.bind(null, null));
+      clients.delete({ client_id: id }).then(done.bind(null, null));
     });
 
     it(`should perform a DELETE request to /clients/${id}`, (done) => {
-      clients.delete({ id }).then(() => {
+      clients.delete({ client_id: id }).then(() => {
         expect(request.isDone()).toBe(true);
 
         done();
@@ -378,13 +378,13 @@ describe('ClientsManager', () => {
 
     it('should return a promise if no callback is given', (done) => {
       clients
-        .rotateClientSecret({ id }, {})
+        .rotateClientSecret({ client_id: id }, {})
         .then(done.bind(null, null))
         .catch(done.bind(null, null));
     });
 
     it('should perform a POST request to /api/v2/clients/5/rotate-secret', (done) => {
-      clients.rotateClientSecret({ id }).then(() => {
+      clients.rotateClientSecret({ client_id: id }).then(() => {
         expect(request.isDone()).toBe(true);
 
         done();
@@ -402,7 +402,7 @@ describe('ClientsManager', () => {
         .post(`/clients/${id}/rotate-secret`)
         .reply(200, { client_id: '123' });
 
-      clients.rotateClientSecret({ id }).then(() => {
+      clients.rotateClientSecret({ client_id: id }).then(() => {
         expect(request.isDone()).toBe(true);
 
         done();
@@ -414,7 +414,7 @@ describe('ClientsManager', () => {
 
       nock(API_URL).post(`/clients/${id}/rotate-secret`).reply(500, {});
 
-      clients.rotateClientSecret({ id }).catch((err) => {
+      clients.rotateClientSecret({ client_id: id }).catch((err) => {
         expect(err).toBeDefined();
 
         done();


### PR DESCRIPTION
### Changes

Change Client `id` params to `client_id` - to match the client response and keep consistent with node-auth0 v2
