### PR TITLE
Clarify obtaining a refresh token that can be used to obtain JWT acce…

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -54,6 +54,28 @@ const { data: tokens } = await auth.oauth.clientCredentialsGrant({
 });
 ```
 
+### Use a Password Grant to get a Refresh Token
+```js
+import { AuthenticationClient } from 'auth0';
+
+const auth = new AuthenticationClient({
+  domain: '{YOUR_TENANT_AND REGION}.auth0.com',
+  clientId: '{YOUR_CLIENT_ID}',
+  clientSecret: '{YOUR_CLIENT_SECRET}',
+});
+
+// Get a refresh token
+const {
+  data: { refresh_token },
+} = await auth.oauth.passwordGrant({
+  username: '{USER_USERNAME}',
+  password: '{USER_PASSWORD}',
+  scope: "offline_access", // To get a refresh token, the scope "offline_access" must be included in the request
+  audience: 'you-api', // For subsequent refresh token grants to return JWT access tokens, instead of opaque access tokens (tokens without payloads), audience must be included in the original grant
+});
+
+```
+
 ### Use Refresh Tokens
 
 ```js


### PR DESCRIPTION
…ss tokens in docs

### Changes

Adds a password grant example to `EXAMPLES.md` to explain how to get a refresh token that can be used to subsequently obtain JWT access tokens, instead of opaque tokens.

### References

GH Issue: https://github.com/auth0/node-auth0/issues/983
Community forum issue: https://community.auth0.com/t/auth0-node-refresh-grant-missing-payload/125305

### Testing

Doc change only.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors
