### PR TITLE
[ULX-1599] feat: add get/update template partials to PromptsManager

### DIFF
--- a/src/management/__generated/managers/prompts-manager.ts
+++ b/src/management/__generated/managers/prompts-manager.ts
@@ -5,6 +5,8 @@ import type {
   PromptsSettingsUpdate,
   GetCustomTextByLanguageRequest,
   PutCustomTextByLanguageRequest,
+  GetTeplatePartialsByPromptRequest,
+  PutTeplatePartialsByPromptRequest,
 } from '../models/index.js';
 
 const { BaseAPI } = runtime;
@@ -36,6 +38,32 @@ export class PromptsManager extends BaseAPI {
     );
 
     return runtime.JSONApiResponse.fromResponse<any>(response);
+  }
+
+  /**
+   * Retrieve template partials for a specific prompt.
+   * Get template partials for a prompt
+   *
+   * @throws {RequiredError}
+   */
+  async getTemplatePartialsByPrompt(
+    requestParameters: GetTeplatePartialsByPromptRequest,
+    initOverrides?: InitOverride
+  ): Promise<ApiResponse<{ [key: string]: any }>> {
+    runtime.validateRequiredRequestParams(requestParameters, ['prompt']);
+
+    const response = await this.request(
+      {
+        path: `/prompts/{prompt}/partials`.replace(
+          '{prompt}',
+          encodeURIComponent(String(requestParameters.prompt))
+        ),
+        method: 'GET',
+      },
+      initOverrides
+    );
+
+    return runtime.JSONApiResponse.fromResponse(response);
   }
 
   /**
@@ -113,5 +141,38 @@ export class PromptsManager extends BaseAPI {
     );
 
     return runtime.VoidApiResponse.fromResponse(response);
+  }
+
+  /**
+   * Set template partials for a specific prompt. Existing partials will be overwritten.
+   * Set template partials for a specific prompt
+   *
+   * @throws {RequiredError}
+   */
+  async updateTemplatePartialsByPrompt(
+    requestParameters: PutTeplatePartialsByPromptRequest,
+    bodyParameters: { [key: string]: any },
+    initOverrides?: InitOverride
+  ): Promise<ApiResponse<{ [key: string]: any }>> {
+    runtime.validateRequiredRequestParams(requestParameters, ['prompt']);
+
+    const headerParameters: runtime.HTTPHeaders = {};
+
+    headerParameters['Content-Type'] = 'application/json';
+
+    const response = await this.request(
+      {
+        path: `/prompts/{prompt}/partials`.replace(
+          '{prompt}',
+          encodeURIComponent(String(requestParameters.prompt))
+        ),
+        method: 'PUT',
+        headers: headerParameters,
+        body: bodyParameters,
+      },
+      initOverrides
+    );
+
+    return runtime.JSONApiResponse.fromResponse(response);
   }
 }

--- a/src/management/__generated/models/index.ts
+++ b/src/management/__generated/models/index.ts
@@ -13605,6 +13605,60 @@ export type GetCustomTextByLanguagePromptEnum =
 /**
  *
  */
+export interface GetTeplatePartialsByPromptRequest {
+  /**
+   * Name of the prompt.
+   *
+   */
+  prompt: GetTemplatePartialsByPromptEnum;
+}
+
+/**
+ *
+ */
+export interface PutTeplatePartialsByPromptRequest {
+  /**
+   * Name of the prompt.
+   *
+   */
+  prompt: PutTemplatePartialsByPromptEnum;
+}
+
+/**
+ *
+ */
+export const GetTemplatePartialsByPromptEnum = {
+  login: 'login',
+  login_id: 'login-id',
+  login_password: 'login-password',
+  login_passwordless: 'login-passwordless',
+  signup: 'signup',
+  signup_id: 'signup-id',
+  signup_password: 'signup-password',
+};
+
+export type GetTemplatePartialsByPromptEnum =
+  (typeof GetTemplatePartialsByPromptEnum)[keyof typeof GetTemplatePartialsByPromptEnum];
+
+/**
+ *
+ */
+export const PutTemplatePartialsByPromptEnum = {
+  login: 'login',
+  login_id: 'login-id',
+  login_password: 'login-password',
+  login_passwordless: 'login-passwordless',
+  signup: 'signup',
+  signup_id: 'signup-id',
+  signup_password: 'signup-password',
+};
+
+export type PutTemplatePartialsByPromptEnum =
+  (typeof PutTemplatePartialsByPromptEnum)[keyof typeof PutTemplatePartialsByPromptEnum];
+
+/**
+ *
+ */
 export const GetCustomTextByLanguageLanguageEnum = {
   ar: 'ar',
   bg: 'bg',

--- a/test/management/prompts.test.ts
+++ b/test/management/prompts.test.ts
@@ -8,6 +8,8 @@ import {
   PromptsManager,
   PromptsSettingsUniversalLoginExperienceEnum,
   PromptsSettingsUpdateUniversalLoginExperienceEnum,
+  GetTemplatePartialsByPromptEnum,
+  PutTemplatePartialsByPromptEnum,
   ManagementClient,
   RequiredError,
 } from '../../src/index.js';
@@ -304,6 +306,164 @@ describe('PromptsManager', () => {
         .reply(200, {});
 
       prompts.updateCustomTextByLanguage(params, params.body).then(() => {
+        expect(request.isDone()).toBe(true);
+
+        done();
+      });
+    });
+  });
+
+  describe('#getTemplatePartialsByPrompt', () => {
+    let request: nock.Scope;
+    const params = {
+      prompt: GetTemplatePartialsByPromptEnum.login,
+    };
+
+    const partial = { login: { 'form-content-start': '<div>TEST</div>' } };
+
+    beforeEach(() => {
+      request = nock(API_URL).get('/prompts/login/partials').reply(200, partial);
+    });
+
+    it('should validate empty prompt parameter', async () => {
+      await expect(prompts.getTemplatePartialsByPrompt({} as any)).rejects.toThrowError(
+        RequiredError
+      );
+    });
+
+    it('should return a promise if no callback is given', (done) => {
+      prompts
+        .getTemplatePartialsByPrompt(params)
+        .then(done.bind(null, null))
+        .catch(done.bind(null, null));
+    });
+
+    it('should pass any errors to the promise catch handler', (done) => {
+      nock.cleanAll();
+
+      nock(API_URL).get('/prompts/login/partials').reply(500, {});
+
+      prompts.getTemplatePartialsByPrompt(params).catch((err) => {
+        expect(err).toBeDefined();
+
+        done();
+      });
+    });
+
+    it('should perform a GET request to /api/v2/prompts/login/partials', (done) => {
+      prompts.getTemplatePartialsByPrompt(params).then(() => {
+        expect(request.isDone()).toBe(true);
+        done();
+      });
+    });
+
+    it('should return the value returned from the Management API', (done) => {
+      prompts.getTemplatePartialsByPrompt(params).then((res) => {
+        expect(res.data).toEqual(partial);
+        done();
+      });
+    });
+
+    it('should include the token in the Authorization header', (done) => {
+      nock.cleanAll();
+
+      const request = nock(API_URL)
+        .get('/prompts/login/partials')
+        .matchHeader('Authorization', `Bearer ${token}`)
+        .reply(200, {});
+
+      prompts.getTemplatePartialsByPrompt(params).then(() => {
+        expect(request.isDone()).toBe(true);
+
+        done();
+      });
+    });
+  });
+
+  describe('#updateTemplatePartialsByPrompt', () => {
+    let request: nock.Scope;
+    const prompt = PutTemplatePartialsByPromptEnum.login;
+    const partial = { login: { 'form-content-start': '<div>TESTING</div>' } };
+
+    beforeEach(() => {
+      request = nock(API_URL).put('/prompts/login/partials').reply(200, partial);
+    });
+
+    it('should validate empty prompt parameter', async () => {
+      await expect(prompts.updateTemplatePartialsByPrompt({} as any, {})).rejects.toThrowError(
+        RequiredError
+      );
+    });
+
+    it('should return a promise if no callback is given', (done) => {
+      prompts
+        .updateTemplatePartialsByPrompt({ prompt }, partial)
+        .then(done.bind(null, null))
+        .catch(done.bind(null, null));
+    });
+
+    it('should pass any errors to the promise catch handler', (done) => {
+      nock.cleanAll();
+
+      nock(API_URL).put('/prompts/login/partials').reply(500, {});
+
+      prompts.updateTemplatePartialsByPrompt({ prompt }, partial).catch((err) => {
+        expect(err).toBeDefined();
+
+        done();
+      });
+    });
+
+    it('should perform a PUT request to /api/v2/prompts/login/partials', (done) => {
+      prompts
+        .updateTemplatePartialsByPrompt({ prompt }, partial)
+        .then(() => {
+          expect(request.isDone()).toBe(true);
+          done();
+        })
+        .catch((e) => {
+          console.error(e);
+        });
+    });
+
+    it('should return the value returned from the Management API', (done) => {
+      prompts
+        .updateTemplatePartialsByPrompt({ prompt }, partial)
+        .then((res) => {
+          expect(res.data).toEqual(partial);
+          done();
+        })
+        .catch((e) => {
+          console.error(e);
+        });
+    });
+
+    it('should include the token in the Authorization header', (done) => {
+      nock.cleanAll();
+
+      const request = nock(API_URL)
+        .put('/prompts/login/partials')
+        .matchHeader('Authorization', `Bearer ${token}`)
+        .reply(200, {});
+
+      prompts.updateTemplatePartialsByPrompt({ prompt }, partial).then(() => {
+        expect(request.isDone()).toBe(true);
+
+        done();
+      });
+    });
+
+    it('should send the payload to the body', (done) => {
+      nock.cleanAll();
+
+      const request = nock(API_URL)
+        .put(
+          '/prompts/login/partials',
+          (body) => body?.login?.['form-content-start'] === '<div>TESTING</div>'
+        )
+        .reply(200, {});
+
+      prompts.updateTemplatePartialsByPrompt({ prompt }, partial).then(() => {
         expect(request.isDone()).toBe(true);
 
         done();


### PR DESCRIPTION
### Changes

This PR adds support for get/update template partials to PromptsManager. This is related to our EA [Custom Prompts](https://auth0.com/docs/sign-up-prompt-customizations) feature.

### References

[ULX-1599](https://auth0team.atlassian.net/browse/ULX-1599)

### Testing

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

To test locally, 
- pull these changes and create a node-auth0 link
```sh
npm run build && yarn link
```
- make another project that requires node-auth0, and link it to the local copy: 
```sh
mkdir temp && \
cd temp && \
npm init -y && \
npm i auth0 && \
npm link auth0 && \
<<EOF >> index.js
const ManagementClient = require("auth0").ManagementClient;
const assert = require("node:assert/strict");

const data = {
  login: { "form-content-end": "<div>TEST</div>" }
};

var management = new ManagementClient({
  domain: process.env.AUTH0_DOMAIN,
  token: process.env.API2_TOKEN,
});

async function test() {
  const putRes = await management.prompts.updateTemplatePartialsByPrompt(
    { prompt: "login" },
    data
  );
  assert(JSON.stringify(putRes.data) === JSON.stringify(data));

  const getRes = await management.prompts.getTemplatePartialsByPrompt({ prompt: "login" });
  assert(JSON.stringify(getRes.data) === JSON.stringify(data));
}

test();

EOF
```
- run it
```sh
export AUTH0_DOMAIN="test-tenant.eu.auth0.com"
export API2_TOKEN="ey..."
node ./index.js
```

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors


[ULX-1599]: https://auth0team.atlassian.net/browse/ULX-1599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ