### PR TITLE
Field 'enabled_clients' is not included in the Connection definition

### DIFF
--- a/src/management/__generated/models/index.ts
+++ b/src/management/__generated/models/index.ts
@@ -2552,6 +2552,11 @@ export interface Connection {
    */
   strategy: string;
   /**
+   * The identifiers of the clients for which the connection is to be enabled. If the array is empty or the property is not specified, no clients are enabled
+   *
+   */
+  enabled_clients?: Array<string>;
+  /**
    * Defines the realms for which the connection will be used (ie: email domains). If the array is empty or the property is not specified, the connection name will be added as realm.
    *
    */

--- a/test/management/connections.test.ts
+++ b/test/management/connections.test.ts
@@ -53,6 +53,7 @@ describe('ConnectionsManager', () => {
         display_name: 'Test Connection',
         id: 'test_connection_id',
         strategy: 'auth0',
+        enabled_clients: ['test_client'],
         realms: ['test'],
         is_domain_connection: false,
         metadata: {
@@ -170,6 +171,7 @@ describe('ConnectionsManager', () => {
       display_name: 'Test Connection',
       id: 'test_connection_id',
       strategy: 'auth0',
+      enabled_clients: ['test_client'],
       realms: ['test'],
       is_domain_connection: false,
       metadata: {
@@ -268,6 +270,7 @@ describe('ConnectionsManager', () => {
       display_name: 'Test Connection',
       id: 'test_connection_id',
       strategy: 'auth0',
+      enabled_clients: ['test_client'],
       realms: ['test'],
       is_domain_connection: false,
       metadata: {
@@ -355,6 +358,7 @@ describe('ConnectionsManager', () => {
       display_name: 'Test Connection',
       id: 'test_connection_id',
       strategy: 'auth0',
+      enabled_clients: ['test_client'],
       realms: ['test'],
       is_domain_connection: false,
       metadata: {


### PR DESCRIPTION
### Checklist
* [X] I have looked into the [Readme](https://github.com/auth0/node-auth0#readme), [Examples](https://github.com/auth0/node-auth0/blob/master/EXAMPLES.md), and [FAQ](https://github.com/auth0/node-auth0/blob/master/FAQ.md) and have not found a suitable solution or answer.
* [X] I have looked into the [API documentation](https://auth0.github.io/node-auth0/) and have not found a suitable solution or answer.
* [X] I have searched the [issues](https://github.com/auth0/node-auth0/issues) and have not found a suitable solution or answer.
* [X] I have searched the [Auth0 Community](https://community.auth0.com) forums and have not found a suitable solution or answer.
* [X] I agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).

### Description
Added missing `enabled_clients` field to `Connection` interface.  Calls to `client.connections.get({ id });` include this field in the response, but it was absent from the interface definition.

### Reproduction
1. Initialize the Auth0 Management API client using library
2. Call the `get( )` method on the `ConnectionsManager`
3. Print the result returned from the method

### Additional context
n/a

### node-auth0 version
4.0.1

### Node.js version
18.16.1

