### PR TITLE
Added changes to support mTLS authentication

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -6,6 +6,7 @@
   - [Use Refresh Tokens](#use-refresh-tokens)
   - [Complete the Authorization Code flow with PKCE](#complete-the-authorization-code-flow-with-pkce)
   - [Login with Passwordless](#login-with-passwordless)
+  - [mTLS request](#mtls-request)
 - [Management Client](#management-client)
   - [Paginate through a list of users](#paginate-through-a-list-of-users)
   - [Paginate through a list of logs using checkpoint pagination](#paginate-through-a-list-of-logs-using-checkpoint-pagination)
@@ -127,6 +128,24 @@ const { data: tokens } = await auth.passwordless.loginWithEmail({
   email: '{user email}',
   code: '{code from email}',
 });
+```
+
+### mTLS request
+
+```js
+import { AuthenticationClient } from 'auth0';
+
+// add mtls prefix to your domain name
+const auth = new AuthenticationClient({
+  domain: 'mtls.{YOUR_TENANT_AND REGION}.auth0.com',
+  clientId: '{YOUR_CLIENT_ID}',
+  agent: new https.Agent({ ... }),
+});
+
+const { data: tokens } = await auth.oauth.clientCredentialsGrant({
+  audience: 'you-api',
+});
+
 ```
 
 ## Management Client

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -135,9 +135,8 @@ const { data: tokens } = await auth.passwordless.loginWithEmail({
 ```js
 import { AuthenticationClient } from 'auth0';
 
-// add mtls prefix to your domain name
 const auth = new AuthenticationClient({
-  domain: 'mtls.{YOUR_TENANT_AND REGION}.auth0.com',
+  domain: '{YOUR_TENANT_AND REGION}.auth0.com',
   clientId: '{YOUR_CLIENT_ID}',
   agent: new https.Agent({ ... }),
 });

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -136,17 +136,20 @@ Refer mTLS documentation for more info - [Link](https://auth0.com/docs/get-start
 
 ```js
 import { AuthenticationClient } from 'auth0';
+const { Agent } = require('undici');
 
 const auth = new AuthenticationClient({
-  domain: 'mtls.{YOUR_TENANT_AND REGION}.auth0.com',
+  domain: '{YOUR_TENANT_AND REGION}.auth0.com',
   clientId: '{YOUR_CLIENT_ID}',
-  agent: new https.Agent({ ... }),
+  agent: new Agent({
+    connect: { cert: 'your_cert', key: 'your_key' },
+  }),
+  useMTLS: true,
 });
 
 const { data: tokens } = await auth.oauth.clientCredentialsGrant({
   audience: 'you-api',
 });
-
 ```
 
 ## Management Client

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -132,11 +132,13 @@ const { data: tokens } = await auth.passwordless.loginWithEmail({
 
 ### mTLS request
 
+Refer mTLS documentation for more info - [Link](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authenticate-with-mtls)
+
 ```js
 import { AuthenticationClient } from 'auth0';
 
 const auth = new AuthenticationClient({
-  domain: '{YOUR_TENANT_AND REGION}.auth0.com',
+  domain: 'mtls.{YOUR_TENANT_AND REGION}.auth0.com',
   clientId: '{YOUR_CLIENT_ID}',
   agent: new https.Agent({ ... }),
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -7250,7 +7250,7 @@
     },
     "node_modules/undici": {
       "version": "6.15.0",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/undici/-/undici-6.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.15.0.tgz",
       "integrity": "sha512-VviMt2tlMg1BvQ0FKXxrz1eJuyrcISrL2sPfBf7ZskX/FCEc/7LeThQaoygsMJpNqrATWQIsRVx+1Dpe4jaYuQ==",
       "dev": true,
       "engines": {
@@ -12887,7 +12887,7 @@
     },
     "undici": {
       "version": "6.15.0",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/undici/-/undici-6.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.15.0.tgz",
       "integrity": "sha512-VviMt2tlMg1BvQ0FKXxrz1eJuyrcISrL2sPfBf7ZskX/FCEc/7LeThQaoygsMJpNqrATWQIsRVx+1Dpe4jaYuQ==",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,8 @@
         "ts-jest": "^29.1.0",
         "ts-node": "^10.9.1",
         "typedoc": "^0.24.6",
-        "typescript": "4.9.5"
+        "typescript": "4.9.5",
+        "undici": "^6.15.0"
       },
       "engines": {
         "node": ">=18"
@@ -7247,6 +7248,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "6.15.0",
+      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/undici/-/undici-6.15.0.tgz",
+      "integrity": "sha512-VviMt2tlMg1BvQ0FKXxrz1eJuyrcISrL2sPfBf7ZskX/FCEc/7LeThQaoygsMJpNqrATWQIsRVx+1Dpe4jaYuQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
@@ -12874,6 +12884,12 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici": {
+      "version": "6.15.0",
+      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/undici/-/undici-6.15.0.tgz",
+      "integrity": "sha512-VviMt2tlMg1BvQ0FKXxrz1eJuyrcISrL2sPfBf7ZskX/FCEc/7LeThQaoygsMJpNqrATWQIsRVx+1Dpe4jaYuQ==",
+      "dev": true
     },
     "update-browserslist-db": {
       "version": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "typedoc": "^0.24.6",
-    "typescript": "4.9.5"
+    "typescript": "4.9.5",
+    "undici": "^6.15.0"
   }
 }

--- a/src/auth/base-auth-api.ts
+++ b/src/auth/base-auth-api.ts
@@ -92,6 +92,7 @@ export class BaseAuthAPI extends BaseAPI {
   clientSecret?: string;
   clientAssertionSigningKey?: string;
   clientAssertionSigningAlg?: string;
+  agent?: unknown;
 
   constructor(options: AuthenticationClientOptions) {
     super({
@@ -107,6 +108,7 @@ export class BaseAuthAPI extends BaseAPI {
     this.clientSecret = options.clientSecret;
     this.clientAssertionSigningKey = options.clientAssertionSigningKey;
     this.clientAssertionSigningAlg = options.clientAssertionSigningAlg;
+    this.agent = options.agent;
   }
 
   /**
@@ -122,6 +124,7 @@ export class BaseAuthAPI extends BaseAPI {
       clientSecret: this.clientSecret,
       clientAssertionSigningKey: this.clientAssertionSigningKey,
       clientAssertionSigningAlg: this.clientAssertionSigningAlg,
+      agent: this.agent,
     });
   }
 }

--- a/src/auth/base-auth-api.ts
+++ b/src/auth/base-auth-api.ts
@@ -22,6 +22,7 @@ export interface AuthenticationClientOptions extends ClientOptions {
   clientAssertionSigningAlg?: string;
   idTokenSigningAlg?: string; // default 'RS256'
   clockTolerance?: number; // default 60s,
+  useMTLS?: boolean;
 }
 
 interface AuthApiErrorResponse {
@@ -92,7 +93,7 @@ export class BaseAuthAPI extends BaseAPI {
   clientSecret?: string;
   clientAssertionSigningKey?: string;
   clientAssertionSigningAlg?: string;
-  agent?: unknown;
+  useMTLS?: boolean;
 
   constructor(options: AuthenticationClientOptions) {
     super({
@@ -108,7 +109,7 @@ export class BaseAuthAPI extends BaseAPI {
     this.clientSecret = options.clientSecret;
     this.clientAssertionSigningKey = options.clientAssertionSigningKey;
     this.clientAssertionSigningAlg = options.clientAssertionSigningAlg;
-    this.agent = options.agent;
+    this.useMTLS = options.useMTLS;
   }
 
   /**
@@ -124,7 +125,7 @@ export class BaseAuthAPI extends BaseAPI {
       clientSecret: this.clientSecret,
       clientAssertionSigningKey: this.clientAssertionSigningKey,
       clientAssertionSigningAlg: this.clientAssertionSigningAlg,
-      agent: this.agent,
+      useMTLS: this.useMTLS,
     });
   }
 }

--- a/src/auth/client-authentication.ts
+++ b/src/auth/client-authentication.ts
@@ -17,6 +17,7 @@ interface AddClientAuthenticationOptions {
   clientAssertionSigningKey?: string;
   clientAssertionSigningAlg?: string;
   clientSecret?: string;
+  agent?: unknown;
 }
 
 /**
@@ -26,7 +27,6 @@ interface AddClientAuthenticationOptions {
  * Adds `client_assertion` and `client_assertion_type` for Private Key JWT token endpoint auth method.
  *
  * If `clientAssertionSigningKey` is provided it takes precedent over `clientSecret` .
- * Also skips  `client_secret` & `clientAssertionSigningKey` if request(domain) is of mTLS type
  */
 export const addClientAuthentication = async ({
   payload,
@@ -35,6 +35,7 @@ export const addClientAuthentication = async ({
   clientAssertionSigningKey,
   clientAssertionSigningAlg,
   clientSecret,
+  agent,
 }: AddClientAuthenticationOptions): Promise<Record<string, unknown>> => {
   const cid = payload.client_id || clientId;
   if (clientAssertionSigningKey && !payload.client_assertion) {
@@ -57,16 +58,18 @@ export const addClientAuthentication = async ({
   if (
     (!payload.client_secret || payload.client_secret.trim().length === 0) &&
     (!payload.client_assertion || payload.client_assertion.trim().length === 0) &&
-    !isMTLSRequest(domain)
+    !isMTLSRequest(agent)
   ) {
-    throw new Error('The client_secret or client_assertion field is required.');
+    throw new Error(
+      'The client_secret or client_assertion field is required, or it should be mTLS request.'
+    );
   }
   return payload;
 };
 
 /**
- * Checks if domain name starts with mTLS keyword for mTLS requests
+ * Checks if the request has agent property provided
  */
-const isMTLSRequest = (domain: string): boolean => {
-  return domain.toLowerCase().startsWith('mtls');
+const isMTLSRequest = (agent: unknown): boolean => {
+  return typeof agent === 'undefined' ? false : true;
 };

--- a/src/auth/client-authentication.ts
+++ b/src/auth/client-authentication.ts
@@ -17,7 +17,7 @@ interface AddClientAuthenticationOptions {
   clientAssertionSigningKey?: string;
   clientAssertionSigningAlg?: string;
   clientSecret?: string;
-  agent?: unknown;
+  useMTLS?: boolean;
 }
 
 /**
@@ -35,7 +35,7 @@ export const addClientAuthentication = async ({
   clientAssertionSigningKey,
   clientAssertionSigningAlg,
   clientSecret,
-  agent,
+  useMTLS,
 }: AddClientAuthenticationOptions): Promise<Record<string, unknown>> => {
   const cid = payload.client_id || clientId;
   if (clientAssertionSigningKey && !payload.client_assertion) {
@@ -58,18 +58,11 @@ export const addClientAuthentication = async ({
   if (
     (!payload.client_secret || payload.client_secret.trim().length === 0) &&
     (!payload.client_assertion || payload.client_assertion.trim().length === 0) &&
-    !isMTLSRequest(agent)
+    !useMTLS
   ) {
     throw new Error(
       'The client_secret or client_assertion field is required, or it should be mTLS request.'
     );
   }
   return payload;
-};
-
-/**
- * Checks if the request has agent property provided
- */
-const isMTLSRequest = (agent: unknown): boolean => {
-  return typeof agent === 'undefined' ? false : true;
 };

--- a/src/auth/client-authentication.ts
+++ b/src/auth/client-authentication.ts
@@ -26,6 +26,7 @@ interface AddClientAuthenticationOptions {
  * Adds `client_assertion` and `client_assertion_type` for Private Key JWT token endpoint auth method.
  *
  * If `clientAssertionSigningKey` is provided it takes precedent over `clientSecret` .
+ * Also skips  `client_secret` & `clientAssertionSigningKey` if request(domain) is of mTLS type
  */
 export const addClientAuthentication = async ({
   payload,
@@ -55,9 +56,17 @@ export const addClientAuthentication = async ({
   }
   if (
     (!payload.client_secret || payload.client_secret.trim().length === 0) &&
-    (!payload.client_assertion || payload.client_assertion.trim().length === 0)
+    (!payload.client_assertion || payload.client_assertion.trim().length === 0) &&
+    !isMTLSRequest(domain)
   ) {
     throw new Error('The client_secret or client_assertion field is required.');
   }
   return payload;
+};
+
+/**
+ * Checks if domain name starts with mTLS keyword for mTLS requests
+ */
+const isMTLSRequest = (domain: string): boolean => {
+  return domain.toLowerCase().startsWith('mtls');
 };

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -274,7 +274,7 @@ export class OAuth extends BaseAuthAPI {
   constructor(options: AuthenticationClientOptions) {
     super({
       ...options,
-      domain: options.useMTLS ? `${mtlsPrefix}.` + options.domain : options.domain,
+      domain: options.useMTLS ? `${mtlsPrefix}.${options.domain}` : options.domain,
     });
     this.idTokenValidator = new IDTokenValidator(options);
   }

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -6,6 +6,7 @@ import {
 } from '../lib/runtime.js';
 import { BaseAuthAPI, AuthenticationClientOptions, grant } from './base-auth-api.js';
 import { IDTokenValidateOptions, IDTokenValidator } from './id-token-validator.js';
+import { mtlsPrefix } from '../utils.js';
 
 export interface TokenSet {
   /**
@@ -271,7 +272,10 @@ export interface TokenExchangeGrantRequest {
 export class OAuth extends BaseAuthAPI {
   private idTokenValidator: IDTokenValidator;
   constructor(options: AuthenticationClientOptions) {
-    super(options);
+    super({
+      ...options,
+      domain: options.useMTLS ? `${mtlsPrefix}.` + options.domain : options.domain,
+    });
     this.idTokenValidator = new IDTokenValidator(options);
   }
 

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,4 +1,5 @@
 import { RetryConfiguration } from './retry.js';
+import { Dispatcher } from 'undici';
 
 /**
  * @private
@@ -25,8 +26,7 @@ export interface Configuration {
   /**
    * Pass your own http agent to support proxies.
    */
-  // https://github.com/octokit/types.ts/blob/v10.0.0/src/RequestRequestOptions.ts#L13
-  agent?: unknown;
+  agent?: Dispatcher;
   /**
    * Custom headers that will be added to every request.
    */

--- a/src/lib/runtime.ts
+++ b/src/lib/runtime.ts
@@ -73,7 +73,7 @@ export class BaseAPI {
       method: context.method,
       headers,
       body: context.body,
-      agent: this.configuration.agent,
+      dispatcher: this.configuration.agent,
     };
 
     const overriddenInit: RequestInit = {

--- a/src/management/management-client-options.ts
+++ b/src/management/management-client-options.ts
@@ -12,12 +12,14 @@ export interface ManagementClientOptionsWithToken extends ManagementClientOption
 export interface ManagementClientOptionsWithClientSecret extends ManagementClientOptions {
   clientId: string;
   clientSecret: string;
+  useMTLS?: boolean;
 }
 
 export interface ManagementClientOptionsWithClientAssertion extends ManagementClientOptions {
   clientId: string;
   clientAssertionSigningKey: string;
   clientAssertionSigningAlg?: string;
+  useMTLS?: boolean;
 }
 
 export type ManagementClientOptionsWithClientCredentials =

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,3 +10,8 @@ export const generateClientInfo = () => ({
     node: process.version.replace('v', ''),
   },
 });
+
+/**
+ * @private
+ */
+export const mtlsPrefix = 'mtls';

--- a/test/auth/client-authentication.test.ts
+++ b/test/auth/client-authentication.test.ts
@@ -3,7 +3,7 @@ import { jest } from '@jest/globals';
 import * as jose from 'jose';
 import { AuthenticationClient } from '../../src/index.js';
 import { TEST_PUBLIC_KEY, TEST_PRIVATE_KEY } from '../constants.js';
-
+import { Agent } from 'undici';
 const URL = 'https://tenant.auth0.com/';
 const clientId = 'test-client-id';
 const verifyOpts = {
@@ -241,9 +241,9 @@ describe('mTLS-authentication', () => {
     const auth0 = new AuthenticationClient({
       domain: 'tenant.auth0.com',
       clientId,
-      agent: {
-        options: { key: 'my-key', cert: 'my-cert' },
-      },
+      agent: new Agent({
+        connect: { cert: 'my-cert', key: 'my-key' },
+      }),
       useMTLS: true,
     });
     await auth0.oauth.clientCredentialsGrant({

--- a/test/auth/client-authentication.test.ts
+++ b/test/auth/client-authentication.test.ts
@@ -239,11 +239,12 @@ describe('mTLS-authentication', () => {
 
   it('should do client credentials grant without client secret or assertion & only with agent', async () => {
     const auth0 = new AuthenticationClient({
-      domain: 'mtls.tenant.auth0.com',
+      domain: 'tenant.auth0.com',
       clientId,
       agent: {
         options: { key: 'my-key', cert: 'my-cert' },
       },
+      useMTLS: true,
     });
     await auth0.oauth.clientCredentialsGrant({
       audience: 'my-api',

--- a/test/auth/client-authentication.test.ts
+++ b/test/auth/client-authentication.test.ts
@@ -111,7 +111,9 @@ describe('client-authentication', () => {
       auth0.oauth.clientCredentialsGrant({
         audience: 'my-api',
       })
-    ).rejects.toThrow('The client_secret or client_assertion field is required.');
+    ).rejects.toThrow(
+      'The client_secret or client_assertion field is required, or it should be mTLS request.'
+    );
   });
 
   it('should allow you to pass your own client assertion', async () => {
@@ -235,10 +237,13 @@ describe('mTLS-authentication', () => {
     jest.clearAllMocks();
   });
 
-  it('should do client credentials grant without client secret or assertion', async () => {
+  it('should do client credentials grant without client secret or assertion & only with agent', async () => {
     const auth0 = new AuthenticationClient({
       domain: 'mtls.tenant.auth0.com',
       clientId,
+      agent: {
+        options: { key: 'my-key', cert: 'my-cert' },
+      },
     });
     await auth0.oauth.clientCredentialsGrant({
       audience: 'my-api',

--- a/test/auth/oauth.test.ts
+++ b/test/auth/oauth.test.ts
@@ -310,7 +310,9 @@ describe('OAuth', () => {
           response_type: 'code',
           redirect_uri: 'https://example.com',
         } as PushedAuthorizationRequest)
-      ).rejects.toThrow('The client_secret or client_assertion field is required.');
+      ).rejects.toThrow(
+        'The client_secret or client_assertion field is required, or it should be mTLS request.'
+      );
     });
 
     it('should return the par response', async () => {


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

- Added relevant changes to start supporting mTLS authentication
- As part of the change a new boolean parameter `useMTLS`, if passed as true, it will append `mtls` prefix to required authentication endpoints.
- If value `useMTLS` is `true` , validation for clientSecret & client assertion signing key will be skipped.

### References

Please include relevant links supporting this change such as a:

- mTLS auth0 documentation - [Link](https://auth0.com/docs/get-started/applications/configure-mtls)

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 
- Verified different client authentication flows like passwordless, database & other oauth methods
- mTLS configuration worked correctly, required access token were received on successful request
- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
