### PR TITLE
Update Migration guide for getUsersByEmail

### DIFF
--- a/v4_MIGRATION_GUIDE.md
+++ b/v4_MIGRATION_GUIDE.md
@@ -178,7 +178,7 @@ const usersAlso = await management.users.getAll();
 | `deleteRule`                                | `rules.delete`                               |
 | `updateRule`                                | `rules.update`                               |
 | `getUsers`                                  | `users.getAll`                               |
-| `getUsersByEmail`                           | `users.getByEmail`                           |
+| `getUsersByEmail`                           | `usersByEmail.getByEmail`                    |
 | `getUser`                                   | `users.get`                                  |
 | `deleteAllUsers`                            | `users.deleteAll`                            |
 | `deleteUser`                                | `users.delete`                               |

--- a/v4_MIGRATION_GUIDE.md
+++ b/v4_MIGRATION_GUIDE.md
@@ -328,7 +328,7 @@ await users.deleteRoles({ id: 'user' }, { roles: ['read:users'] });
 | `emailProvider.configure`               | `emails.configure`                              |
 | `tenant.getSettings`                    | `tenants.getSettings`                           |
 | `tenant.updateSettings`                 | `tenants.updateSettings`                        |
-| `users.getByEmail`                      | `usersByEmailManager.getByEmail`                |
+| `users.getByEmail`                      | `usersByEmail.getByEmail`                       |
 | `users.updateUserMetadata`              | `users.update`                                  |
 | `users.updateAppMetadata`               | `users.update`                                  |
 | `users.deleteAll`                       | `REMOVED`                                       |


### PR DESCRIPTION
### Changes

Fixes an incorrect entry in the migration guide for `getUsersByEmail`, which is now `usersByEmail.getByEmail`

### References

#943 

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
