### PR TITLE
Add support for show_as_button on organization connections

### DIFF
--- a/src/management/__generated/managers/organizations-manager.ts
+++ b/src/management/__generated/managers/organizations-manager.ts
@@ -17,6 +17,7 @@ import type {
   PostInvitationsRequest,
   PostMembersRequest,
   PostOrganizationMemberRolesRequest,
+  PostOrganizations201Response,
   PostOrganizationsRequest,
   GetEnabledConnections200ResponseOneOf,
   GetInvitations200ResponseOneOf,
@@ -831,7 +832,7 @@ export class OrganizationsManager extends BaseAPI {
   async create(
     bodyParameters: PostOrganizationsRequest,
     initOverrides?: InitOverride
-  ): Promise<ApiResponse<GetOrganizations200ResponseOneOfInner>> {
+  ): Promise<ApiResponse<PostOrganizations201Response>> {
     const headerParameters: runtime.HTTPHeaders = {};
 
     headerParameters['Content-Type'] = 'application/json';

--- a/src/management/__generated/models/index.ts
+++ b/src/management/__generated/models/index.ts
@@ -4889,6 +4889,11 @@ export interface GetEnabledConnections200ResponseOneOfInner {
    */
   assign_membership_on_login: boolean;
   /**
+   * Enables showing a button for the connection in the organization login page. If false, it will be usable only by HRD.
+   *
+   */
+  show_as_button: boolean;
+  /**
    */
   connection: GetEnabledConnections200ResponseOneOfInnerConnection;
 }
@@ -7539,7 +7544,12 @@ export interface PatchEnabledConnectionsByConnectionIdRequest {
    * When true, all users that log in with this connection will be automatically granted membership in the organization. When false, users must be granted membership in the organization before logging in with this connection.
    *
    */
-  assign_membership_on_login: boolean;
+  assign_membership_on_login?: boolean;
+  /**
+   * Enables showing a button for the connection in the organization login page. If false, it will be usable only by HRD.
+   *
+   */
+  show_as_button?: boolean;
 }
 /**
  *
@@ -8790,6 +8800,11 @@ export interface PostEnabledConnectionsRequest {
    *
    */
   assign_membership_on_login?: boolean;
+  /**
+   * Enables showing a button for the connection in the organization login page. If false, it will be usable only by HRD.
+   *
+   */
+  show_as_button?: boolean;
 }
 /**
  *
@@ -9434,6 +9449,59 @@ export interface PostOrganizationMemberRolesRequest {
 /**
  *
  */
+export interface PostOrganizations201Response {
+  [key: string]: any | any;
+  /**
+   * Organization identifier
+   *
+   */
+  id: string;
+  /**
+   * The name of this organization.
+   *
+   */
+  name: string;
+  /**
+   * Friendly name of this organization.
+   *
+   */
+  display_name: string;
+  /**
+   */
+  branding: GetOrganizations200ResponseOneOfInnerBranding;
+  /**
+   * Metadata associated with the organization, in the form of an object with string values (max 255 chars).  Maximum of 10 metadata properties allowed.
+   *
+   */
+  metadata: { [key: string]: any };
+  /**
+   */
+  enabled_connections: Array<PostOrganizations201ResponseEnabledConnectionsInner>;
+}
+/**
+ *
+ */
+export interface PostOrganizations201ResponseEnabledConnectionsInner {
+  [key: string]: any | any;
+  /**
+   * ID of the connection.
+   *
+   */
+  connection_id: string;
+  /**
+   * When true, all users that log in with this connection will be automatically granted membership in the organization. When false, users must be granted membership in the organization before logging in with this connection.
+   *
+   */
+  assign_membership_on_login: boolean;
+  /**
+   * Enables showing a button for the connection in the organization login page. If false, it will be usable only by HRD.
+   *
+   */
+  show_as_button: boolean;
+}
+/**
+ *
+ */
 export interface PostOrganizationsRequest {
   /**
    * The name of this organization.
@@ -9486,6 +9554,11 @@ export interface PostOrganizationsRequestEnabledConnectionsInner {
    *
    */
   assign_membership_on_login?: boolean;
+  /**
+   * Enables showing a button for the connection in the organization login page. If false, it will be usable only by HRD.
+   *
+   */
+  show_as_button?: boolean;
 }
 /**
  *

--- a/test/management/organizations.test.ts
+++ b/test/management/organizations.test.ts
@@ -429,6 +429,7 @@ describe('OrganizationsManager', () => {
     const data = {
       id: 'org_id',
       connectionId: 'conn_id',
+      show_as_button: false,
     };
 
     beforeEach(() => {
@@ -484,7 +485,7 @@ describe('OrganizationsManager', () => {
       id: 'org_123',
     };
 
-    const body = { connection_id: '123', assign_membership_on_login: false };
+    const body = { connection_id: '123', assign_membership_on_login: false, show_as_button: false };
 
     beforeEach(() => {
       request = nock(API_URL).post(`/organizations/${data.id}/enabled_connections`).reply(200, {});
@@ -551,6 +552,7 @@ describe('OrganizationsManager', () => {
     const data = {
       id: 'org_123',
       connectionId: '123',
+      show_as_button: false,
     };
     const body = { assign_membership_on_login: false };
 


### PR DESCRIPTION
### Changes

Adds support for show_as_button to organization connections.

### Testing

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
