### PR TITLE
[SDK-4548] Support optional responses

### DIFF
--- a/playground/handlers.ts
+++ b/playground/handlers.ts
@@ -324,14 +324,16 @@ export async function clients() {
   const mgmntClient = new ManagementClient(program.opts());
   const { data: newClient } = await mgmntClient.clients.create({ name: uuid() });
   console.log('Create a client: ' + newClient.name);
-  const { data: client } = await mgmntClient.clients.get({ id: newClient.client_id as string });
+  const { data: client } = await mgmntClient.clients.get({
+    client_id: newClient.client_id as string,
+  });
   console.log('Get the client: ' + client.name);
   const { data: updatedClient } = await mgmntClient.clients.update(
-    { id: client.client_id as string },
+    { client_id: client.client_id as string },
     { name: uuid() }
   );
   console.log('Updated the client: ' + updatedClient.name);
-  await mgmntClient.clients.delete({ id: newClient.client_id as string });
+  await mgmntClient.clients.delete({ client_id: newClient.client_id as string });
   console.log('Removed the client: ' + updatedClient.name);
 }
 
@@ -524,8 +526,8 @@ export async function guardian() {
 
   const { data: smsTemplates } = await mgmntClient.guardian.getSmsFactorTemplates();
 
-  console.log(`Get SMS enrollement message: ${smsTemplates.enrollment_message}`);
-  console.log(`Get SMS verification message: ${smsTemplates.verification_message}`);
+  console.log(`Get SMS enrollement message: ${smsTemplates?.enrollment_message}`);
+  console.log(`Get SMS verification message: ${smsTemplates?.verification_message}`);
 
   const { data: updateSmsTemplates } = await mgmntClient.guardian.setSmsFactorTemplates({
     enrollment_message: 'This is the encrollment message ' + uuid(),
@@ -794,7 +796,9 @@ export async function keys() {
 
   const { data: newClient } = await mgmntClient.clients.create({ name: uuid() });
   console.log('Create a client: ' + newClient.name);
-  const { data: client } = await mgmntClient.clients.get({ id: newClient.client_id as string });
+  const { data: client } = await mgmntClient.clients.get({
+    client_id: newClient.client_id as string,
+  });
 
   const cert = client.signing_keys![0].cert;
   const { data: keys } = await mgmntClient.keys.getAll();
@@ -803,7 +807,7 @@ export async function keys() {
   const { data: key } = await mgmntClient.keys.get({ kid });
   console.log('Got key:', key.kid);
 
-  await mgmntClient.clients.delete({ id: newClient.client_id as string });
+  await mgmntClient.clients.delete({ client_id: newClient.client_id as string });
   console.log('Removed the client: ' + newClient.name);
 }
 

--- a/src/management/__generated/managers/guardian-manager.ts
+++ b/src/management/__generated/managers/guardian-manager.ts
@@ -135,7 +135,7 @@ export class GuardianManager extends BaseAPI {
    */
   async getSmsFactorTemplates(
     initOverrides?: InitOverride
-  ): Promise<ApiResponse<TemplateMessages>> {
+  ): Promise<ApiResponse<TemplateMessages | void>> {
     const response = await this.request(
       {
         path: `/guardian/factors/sms/templates`,
@@ -144,7 +144,9 @@ export class GuardianManager extends BaseAPI {
       initOverrides
     );
 
-    return runtime.JSONApiResponse.fromResponse(response);
+    return response.status === 204
+      ? runtime.VoidApiResponse.fromResponse(response)
+      : runtime.JSONApiResponse.fromResponse(response);
   }
 
   /**

--- a/src/management/__generated/managers/jobs-manager.ts
+++ b/src/management/__generated/managers/jobs-manager.ts
@@ -25,7 +25,7 @@ export class JobsManager extends BaseAPI {
   async getErrors(
     requestParameters: GetErrorsRequest,
     initOverrides?: InitOverride
-  ): Promise<ApiResponse<GetErrors200Response>> {
+  ): Promise<ApiResponse<GetErrors200Response | void>> {
     runtime.validateRequiredRequestParams(requestParameters, ['id']);
 
     const response = await this.request(
@@ -36,7 +36,9 @@ export class JobsManager extends BaseAPI {
       initOverrides
     );
 
-    return runtime.JSONApiResponse.fromResponse(response);
+    return response.status === 204
+      ? runtime.VoidApiResponse.fromResponse(response)
+      : runtime.JSONApiResponse.fromResponse(response);
   }
 
   /**

--- a/test/management/guardian.test.ts
+++ b/test/management/guardian.test.ts
@@ -216,6 +216,12 @@ describe('GuardianManager', () => {
 
       await expect(guardian.getSmsFactorTemplates()).resolves.toHaveProperty('data', data);
     });
+
+    it('should not fail when no response returned', async () => {
+      nock(API_URL).get('/guardian/factors/sms/templates').reply(204);
+
+      await expect(guardian.getSmsFactorTemplates()).resolves.not.toThrow();
+    });
   });
 
   describe('#getFactors', () => {

--- a/test/management/jobs.test.ts
+++ b/test/management/jobs.test.ts
@@ -166,6 +166,14 @@ describe('JobsManager', () => {
         done();
       });
     });
+
+    it('should not fail when no response returned', async () => {
+      nock.cleanAll();
+
+      nock(API_URL).get(`/jobs/${id}/errors`).reply(204);
+
+      await expect(jobs.getErrors({ id: id })).resolves.not.toThrow();
+    });
   });
 
   const usersFilePath = path.join(__dirname, '../data/users.json');


### PR DESCRIPTION
### Changes

Add support for endpoints where `isResponseOptional=true`

This is where the endpoint can return a 200 or a 204.

- GET /guardian/factors/sms/templates 200,204
- GET /jobs/{id}/errors 200,204

(also fixed the playground)