### PR TITLE
Added new authorization_details parameter to support RAR requests

### DIFF
--- a/src/auth/client-authentication.ts
+++ b/src/auth/client-authentication.ts
@@ -36,9 +36,6 @@ export const addClientAuthentication = async ({
   clientSecret,
 }: AddClientAuthenticationOptions): Promise<Record<string, unknown>> => {
   const cid = payload.client_id || clientId;
-  if (payload.authorization_details) {
-    payload.authorization_details = JSON.stringify(payload.authorization_details);
-  }
   if (clientAssertionSigningKey && !payload.client_assertion) {
     const alg = clientAssertionSigningAlg || 'RS256';
     const privateKey = await jose.importPKCS8(clientAssertionSigningKey, alg);

--- a/src/auth/client-authentication.ts
+++ b/src/auth/client-authentication.ts
@@ -36,6 +36,9 @@ export const addClientAuthentication = async ({
   clientSecret,
 }: AddClientAuthenticationOptions): Promise<Record<string, unknown>> => {
   const cid = payload.client_id || clientId;
+  if (payload.authorization_details) {
+    payload.authorization_details = JSON.stringify(payload.authorization_details);
+  }
   if (clientAssertionSigningKey && !payload.client_assertion) {
     const alg = clientAssertionSigningAlg || 'RS256';
     const privateKey = await jose.importPKCS8(clientAssertionSigningKey, alg);

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -91,6 +91,19 @@ export interface ClientCredentialsGrantRequest extends ClientCredentials {
   audience: string;
 }
 
+interface AuthorizationDetails {
+  /**
+   * An identifier for the authorization details
+   */
+  type: string;
+
+  /**
+   * Allow for any custom property to be sent to Auth0
+   * It represents data to specify the authorization requirements for a certain type of resource.
+   */
+  [key: string]: any;
+}
+
 export interface PushedAuthorizationRequest extends ClientCredentials {
   /**
    * URI to redirect to.
@@ -145,6 +158,11 @@ export interface PushedAuthorizationRequest extends ClientCredentials {
    * A Base64-encoded SHA-256 hash of the {@link AuthorizationCodeGrantWithPKCERequest.code_verifier} used for the Authorization Code Flow with PKCE.
    */
   code_challenge?: string;
+
+  /**
+   * Can carry fine-grained authorization data in OAuth messages as part of Rich Authorization Requests(RAR) {@link https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow/authorization-code-flow-with-rar | Reference}
+   */
+  authorization_details?: Required<AuthorizationDetails>[];
 
   /**
    * Allow for any custom property to be sent to Auth0

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -147,7 +147,7 @@ export interface PushedAuthorizationRequest extends ClientCredentials {
   code_challenge?: string;
 
   /**
-   * A JSON stringified an array of objects. It Can carry fine-grained authorization data in OAuth messages as part of Rich Authorization Requests(RAR) {@link https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow/authorization-code-flow-with-rar | Reference}
+   * A JSON stringified array of objects. It can carry fine-grained authorization data in OAuth messages as part of Rich Authorization Requests (RAR) {@link https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow/authorization-code-flow-with-rar | Reference}
    */
   authorization_details?: string;
 

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -91,19 +91,6 @@ export interface ClientCredentialsGrantRequest extends ClientCredentials {
   audience: string;
 }
 
-interface AuthorizationDetails {
-  /**
-   * An identifier for the authorization details
-   */
-  type: string;
-
-  /**
-   * Allow for any custom property to be sent to Auth0
-   * It represents data to specify the authorization requirements for a certain type of resource.
-   */
-  [key: string]: any;
-}
-
 export interface PushedAuthorizationRequest extends ClientCredentials {
   /**
    * URI to redirect to.
@@ -160,9 +147,9 @@ export interface PushedAuthorizationRequest extends ClientCredentials {
   code_challenge?: string;
 
   /**
-   * Can carry fine-grained authorization data in OAuth messages as part of Rich Authorization Requests(RAR) {@link https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow/authorization-code-flow-with-rar | Reference}
+   * A JSON stringified an array of objects. It Can carry fine-grained authorization data in OAuth messages as part of Rich Authorization Requests(RAR) {@link https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow/authorization-code-flow-with-rar | Reference}
    */
-  authorization_details?: Required<AuthorizationDetails>[];
+  authorization_details?: string;
 
   /**
    * Allow for any custom property to be sent to Auth0

--- a/test/auth/client-authentication.test.ts
+++ b/test/auth/client-authentication.test.ts
@@ -206,21 +206,3 @@ describe('client-authentication for par endpoint', () => {
     });
   });
 });
-
-describe('Validate addClientAuthentication function', () => {
-  it('should stringify authorization_details property of payload parameter', async () => {
-    const authorization_details = [{ type: 'payment_initiation', actions: ['write'] }];
-    const authenticatedPayload = await addClientAuthentication({
-      payload: {
-        authorization_details: authorization_details,
-        client_secret: 'foo',
-      },
-      domain: 'tenant.auth0.com',
-      clientId,
-    });
-
-    expect(authenticatedPayload.authorization_details).toEqual(
-      JSON.stringify(authorization_details)
-    );
-  });
-});

--- a/test/auth/client-authentication.test.ts
+++ b/test/auth/client-authentication.test.ts
@@ -3,7 +3,6 @@ import { jest } from '@jest/globals';
 import * as jose from 'jose';
 import { AuthenticationClient } from '../../src/index.js';
 import { TEST_PUBLIC_KEY, TEST_PRIVATE_KEY } from '../constants.js';
-import { addClientAuthentication } from '../../src/auth/client-authentication.js';
 
 const URL = 'https://tenant.auth0.com/';
 const clientId = 'test-client-id';

--- a/test/auth/fixtures/oauth.json
+++ b/test/auth/fixtures/oauth.json
@@ -167,5 +167,16 @@
       "request_uri": "https://www.request.uri",
       "expires_in": 86400
     }
+  },
+  {
+    "scope": "https://test-domain.auth0.com",
+    "method": "POST",
+    "path": "/oauth/par",
+    "body": "client_id=test-client-id&response_type=code&redirect_uri=https%3A%2F%2Fexample.com&authorization_details=%5B%7B%22type%22%3A%22payment_initiation%22%2C%22actions%22%3A%5B%22write%22%5D%7D%5D&client_secret=test-client-secret",
+    "status": 200,
+    "response": {
+      "request_uri": "https://www.request.uri",
+      "expires_in": 86400
+    }
   }
 ]

--- a/test/auth/oauth.test.ts
+++ b/test/auth/oauth.test.ts
@@ -328,6 +328,25 @@ describe('OAuth', () => {
         },
       });
     });
+
+    it('should send authorization_details when provided', async () => {
+      const oauth = new OAuth(opts);
+      await expect(
+        oauth.pushedAuthorization({
+          client_id: 'test-client-id',
+          response_type: 'code',
+          redirect_uri: 'https://example.com',
+          authorization_details: JSON.stringify([
+            { type: 'payment_initiation', actions: ['write'] },
+          ]),
+        })
+      ).resolves.toMatchObject({
+        data: {
+          request_uri: 'https://www.request.uri',
+          expires_in: 86400,
+        },
+      });
+    });
   });
 });
 


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

- Added a new parameter authorization_details to support Rich Authorization request(RAR) for /par endpoint

### References

- RFC document - https://datatracker.ietf.org/doc/html/rfc9396#name-request-parameter-authoriza

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- To test the changes user has to first [configure resource server api](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow/authorization-code-flow-with-rar). 
  - Then using the new `authorization_details` parameter call the par endpoint.
  - `authorization_details` should follow the format as stated in [RFC doc](https://datatracker.ietf.org/doc/html/rfc9396#name-request-parameter-authoriza)
- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
