### PR TITLE
fix: ManagementTokenProvider should also respect the keepAlive config option

### DIFF
--- a/src/management/ManagementTokenProvider.js
+++ b/src/management/ManagementTokenProvider.js
@@ -20,6 +20,7 @@ class ManagementTokenProvider {
    * @param {number}  [options.cacheTTLInSeconds]     By default the `expires_in` value will be used to determine the cached time of the token, this can be overridden.
    * @param {object}  [options.headers]               Additional headers that will be added to the outgoing requests.
    * @param {string}  [options.proxy]                 Add the `superagent-proxy` dependency and specify a proxy url eg 'https://myproxy.com:1234'
+   * @param {boolean}  [options.keepAlive]          Keep the http connections alive.
    */
   constructor(options) {
     if (!options || typeof options !== 'object') {
@@ -76,6 +77,7 @@ class ManagementTokenProvider {
       clientInfo: this.options.clientInfo,
       headers: this.options.headers,
       proxy: this.options.proxy,
+      keepAlive: this.options.keepAlive,
     };
     this.authenticationClient = new AuthenticationClient(authenticationClientOptions);
 

--- a/test/management/management-token-provider.tests.js
+++ b/test/management/management-token-provider.tests.js
@@ -154,6 +154,20 @@ describe('ManagementTokenProvider', () => {
     expect(provider.options.headers).to.be.equal(options.headers);
   });
 
+  it('should send keepAlive true value to authentication client when passed into options', () => {
+    const options = Object.assign({}, defaultOptions);
+    options.keepAlive = true;
+    const provider = new ManagementTokenProvider(options);
+    expect(provider.authenticationClient.oauth.oauth.options.keepAlive).to.be.true;
+  });
+
+  it('should send keepAlive false value to authentication client when passed into options', () => {
+    const options = Object.assign({}, defaultOptions);
+    options.keepAlive = false;
+    const provider = new ManagementTokenProvider(options);
+    expect(provider.authenticationClient.oauth.oauth.options.keepAlive).to.be.false;
+  });
+
   it('should handle network errors correctly', async () => {
     const options = Object.assign({}, defaultOptions);
     options.domain = 'domain';


### PR DESCRIPTION
### Changes

ManagementTokenProvider should also respect the keepAlive config option and pass it to the AuthenticationClient's constructor.

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
