### PR TITLE
parameter name change for Organizations for Client Credentials

### DIFF
--- a/src/management/__generated/models/index.ts
+++ b/src/management/__generated/models/index.ts
@@ -6533,7 +6533,7 @@ export interface GetOrganizationClientGrants200ResponseOneOf {
   total: number;
   /**
    */
-  grants: Array<GetOrganizationClientGrants200ResponseOneOfInner>;
+  'client-grants': Array<GetOrganizationClientGrants200ResponseOneOfInner>;
 }
 /**
  *


### PR DESCRIPTION
### Changes
*parameter name change in model `GetOrganizationClientGrants200ResponseOneOf`*

the parameter was specified 'grants' in the api docs when it should actually be 'client-grants', this patch fixes the discrepancy

### References
Please include relevant links supporting this change such as a:
- [Public docs](https://auth0.com/docs/api/management/v2/organizations/get-organization-client-grants#response-messages)

> GET  /api/v2/organizations/{id}/client-grants
> ```
> {
>   "client_grants": [......],
>   "start": 0,
>   "limit": 50,
>   "total": 1
> }
> ```
> 

### Testing
- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

```
➜ npm run test                                                         
Test Suites: 42 passed, 42 total
Tests:       1346 passed, 1346 total
Snapshots:   0 total
Time:        7.72 s, estimated 8 s
```

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors


