### PR TITLE
Ensure to pass-trough options to TokenProvider

### DIFF
--- a/src/management/management-client-options.ts
+++ b/src/management/management-client-options.ts
@@ -17,6 +17,7 @@ export interface ManagementClientOptionsWithClientSecret extends ManagementClien
 export interface ManagementClientOptionsWithClientAssertion extends ManagementClientOptions {
   clientId: string;
   clientAssertionSigningKey: string;
+  clientAssertionSigningAlg?: string;
 }
 
 export type ManagementClientOptionsWithClientCredentials =

--- a/src/management/token-provider-middleware.ts
+++ b/src/management/token-provider-middleware.ts
@@ -18,8 +18,7 @@ export class TokenProviderMiddleware implements Middleware {
       };
     } else {
       this.tokenProvider = new TokenProvider({
-        clientId: options.clientId,
-        domain: options.domain,
+        ...options,
         audience: options.audience ?? `https://${options.domain}/api/v2/`,
         ...{ clientSecret: (options as ManagementClientOptionsWithClientSecret).clientSecret },
         ...{

--- a/v4_MIGRATION_GUIDE.md
+++ b/v4_MIGRATION_GUIDE.md
@@ -129,7 +129,7 @@ Some method names have been changed to better align with the documentation.
 The following configuration options have changed:
 
 - `scope` - The Management Client uses the Client Credentials grant which gets all the scopes granted to the application. So this is redundant and has been removed.
-- `tokenProvider.enableCache` - Use the `enableCache` option of the Management Client.
+- `tokenProvider.enableCache` - Each instance of the Management Client has its own cache, if you want a new cache you want to instantiate a new Management Client.
 - `tokenProvider.cacheTTLInSeconds` - Each instance of the Management Client only stores a single access token, so this functionality has been removed.
 - `proxy` - You should now provide an [HttpsAgent](https://nodejs.org/api/https.html#class-httpsagent) as the `agent` config.
 - `includeResponseHeaders` - This has been removed, all return types include the response headers by default.


### PR DESCRIPTION
### Changes

This PR ensures we pass options to the token provider, such as a custom fetch.

This also removes the disabling of the cache, which was internal only and shouldn't affect our consumers.

### References

#937 

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
