### PR TITLE
fix: add enabled_clients to connection model

### DIFF
--- a/src/management/__generated/models/index.ts
+++ b/src/management/__generated/models/index.ts
@@ -2562,6 +2562,10 @@ export interface Connection {
    */
   is_domain_connection: boolean;
   /**
+   * The identifiers of the clients for which the connection is to be enabled. If the array is empty or the property is not specified, no clients are enabled
+   */
+  enabled_clients: Array<string>;
+  /**
    * Metadata associated with the connection in the form of an object with string values (max 255 chars).  Maximum of 10 metadata properties allowed.
    *
    */

--- a/test/management/connections.test.ts
+++ b/test/management/connections.test.ts
@@ -55,6 +55,7 @@ describe('ConnectionsManager', () => {
         strategy: 'auth0',
         realms: ['test'],
         is_domain_connection: false,
+        enabled_clients: ['test'],
         metadata: {
           test: 'test value',
         },
@@ -96,6 +97,7 @@ describe('ConnectionsManager', () => {
         expect(connections.data[0].strategy).toBe(response[0].strategy);
         expect(connections.data[0].realms?.[0]).toBe(response[0].realms[0]);
         expect(connections.data[0].is_domain_connection).toBe(response[0].is_domain_connection);
+        expect(connections.data[0].enabled_clients).toBe(response[0].enabled_clients);
         expect(connections.data[0].metadata?.test).toBe(response[0].metadata.test);
 
         done();
@@ -172,6 +174,7 @@ describe('ConnectionsManager', () => {
       strategy: 'auth0',
       realms: ['test'],
       is_domain_connection: false,
+      enabled_clients: ['test'],
       metadata: {
         test: 'test value',
       },
@@ -208,6 +211,7 @@ describe('ConnectionsManager', () => {
         expect(connection.data.strategy).toBe(response.strategy);
         expect(connection.data.realms?.[0]).toBe(response.realms[0]);
         expect(connection.data.is_domain_connection).toBe(response.is_domain_connection);
+        expect(connection.data.enabled_clients).toBe(response.enabled_clients);
         expect(connection.data.metadata?.test).toBe(response.metadata.test);
 
         done();


### PR DESCRIPTION
### Changes

Adds a missing field as addressed in https://github.com/auth0/node-auth0/issues/945. This field existed in 3.x, and was lost in the migration.

### References

 - https://github.com/auth0/node-auth0/issues/945
 - https://support.auth0.com/tickets/02353128

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
