### PR TITLE
Added additional request parameter to support PAR with JAR requests

### DIFF
--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -147,6 +147,11 @@ export interface PushedAuthorizationRequest extends ClientCredentials {
   code_challenge?: string;
 
   /**
+   * Allows JWT-Secured Authorization Request (JAR), when JAR & PAR request are used together. {@link https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow/authorization-code-flow-with-par-and-jar | Reference}
+   */
+  request?: string;
+
+  /**
    * Allow for any custom property to be sent to Auth0
    */
   [key: string]: any;

--- a/test/auth/fixtures/oauth.json
+++ b/test/auth/fixtures/oauth.json
@@ -167,5 +167,16 @@
       "request_uri": "https://www.request.uri",
       "expires_in": 86400
     }
+  },
+  {
+    "scope": "https://test-domain.auth0.com",
+    "method": "POST",
+    "path": "/oauth/par",
+    "body": "client_id=test-client-id&response_type=code&redirect_uri=https%3A%2F%2Fexample.com&request=eyJhbGciOiJSUzI1NiIsInR5cCI6Imp3dCIsImtpZCI6IjNreHdsVm5ZdW5oVUIyQVFYLVFYVUVZV0oxSlRyd08tQUpBMmc3MVVfa0UifQ.eyJpc3MiOiJkUkRDaWNobkk1YUpLcHZqYVJNZG0yUWdTRUxycVlHVSIsImF1ZCI6Imh0dHBzOi8vcGV1Mi10ZXN0LmV1LmF1dGgwLmNvbS8iLCJjbGllbnRfaWQiOiJkUkRDaWNobkk1YUpLcHZqYVJNZG0yUWdTRUxycVlHVSIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDozMDAwIiwibm9uY2UiOiIzMjNmMWYxNDIxMjI3Y2U1OGE3M2IxOTVkZWRjMDRmOCIsImlhdCI6MTcxMjMzNTMyMn0.E9ZAju2emT9KyR-asklRydgT0q2GmL3u90enSHvpF1PVn7zKqHBW9i6o4-QlIy-efHAsaGikMsysRMbp2xNVl5p9SFn-mZXlxrtIe2vKwbIRrknCT29CRyxX7Ulvv9840YK7N8BHoah8PRuAfJMq-e0jvCgfxuxBJC8uXBY2S43_YpLe2SKkmb-E9APwKh-55Mx-DPFVUKm1hasZ9GnRSZUb9F4aVB9Q8YndZ0uxKSjtPPwakDECHxSyA1yXQ7B1FrhcsZcTwneTDbmzepodStNboBdxmDVjXQggfyPeqeeeW5cCpJAhVnoo740TjwgsncJ9ftymR2uLP_fexru6KA&client_secret=test-client-secret",
+    "status": 200,
+    "response": {
+      "request_uri": "https://www.request.uri",
+      "expires_in": 86400
+    }
   }
 ]

--- a/test/auth/fixtures/oauth.json
+++ b/test/auth/fixtures/oauth.json
@@ -172,7 +172,7 @@
     "scope": "https://test-domain.auth0.com",
     "method": "POST",
     "path": "/oauth/par",
-    "body": "client_id=test-client-id&response_type=code&redirect_uri=https%3A%2F%2Fexample.com&request=eyJhbGciOiJSUzI1NiIsInR5cCI6Imp3dCIsImtpZCI6IjNreHdsVm5ZdW5oVUIyQVFYLVFYVUVZV0oxSlRyd08tQUpBMmc3MVVfa0UifQ.eyJpc3MiOiJkUkRDaWNobkk1YUpLcHZqYVJNZG0yUWdTRUxycVlHVSIsImF1ZCI6Imh0dHBzOi8vcGV1Mi10ZXN0LmV1LmF1dGgwLmNvbS8iLCJjbGllbnRfaWQiOiJkUkRDaWNobkk1YUpLcHZqYVJNZG0yUWdTRUxycVlHVSIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDozMDAwIiwibm9uY2UiOiIzMjNmMWYxNDIxMjI3Y2U1OGE3M2IxOTVkZWRjMDRmOCIsImlhdCI6MTcxMjMzNTMyMn0.E9ZAju2emT9KyR-asklRydgT0q2GmL3u90enSHvpF1PVn7zKqHBW9i6o4-QlIy-efHAsaGikMsysRMbp2xNVl5p9SFn-mZXlxrtIe2vKwbIRrknCT29CRyxX7Ulvv9840YK7N8BHoah8PRuAfJMq-e0jvCgfxuxBJC8uXBY2S43_YpLe2SKkmb-E9APwKh-55Mx-DPFVUKm1hasZ9GnRSZUb9F4aVB9Q8YndZ0uxKSjtPPwakDECHxSyA1yXQ7B1FrhcsZcTwneTDbmzepodStNboBdxmDVjXQggfyPeqeeeW5cCpJAhVnoo740TjwgsncJ9ftymR2uLP_fexru6KA&client_secret=test-client-secret",
+    "body": "client_id=test-client-id&response_type=code&redirect_uri=https%3A%2F%2Fexample.com&request=my-jwt-request&client_secret=test-client-secret",
     "status": 200,
     "response": {
       "request_uri": "https://www.request.uri",

--- a/test/auth/oauth.test.ts
+++ b/test/auth/oauth.test.ts
@@ -336,8 +336,7 @@ describe('OAuth', () => {
           client_id: 'test-client-id',
           response_type: 'code',
           redirect_uri: 'https://example.com',
-          request:
-            'eyJhbGciOiJSUzI1NiIsInR5cCI6Imp3dCIsImtpZCI6IjNreHdsVm5ZdW5oVUIyQVFYLVFYVUVZV0oxSlRyd08tQUpBMmc3MVVfa0UifQ.eyJpc3MiOiJkUkRDaWNobkk1YUpLcHZqYVJNZG0yUWdTRUxycVlHVSIsImF1ZCI6Imh0dHBzOi8vcGV1Mi10ZXN0LmV1LmF1dGgwLmNvbS8iLCJjbGllbnRfaWQiOiJkUkRDaWNobkk1YUpLcHZqYVJNZG0yUWdTRUxycVlHVSIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDozMDAwIiwibm9uY2UiOiIzMjNmMWYxNDIxMjI3Y2U1OGE3M2IxOTVkZWRjMDRmOCIsImlhdCI6MTcxMjMzNTMyMn0.E9ZAju2emT9KyR-asklRydgT0q2GmL3u90enSHvpF1PVn7zKqHBW9i6o4-QlIy-efHAsaGikMsysRMbp2xNVl5p9SFn-mZXlxrtIe2vKwbIRrknCT29CRyxX7Ulvv9840YK7N8BHoah8PRuAfJMq-e0jvCgfxuxBJC8uXBY2S43_YpLe2SKkmb-E9APwKh-55Mx-DPFVUKm1hasZ9GnRSZUb9F4aVB9Q8YndZ0uxKSjtPPwakDECHxSyA1yXQ7B1FrhcsZcTwneTDbmzepodStNboBdxmDVjXQggfyPeqeeeW5cCpJAhVnoo740TjwgsncJ9ftymR2uLP_fexru6KA',
+          request: 'my-jwt-request',
         })
       ).resolves.toMatchObject({
         data: {

--- a/test/auth/oauth.test.ts
+++ b/test/auth/oauth.test.ts
@@ -328,6 +328,24 @@ describe('OAuth', () => {
         },
       });
     });
+
+    it('should send request param when provided', async () => {
+      const oauth = new OAuth(opts);
+      await expect(
+        oauth.pushedAuthorization({
+          client_id: 'test-client-id',
+          response_type: 'code',
+          redirect_uri: 'https://example.com',
+          request:
+            'eyJhbGciOiJSUzI1NiIsInR5cCI6Imp3dCIsImtpZCI6IjNreHdsVm5ZdW5oVUIyQVFYLVFYVUVZV0oxSlRyd08tQUpBMmc3MVVfa0UifQ.eyJpc3MiOiJkUkRDaWNobkk1YUpLcHZqYVJNZG0yUWdTRUxycVlHVSIsImF1ZCI6Imh0dHBzOi8vcGV1Mi10ZXN0LmV1LmF1dGgwLmNvbS8iLCJjbGllbnRfaWQiOiJkUkRDaWNobkk1YUpLcHZqYVJNZG0yUWdTRUxycVlHVSIsInJlc3BvbnNlX3R5cGUiOiJjb2RlIiwicmVkaXJlY3RfdXJpIjoiaHR0cDovL2xvY2FsaG9zdDozMDAwIiwibm9uY2UiOiIzMjNmMWYxNDIxMjI3Y2U1OGE3M2IxOTVkZWRjMDRmOCIsImlhdCI6MTcxMjMzNTMyMn0.E9ZAju2emT9KyR-asklRydgT0q2GmL3u90enSHvpF1PVn7zKqHBW9i6o4-QlIy-efHAsaGikMsysRMbp2xNVl5p9SFn-mZXlxrtIe2vKwbIRrknCT29CRyxX7Ulvv9840YK7N8BHoah8PRuAfJMq-e0jvCgfxuxBJC8uXBY2S43_YpLe2SKkmb-E9APwKh-55Mx-DPFVUKm1hasZ9GnRSZUb9F4aVB9Q8YndZ0uxKSjtPPwakDECHxSyA1yXQ7B1FrhcsZcTwneTDbmzepodStNboBdxmDVjXQggfyPeqeeeW5cCpJAhVnoo740TjwgsncJ9ftymR2uLP_fexru6KA',
+        })
+      ).resolves.toMatchObject({
+        data: {
+          request_uri: 'https://www.request.uri',
+          expires_in: 86400,
+        },
+      });
+    });
   });
 });
 


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

- Added a new parameter `request` to support PAR with with requests

### References

- https://datatracker.ietf.org/doc/html/rfc9126#name-the-request-request-paramet


### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 
- To test the changes, user has to [generate a JAR request](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow/authorization-code-flow-with-jar), then add the generated JWT to newly added request parameter. 
- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
