### PR TITLE
Added enabled_clients in connection interface

### DIFF
--- a/src/management/__generated/models/index.ts
+++ b/src/management/__generated/models/index.ts
@@ -2557,6 +2557,11 @@ export interface Connection {
    */
   realms: Array<string>;
   /**
+   * The ids of the clients for which the connection is enabled
+   *
+   */
+  enabled_clients: Array<string>;
+  /**
    * True if the connection is domain level
    *
    */

--- a/test/management/connections.test.ts
+++ b/test/management/connections.test.ts
@@ -55,6 +55,7 @@ describe('ConnectionsManager', () => {
         strategy: 'auth0',
         realms: ['test'],
         is_domain_connection: false,
+        enabled_clients: ['test'],
         metadata: {
           test: 'test value',
         },
@@ -97,6 +98,7 @@ describe('ConnectionsManager', () => {
         expect(connections.data[0].realms?.[0]).toBe(response[0].realms[0]);
         expect(connections.data[0].is_domain_connection).toBe(response[0].is_domain_connection);
         expect(connections.data[0].metadata?.test).toBe(response[0].metadata.test);
+        expect(connections.data[0].enabled_clients[0]).toBe(response[0].enabled_clients[0]);
 
         done();
       });
@@ -172,6 +174,7 @@ describe('ConnectionsManager', () => {
       strategy: 'auth0',
       realms: ['test'],
       is_domain_connection: false,
+      enabled_clients: ['test'],
       metadata: {
         test: 'test value',
       },
@@ -209,6 +212,7 @@ describe('ConnectionsManager', () => {
         expect(connection.data.realms?.[0]).toBe(response.realms[0]);
         expect(connection.data.is_domain_connection).toBe(response.is_domain_connection);
         expect(connection.data.metadata?.test).toBe(response.metadata.test);
+        expect(connection.data.enabled_clients[0]).toBe(response.enabled_clients[0]);
 
         done();
       });


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

- Addresses issue mentioned in #945
- Added  `enabled_clients` in `connection` interface in management api generated section

### References

Please include relevant links supporting this change such as a:

- Github issue - #945 
- Addresses Closed PR -  #1009 


### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage
- Tested my changes with a client app. Was able to reproduce the issue without my changes. Verified the client app with updated changes. Type issue of `enabled_clients` was fixed in the client app. 


### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
