### PR TITLE
Self Service SSO GA release changes

### DIFF
--- a/src/management/__generated/managers/self-service-profiles-manager.ts
+++ b/src/management/__generated/managers/self-service-profiles-manager.ts
@@ -1,16 +1,21 @@
 import * as runtime from '../../../lib/runtime.js';
 import type { InitOverride, ApiResponse } from '../../../lib/runtime.js';
 import type {
+  GetSelfServiceProfiles200Response,
+  PostSsoTicketRequest,
   SsProfile,
   SsProfileCreate,
-  SsProfileList,
   SsProfileUpdate,
   SsoAccessTicketResponse,
-  SsoTicketRequestJson,
+  GetSelfServiceProfiles200ResponseOneOf,
   DeleteSelfServiceProfilesByIdRequest,
+  GetSelfServiceProfileCustomTextRequest,
+  GetSelfServiceProfilesRequest,
   GetSelfServiceProfilesByIdRequest,
   PatchSelfServiceProfilesByIdRequest,
-  PostSsoTicketRequest,
+  PostRevokeRequest,
+  PostSsoTicketOperationRequest,
+  PutSelfServiceProfileCustomTextRequest,
 } from '../models/index.js';
 
 const { BaseAPI } = runtime;
@@ -25,7 +30,7 @@ export class SelfServiceProfilesManager extends BaseAPI {
    *
    * @throws {RequiredError}
    */
-  async deleteSelfServiceProfiles(
+  async delete(
     requestParameters: DeleteSelfServiceProfilesByIdRequest,
     initOverrides?: InitOverride
   ): Promise<ApiResponse<void>> {
@@ -46,16 +51,70 @@ export class SelfServiceProfilesManager extends BaseAPI {
   }
 
   /**
-   * Retrieves self-service profiles. Currently only one profile can be created per tenant.
-   * Retrieve self-service profiles
+   * Retrieves text customizations for a given self-service profile, language and Self Service SSO Flow page.
+   *
+   * Get custom text for a self-service profile
    *
    * @throws {RequiredError}
    */
-  async getSelfServiceProfiles(initOverrides?: InitOverride): Promise<ApiResponse<SsProfileList>> {
+  async getCustomText(
+    requestParameters: GetSelfServiceProfileCustomTextRequest,
+    initOverrides?: InitOverride
+  ): Promise<ApiResponse<{ [key: string]: any }>> {
+    runtime.validateRequiredRequestParams(requestParameters, ['id', 'language', 'page']);
+
+    const response = await this.request(
+      {
+        path: `/self-service-profiles/{id}/custom-text/{language}/{page}`
+          .replace('{id}', encodeURIComponent(String(requestParameters.id)))
+          .replace('{language}', encodeURIComponent(String(requestParameters.language)))
+          .replace('{page}', encodeURIComponent(String(requestParameters.page))),
+        method: 'GET',
+      },
+      initOverrides
+    );
+
+    return runtime.JSONApiResponse.fromResponse<any>(response);
+  }
+
+  /**
+   * Retrieves self-service profiles. Currently only one profile can be created per tenant.
+   * Get self-service profiles
+   *
+   * @throws {RequiredError}
+   */
+  async getAll(
+    requestParameters: GetSelfServiceProfilesRequest & { include_totals: true },
+    initOverrides?: InitOverride
+  ): Promise<ApiResponse<GetSelfServiceProfiles200ResponseOneOf>>;
+  async getAll(
+    requestParameters?: GetSelfServiceProfilesRequest,
+    initOverrides?: InitOverride
+  ): Promise<ApiResponse<Array<SsProfile>>>;
+  async getAll(
+    requestParameters: GetSelfServiceProfilesRequest = {},
+    initOverrides?: InitOverride
+  ): Promise<ApiResponse<GetSelfServiceProfiles200Response>> {
+    const queryParameters = runtime.applyQueryParams(requestParameters, [
+      {
+        key: 'page',
+        config: {},
+      },
+      {
+        key: 'per_page',
+        config: {},
+      },
+      {
+        key: 'include_totals',
+        config: {},
+      },
+    ]);
+
     const response = await this.request(
       {
         path: `/self-service-profiles`,
         method: 'GET',
+        query: queryParameters,
       },
       initOverrides
     );
@@ -65,11 +124,11 @@ export class SelfServiceProfilesManager extends BaseAPI {
 
   /**
    * Retrieves a self-service profile by Id.
-   * Retrieve a self-service profile by Id
+   * Get a self-service profile by Id
    *
    * @throws {RequiredError}
    */
-  async getSelfServiceProfilesById(
+  async get(
     requestParameters: GetSelfServiceProfilesByIdRequest,
     initOverrides?: InitOverride
   ): Promise<ApiResponse<SsProfile>> {
@@ -95,7 +154,7 @@ export class SelfServiceProfilesManager extends BaseAPI {
    *
    * @throws {RequiredError}
    */
-  async patchSelfServiceProfiles(
+  async update(
     requestParameters: PatchSelfServiceProfilesByIdRequest,
     bodyParameters: SsProfileUpdate,
     initOverrides?: InitOverride
@@ -123,12 +182,39 @@ export class SelfServiceProfilesManager extends BaseAPI {
   }
 
   /**
+   * Revokes an SSO access ticket and invalidates associated sessions. The ticket will no longer be accepted to initiate a Self-Service SSO session. If any users have already started a session through this ticket, their session will be terminated. Clients should expect a `202 Accepted` response upon successful processing, indicating that the request has been acknowledged and that the revocation is underway but may not be fully completed at the time of response. If the specified ticket does not exist, a `202 Accepted` response is also returned, signaling that no further action is required.
+   * Clients should treat these `202` responses as an acknowledgment that the request has been accepted and is in progress, even if the ticket was not found.
+   *
+   * Revoke an SSO access ticket
+   *
+   * @throws {RequiredError}
+   */
+  async revokeSsoTicket(
+    requestParameters: PostRevokeRequest,
+    initOverrides?: InitOverride
+  ): Promise<ApiResponse<any>> {
+    runtime.validateRequiredRequestParams(requestParameters, ['profileId', 'id']);
+
+    const response = await this.request(
+      {
+        path: `/self-service-profiles/{profileId}/sso-ticket/{id}/revoke`
+          .replace('{profileId}', encodeURIComponent(String(requestParameters.profileId)))
+          .replace('{id}', encodeURIComponent(String(requestParameters.id))),
+        method: 'POST',
+      },
+      initOverrides
+    );
+
+    return runtime.TextApiResponse.fromResponse(response) as any;
+  }
+
+  /**
    * Creates a self-service profile. Currently only one profile can be created per tenant.
    * Create a self-service profile
    *
    * @throws {RequiredError}
    */
-  async postSelfServiceProfiles(
+  async create(
     bodyParameters: SsProfileCreate,
     initOverrides?: InitOverride
   ): Promise<ApiResponse<SsProfile>> {
@@ -150,14 +236,15 @@ export class SelfServiceProfilesManager extends BaseAPI {
   }
 
   /**
-   * Creates an sso-access ticket to initiate the Self Service SSO Flow using a self-service profile.
-   * Create an sso-access ticket to initiate the Self Service SSO Flow
+   * Creates an SSO access ticket to initiate the Self Service SSO Flow using a self-service profile.
+   *
+   * Create an SSO access ticket to initiate the Self Service SSO Flow
    *
    * @throws {RequiredError}
    */
-  async postSsoTicket(
-    requestParameters: PostSsoTicketRequest,
-    bodyParameters: SsoTicketRequestJson,
+  async createSsoTicket(
+    requestParameters: PostSsoTicketOperationRequest,
+    bodyParameters: PostSsoTicketRequest,
     initOverrides?: InitOverride
   ): Promise<ApiResponse<SsoAccessTicketResponse>> {
     runtime.validateRequiredRequestParams(requestParameters, ['id']);
@@ -180,5 +267,39 @@ export class SelfServiceProfilesManager extends BaseAPI {
     );
 
     return runtime.JSONApiResponse.fromResponse(response);
+  }
+
+  /**
+   * Updates text customizations for a given self-service profile, language and Self Service SSO Flow page.
+   *
+   * Set custom text for a self-service profile
+   *
+   * @throws {RequiredError}
+   */
+  async updateCustomText(
+    requestParameters: PutSelfServiceProfileCustomTextRequest,
+    bodyParameters: { [key: string]: any },
+    initOverrides?: InitOverride
+  ): Promise<ApiResponse<{ [key: string]: any }>> {
+    runtime.validateRequiredRequestParams(requestParameters, ['id', 'language', 'page']);
+
+    const headerParameters: runtime.HTTPHeaders = {};
+
+    headerParameters['Content-Type'] = 'application/json';
+
+    const response = await this.request(
+      {
+        path: `/self-service-profiles/{id}/custom-text/{language}/{page}`
+          .replace('{id}', encodeURIComponent(String(requestParameters.id)))
+          .replace('{language}', encodeURIComponent(String(requestParameters.language)))
+          .replace('{page}', encodeURIComponent(String(requestParameters.page))),
+        method: 'PUT',
+        headers: headerParameters,
+        body: bodyParameters,
+      },
+      initOverrides
+    );
+
+    return runtime.JSONApiResponse.fromResponse<any>(response);
   }
 }

--- a/src/management/__generated/models/index.ts
+++ b/src/management/__generated/models/index.ts
@@ -7430,6 +7430,29 @@ export interface GetScimTokens200ResponseInner {
 /**
  *
  */
+export type GetSelfServiceProfiles200Response =
+  | Array<SsProfile>
+  | GetSelfServiceProfiles200ResponseOneOf;
+/**
+ *
+ */
+export interface GetSelfServiceProfiles200ResponseOneOf {
+  /**
+   */
+  start: number;
+  /**
+   */
+  limit: number;
+  /**
+   */
+  total: number;
+  /**
+   */
+  self_service_profiles: Array<SsProfile>;
+}
+/**
+ *
+ */
 export interface GetSession200Response {
   [key: string]: any | any;
   /**
@@ -13318,6 +13341,95 @@ export interface PostSigningKeys201Response {
 /**
  *
  */
+export interface PostSsoTicketRequest {
+  /**
+   * If provided, this will allow editing of the provided connection during the SSO Flow
+   *
+   */
+  connection_id?: string;
+  /**
+   */
+  connection_config?: PostSsoTicketRequestConnectionConfig;
+  /**
+   * List of client_ids that the connection will be enabled for.
+   *
+   */
+  enabled_clients?: Array<string>;
+  /**
+   * List of organizations that the connection will be enabled for.
+   *
+   */
+  enabled_organizations?: Array<PostSsoTicketRequestEnabledOrganizationsInner>;
+  /**
+   * Number of seconds for which the ticket is valid before expiration. If unspecified or set to 0, this value defaults to 432000 seconds (5 days).
+   *
+   */
+  ttl_sec?: number;
+}
+/**
+ * If provided, this will create a new connection for the SSO flow with the given configuration
+ */
+export interface PostSsoTicketRequestConnectionConfig {
+  /**
+   * The name of the connection that will be created as a part of the SSO flow.
+   *
+   */
+  name: string;
+  /**
+   * Connection name used in the new universal login experience
+   *
+   */
+  display_name?: string;
+  /**
+   */
+  is_domain_connection?: boolean;
+  /**
+   * Metadata associated with the connection in the form of an object with string values (max 255 chars).  Maximum of 10 metadata properties allowed.
+   *
+   */
+  metadata?: { [key: string]: any };
+  /**
+   */
+  options?: PostSsoTicketRequestConnectionConfigOptions | null;
+}
+/**
+ * The connection's options (depend on the connection strategy)
+ */
+export interface PostSsoTicketRequestConnectionConfigOptions {
+  /**
+   * URL for the icon. Must use HTTPS.
+   *
+   */
+  icon_url?: string | null;
+  /**
+   * List of domain_aliases that can be authenticated in the Identity Provider
+   *
+   */
+  domain_aliases?: Array<string>;
+}
+/**
+ *
+ */
+export interface PostSsoTicketRequestEnabledOrganizationsInner {
+  /**
+   * Organization identifier
+   *
+   */
+  organization_id: string;
+  /**
+   * When true, all users that log in with this connection will be automatically granted membership in the organization. When false, users must be granted membership in the organization before logging in with this connection.
+   *
+   */
+  assign_membership_on_login?: boolean;
+  /**
+   * Determines whether a connection should be displayed on this organization’s login prompt. Only applicable for enterprise connections. Default: true.
+   *
+   */
+  show_as_button?: boolean;
+}
+/**
+ *
+ */
 export interface PostTestAction200Response {
   /**
    * The resulting payload after an action was executed.
@@ -14519,6 +14631,16 @@ export interface SsProfile {
    */
   id: string;
   /**
+   * The name of the self-service Profile.
+   *
+   */
+  name: string;
+  /**
+   * The description of the self-service Profile.
+   *
+   */
+  description: string;
+  /**
    * List of attributes to be mapped that will be shown to the user during the SS-SSO flow.
    *
    */
@@ -14536,7 +14658,26 @@ export interface SsProfile {
   /**
    */
   branding: SsProfileBranding;
+  /**
+   * List of IdP strategies that will be shown to users during the Self-Service SSO flow. Possible values: [`oidc`, `samlp`, `waad`, `google-apps`, `adfs`, `okta`, `keycloak-samlp`, `pingfederate`]
+   *
+   */
+  allowed_strategies: Array<SsProfileAllowedStrategiesEnum>;
 }
+
+export const SsProfileAllowedStrategiesEnum = {
+  oidc: 'oidc',
+  samlp: 'samlp',
+  waad: 'waad',
+  google_apps: 'google-apps',
+  adfs: 'adfs',
+  okta: 'okta',
+  keycloak_samlp: 'keycloak-samlp',
+  pingfederate: 'pingfederate',
+} as const;
+export type SsProfileAllowedStrategiesEnum =
+  (typeof SsProfileAllowedStrategiesEnum)[keyof typeof SsProfileAllowedStrategiesEnum];
+
 /**
  *
  */
@@ -14563,6 +14704,16 @@ export interface SsProfileBrandingColors {
  */
 export interface SsProfileCreate {
   /**
+   * The name of the self-service Profile.
+   *
+   */
+  name: string;
+  /**
+   * The description of the self-service Profile.
+   *
+   */
+  description?: string;
+  /**
    * List of attributes to be mapped that will be shown to the user during the SS-SSO flow.
    *
    */
@@ -14570,7 +14721,26 @@ export interface SsProfileCreate {
   /**
    */
   branding?: SsProfileCreateBranding;
+  /**
+   * List of IdP strategies that will be shown to users during the Self-Service SSO flow. Possible values: [`oidc`, `samlp`, `waad`, `google-apps`, `adfs`, `okta`, `keycloak-samlp`, `pingfederate`]
+   *
+   */
+  allowed_strategies?: Array<SsProfileCreateAllowedStrategiesEnum>;
 }
+
+export const SsProfileCreateAllowedStrategiesEnum = {
+  oidc: 'oidc',
+  samlp: 'samlp',
+  waad: 'waad',
+  google_apps: 'google-apps',
+  adfs: 'adfs',
+  okta: 'okta',
+  keycloak_samlp: 'keycloak-samlp',
+  pingfederate: 'pingfederate',
+} as const;
+export type SsProfileCreateAllowedStrategiesEnum =
+  (typeof SsProfileCreateAllowedStrategiesEnum)[keyof typeof SsProfileCreateAllowedStrategiesEnum];
+
 /**
  *
  */
@@ -14586,11 +14756,17 @@ export interface SsProfileCreateBranding {
 /**
  *
  */
-export interface SsProfileList extends Array<SsProfile> {}
-/**
- *
- */
 export interface SsProfileUpdate {
+  /**
+   * The name of the self-service Profile.
+   *
+   */
+  name?: string;
+  /**
+   * The description of the self-service Profile.
+   *
+   */
+  description?: string | null;
   /**
    * List of attributes to be mapped that will be shown to the user during the SS-SSO flow.
    *
@@ -14599,7 +14775,26 @@ export interface SsProfileUpdate {
   /**
    */
   branding?: SsProfileUpdateBranding | null;
+  /**
+   * List of IdP strategies that will be shown to users during the Self-Service SSO flow. Possible values: [`oidc`, `samlp`, `waad`, `google-apps`, `adfs`, `okta`, `keycloak-samlp`, `pingfederate`]
+   *
+   */
+  allowed_strategies?: Array<SsProfileUpdateAllowedStrategiesEnum>;
 }
+
+export const SsProfileUpdateAllowedStrategiesEnum = {
+  oidc: 'oidc',
+  samlp: 'samlp',
+  waad: 'waad',
+  google_apps: 'google-apps',
+  adfs: 'adfs',
+  okta: 'okta',
+  keycloak_samlp: 'keycloak-samlp',
+  pingfederate: 'pingfederate',
+} as const;
+export type SsProfileUpdateAllowedStrategiesEnum =
+  (typeof SsProfileUpdateAllowedStrategiesEnum)[keyof typeof SsProfileUpdateAllowedStrategiesEnum];
+
 /**
  *
  */
@@ -18705,6 +18900,65 @@ export interface DeleteSelfServiceProfilesByIdRequest {
    */
   id: string;
 }
+
+/**
+ *
+ */
+export const GetSelfServiceProfileCustomTextLanguageEnum = {
+  en: 'en',
+} as const;
+export type GetSelfServiceProfileCustomTextLanguageEnum =
+  (typeof GetSelfServiceProfileCustomTextLanguageEnum)[keyof typeof GetSelfServiceProfileCustomTextLanguageEnum];
+
+/**
+ *
+ */
+export const GetSelfServiceProfileCustomTextPageEnum = {
+  get_started: 'get-started',
+} as const;
+export type GetSelfServiceProfileCustomTextPageEnum =
+  (typeof GetSelfServiceProfileCustomTextPageEnum)[keyof typeof GetSelfServiceProfileCustomTextPageEnum];
+
+/**
+ *
+ */
+export interface GetSelfServiceProfileCustomTextRequest {
+  /**
+   * The id of the self-service profile.
+   *
+   */
+  id: string;
+  /**
+   * The language of the custom text.
+   *
+   */
+  language: GetSelfServiceProfileCustomTextLanguageEnum;
+  /**
+   * The page where the custom text is shown.
+   *
+   */
+  page: GetSelfServiceProfileCustomTextPageEnum;
+}
+/**
+ *
+ */
+export interface GetSelfServiceProfilesRequest {
+  /**
+   * Page index of the results to return. First page is 0.
+   *
+   */
+  page?: number;
+  /**
+   * Number of results per page. Defaults to 50.
+   *
+   */
+  per_page?: number;
+  /**
+   * Return results inside an object that contains the total result count (true) or as a direct array of results (false, default).
+   *
+   */
+  include_totals?: boolean;
+}
 /**
  *
  */
@@ -18728,12 +18982,66 @@ export interface PatchSelfServiceProfilesByIdRequest {
 /**
  *
  */
-export interface PostSsoTicketRequest {
+export interface PostRevokeRequest {
   /**
-   * The id of the sso-profile to retrieve
+   * The id of the self-service profile
+   *
+   */
+  profileId: string;
+  /**
+   * The id of the ticket to revoke
    *
    */
   id: string;
+}
+/**
+ *
+ */
+export interface PostSsoTicketOperationRequest {
+  /**
+   * The id of the self-service profile to retrieve
+   *
+   */
+  id: string;
+}
+
+/**
+ *
+ */
+export const PutSelfServiceProfileCustomTextLanguageEnum = {
+  en: 'en',
+} as const;
+export type PutSelfServiceProfileCustomTextLanguageEnum =
+  (typeof PutSelfServiceProfileCustomTextLanguageEnum)[keyof typeof PutSelfServiceProfileCustomTextLanguageEnum];
+
+/**
+ *
+ */
+export const PutSelfServiceProfileCustomTextPageEnum = {
+  get_started: 'get-started',
+} as const;
+export type PutSelfServiceProfileCustomTextPageEnum =
+  (typeof PutSelfServiceProfileCustomTextPageEnum)[keyof typeof PutSelfServiceProfileCustomTextPageEnum];
+
+/**
+ *
+ */
+export interface PutSelfServiceProfileCustomTextRequest {
+  /**
+   * The id of the self-service profile.
+   *
+   */
+  id: string;
+  /**
+   * The language of the custom text.
+   *
+   */
+  language: PutSelfServiceProfileCustomTextLanguageEnum;
+  /**
+   * The page where the custom text is shown.
+   *
+   */
+  page: PutSelfServiceProfileCustomTextPageEnum;
 }
 /**
  *

--- a/test/management/self-service-profiles.test.ts
+++ b/test/management/self-service-profiles.test.ts
@@ -108,6 +108,6 @@ describe('selfServiceProfilesManager', () => {
     const uri = `/self-service-profiles/profile1/sso-ticket/id1/revoke`;
     const method = 'post';
 
-    checkMethod({ operation, uri, method, expectedResponse: {} });
+    checkMethod({ operation, uri, method, expectedResponse: '{}' });
   });
 });

--- a/test/management/self-service-profiles.test.ts
+++ b/test/management/self-service-profiles.test.ts
@@ -1,314 +1,113 @@
-import nock from 'nock';
-
-const DOMAIN = `tenant.auth0.com`;
-const API_URL = `https://${DOMAIN}/api/v2`;
-
 import {
-  DeleteSelfServiceProfilesByIdRequest,
-  GetSelfServiceProfilesByIdRequest,
   ManagementClient,
-  PatchSelfServiceProfilesByIdRequest,
-  PostSsoTicketRequest,
   SelfServiceProfilesManager,
-  SsoAccessTicketResponse,
-  SsoTicketRequestJson,
-  SsProfile,
   SsProfileCreate,
-  SsProfileList,
   SsProfileUpdate,
 } from '../../src/index.js';
+import { checkMethod, CheckMethodParams } from './tests.util.js';
 
-describe('SelfServiceProfilesManager', () => {
-  let selfServiceProfileManager: SelfServiceProfilesManager;
-  let nockedRequest: nock.Scope;
-  const token = 'TOKEN';
+const DOMAIN = `tenant.auth0.com`;
+const token = 'TOKEN';
 
-  beforeAll(() => {
-    const client = new ManagementClient({
-      domain: DOMAIN,
-      token: token,
-    });
-    selfServiceProfileManager = client.selfServiceProfiles;
+describe('selfServiceProfilesManager', () => {
+  const flowsManager: SelfServiceProfilesManager = new ManagementClient({ domain: DOMAIN, token })
+    .selfServiceProfiles;
+
+  const dummyBody: SsProfileCreate = {
+    name: 'profileName',
+    description: 'description',
+    allowed_strategies: ['oidc', 'samlp'],
+    user_attributes: [{ name: 'name', description: 'description', is_optional: false }],
+    branding: {
+      logo_url: 'logoUrl',
+      colors: { primary: 'primary', page_background: 'pageBackground' },
+    },
+  };
+
+  // this is the test for the method flowsManager.create
+  describe('create', () => {
+    const operation = flowsManager.create(dummyBody);
+    const uri = `/self-service-profiles`;
+    const method = 'post';
+
+    checkMethod({ operation, uri, method });
   });
 
-  describe('createSelfServiceProfiles', () => {
-    const requestBody: SsProfileCreate | any = {
-      user_attributes: [{ name: 'testAttribute', description: 'testAttribute', is_optional: true }],
-      branding: { logo_url: 'https://example.com', colors: { primary: '#1c1c1c' } },
-    };
+  // this is the test for the method flowsManager.update
+  describe('update', () => {
+    const operation = flowsManager.update({ id: 'profile1' }, dummyBody);
+    const uri = `/self-service-profiles/profile1`;
+    const method = 'patch';
 
-    it('should return a promise if no callback is given', (done) => {
-      selfServiceProfileManager
-        .postSelfServiceProfiles(requestBody)
-        .then(done.bind(null, null))
-        .catch(done.bind(null, null));
-    });
-
-    it('should pass any errors to the promise catch handler', () => {
-      nock.cleanAll();
-
-      nock(API_URL).post('/self-service-profiles').reply(500, {});
-
-      return selfServiceProfileManager.postSelfServiceProfiles(requestBody).catch((err) => {
-        expect(err).toBeDefined();
-      });
-    });
-
-    // this test is for the method postSelfServiceProfiles, uses SsProfileCreate as body
-    it('should return the created self-service profile', async () => {
-      const nockedResponse: SsProfile = {
-        id: 'testing_id_123',
-        user_attributes: [
-          { name: 'testAttribute', description: 'testAttribute', is_optional: true },
-        ],
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-        branding: { logo_url: 'https://example.com', colors: { primary: '#1c1c1c' } },
-      };
-
-      // eslint-disable-next-line prettier/prettier
-      nockedRequest = nock(API_URL)
-        .post('/self-service-profiles', requestBody)
-        .reply(200, nockedResponse);
-
-      const createResult = await selfServiceProfileManager.postSelfServiceProfiles(requestBody);
-
-      expect(createResult.data).toEqual(nockedResponse);
-    });
+    checkMethod({ operation, uri, method });
   });
 
-  describe('getSelfServiceProfiles', () => {
-    it('should return a promise if no callback is given', (done) => {
-      selfServiceProfileManager
-        .getSelfServiceProfiles()
-        .then(done.bind(null, null))
-        .catch(done.bind(null, null));
-    });
+  // this is the test for the method flowsManager.delete
+  describe('delete', () => {
+    const operation = flowsManager.delete({ id: 'profile1' });
+    const uri = `/self-service-profiles/profile1`;
+    const method = 'delete';
 
-    it('should pass any errors to the promise catch handler', () => {
-      nock.cleanAll();
-
-      nock(API_URL).get('/self-service-profiles').reply(500, {});
-
-      return selfServiceProfileManager.getSelfServiceProfiles().catch((err) => {
-        expect(err).toBeDefined();
-      });
-    });
-
-    // this unit test is for the getSelfServiceProfiles() method
-    it('should return the list of self-service profiles', async () => {
-      const exampleData: SsProfile = {
-        id: 'testing_id_123',
-        user_attributes: [
-          { name: 'testAttribute', description: 'testAttribute', is_optional: true },
-        ],
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-        branding: { logo_url: 'https://example.com', colors: { primary: '#1c1c1c' } },
-      };
-
-      const nockedResponse: SsProfileList = [exampleData];
-
-      // eslint-disable-next-line prettier/prettier
-      nockedRequest = nock(API_URL).get('/self-service-profiles').reply(200, nockedResponse);
-
-      const getResult = await selfServiceProfileManager.getSelfServiceProfiles();
-
-      expect(getResult.data).toEqual(nockedResponse);
-      expect(getResult.data.length).toBeGreaterThan(0);
-    });
+    checkMethod({ operation, uri, method });
   });
 
-  describe('getSelfServiceProfilesById', () => {
-    const requestParameters: GetSelfServiceProfilesByIdRequest = {
-      id: 'testing_id_123',
-    };
+  // this is the test for the method flowsManager.get
+  describe('get', () => {
+    const operation = flowsManager.get({ id: 'profile1' });
+    const uri = `/self-service-profiles/profile1`;
+    const method = 'get';
 
-    it('should return a promise if no callback is given', (done) => {
-      selfServiceProfileManager
-        .getSelfServiceProfilesById(requestParameters)
-        .then(done.bind(null, null))
-        .catch(done.bind(null, null));
-    });
-
-    it('should pass any errors to the promise catch handler', () => {
-      nock.cleanAll();
-
-      nock(API_URL).get(`/self-service-profiles/${requestParameters.id}`).reply(500, {});
-
-      return selfServiceProfileManager
-        .getSelfServiceProfilesById(requestParameters)
-        .catch((err) => {
-          expect(err).toBeDefined();
-        });
-    });
-
-    // this unit test is for the getSelfServiceProfileById() method
-    it('should return one of self-service profile by id', async () => {
-      const nockedResponse: SsProfile = {
-        id: 'testing_id_123',
-        user_attributes: [
-          { name: 'testAttribute', description: 'testAttribute', is_optional: true },
-        ],
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-        branding: { logo_url: 'https://example.com', colors: { primary: '#1c1c1c' } },
-      };
-
-      nock.cleanAll();
-      // eslint-disable-next-line prettier/prettier
-      nockedRequest = nock(API_URL)
-        .get(`/self-service-profiles/${requestParameters.id}`)
-        .reply(200, nockedResponse);
-
-      const getResult = await selfServiceProfileManager.getSelfServiceProfilesById(
-        requestParameters
-      );
-      expect(getResult.data).toEqual(nockedResponse);
-    });
+    checkMethod({ operation, uri, method });
   });
 
-  describe('deleteSelfServiceProfiles', () => {
-    const requestParameters: DeleteSelfServiceProfilesByIdRequest = {
-      id: 'testing_id_123',
-    };
+  // this is the test for the method flowsManager.getAll
+  describe('getAll', () => {
+    const operation = flowsManager.getAll();
+    const uri = `/self-service-profiles`;
+    const method = 'get';
 
-    it('should return a promise if no callback is given', (done) => {
-      selfServiceProfileManager
-        .deleteSelfServiceProfiles(requestParameters)
-        .then(done.bind(null, null))
-        .catch(done.bind(null, null));
-    });
-
-    it('should pass any errors to the promise catch handler', () => {
-      nock.cleanAll();
-
-      nock(API_URL).get(`/self-service-profiles/${requestParameters.id}`).reply(500, {});
-
-      return selfServiceProfileManager.deleteSelfServiceProfiles(requestParameters).catch((err) => {
-        expect(err).toBeDefined();
-      });
-    });
-
-    // this unit test is for the deleteSelfServiceProfiles() method
-    it('should delete one of self-service profile by id', async () => {
-      // eslint-disable-next-line prettier/prettier
-      nockedRequest = nock(API_URL)
-        .delete(`/self-service-profiles/${requestParameters.id}`)
-        .reply(200);
-
-      await selfServiceProfileManager.deleteSelfServiceProfiles(requestParameters);
-
-      expect(nockedRequest.isDone()).toBe(true);
-    });
+    checkMethod({ operation, uri, method });
   });
 
-  describe('patchSelfServiceProfiles', () => {
-    const requestParameters: PatchSelfServiceProfilesByIdRequest = {
-      id: 'testing_id_123',
-    };
-    const requestBody: SsProfileUpdate = {
-      user_attributes: [
-        { name: 'modifiedTestAttribute', description: 'modifiedTestAttribute', is_optional: true },
-      ],
-      branding: { logo_url: 'https://example.com', colors: { primary: '#ff00ff' } },
-    };
+  // this is the test for the method flowsManager.updateCustomText
+  describe('updateCustomText', () => {
+    const operation = flowsManager.updateCustomText(
+      { id: 'profile1', language: 'en', page: 'get-started' },
+      { custom_text: 'new custom text' }
+    );
+    const uri = `/self-service-profiles/profile1/custom-text/en/get-started`;
+    const method = 'put';
 
-    it('should return a promise if no callback is given', (done) => {
-      selfServiceProfileManager
-        .patchSelfServiceProfiles(requestParameters, requestBody)
-        .then(done.bind(null, null))
-        .catch(done.bind(null, null));
-    });
-
-    it('should pass any errors to the promise catch handler', () => {
-      nock.cleanAll();
-
-      nock(API_URL).patch(`/self-service-profiles/${requestParameters.id}`).reply(500, {});
-
-      return selfServiceProfileManager
-        .patchSelfServiceProfiles(requestParameters, requestBody)
-        .catch((err) => {
-          expect(err).toBeDefined();
-        });
-    });
-
-    // this unit test is for the patchSelfServiceProfiles() method
-    it('should update one of self-service profile by id', async () => {
-      const nockedResponse: SsProfile = {
-        id: requestParameters.id,
-        user_attributes: [
-          {
-            name: 'modifiedTestAttribute',
-            description: 'modifiedTestAttribute',
-            is_optional: true,
-          },
-        ],
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-        branding: { logo_url: 'https://example.com', colors: { primary: '#ff00ff' } },
-      };
-
-      // eslint-disable-next-line prettier/prettier
-      nockedRequest = nock(API_URL)
-        .patch(`/self-service-profiles/${requestParameters.id}`)
-        .reply(200, nockedResponse);
-
-      const patchResult = await selfServiceProfileManager.patchSelfServiceProfiles(
-        requestParameters,
-        requestBody
-      );
-
-      expect(patchResult.data).toEqual(nockedResponse);
-    });
+    checkMethod({ operation, uri, method });
   });
 
-  describe('postSsoTicket', () => {
-    const requestParameters: PostSsoTicketRequest = {
-      id: 'testing_id_123',
-    };
-    const requestBody: SsoTicketRequestJson = {
-      connection_id: 'connection_id',
-      connection_config: { name: 'test_connection_config' },
-      enabled_clients: ['client1'],
-      enabled_organizations: [{ organization_id: requestParameters.id }],
-    };
+  // this is the test for the method flowsManager.createSsoTicket
+  describe('createSsoTicket', () => {
+    const operation = flowsManager.createSsoTicket(
+      { id: 'id1' },
+      {
+        connection_id: 'connection1',
+        connection_config: {
+          name: 'config1',
+          display_name: 'config1',
+          is_domain_connection: false,
+          metadata: {},
+          options: null,
+        },
+      }
+    );
+    const uri = `/self-service-profiles/id1/sso-ticket`;
+    const method = 'post';
 
-    it('should return a promise if no callback is given', (done) => {
-      selfServiceProfileManager
-        .postSsoTicket(requestParameters, requestBody)
-        .then(done.bind(null, null))
-        .catch(done.bind(null, null));
-    });
+    checkMethod({ operation, uri, method });
+  });
 
-    it('should pass any errors to the promise catch handler', () => {
-      nock.cleanAll();
+  // this is the test for the method flowsManager.revokeSsoTicket
+  describe('revokeSsoTicket', () => {
+    const operation = flowsManager.revokeSsoTicket({ profileId: 'profile1', id: 'id1' });
+    const uri = `/self-service-profiles/profile1/sso-ticket/id1/revoke`;
+    const method = 'post';
 
-      nock(API_URL)
-        .post(`/self-service-profiles/${requestParameters.id}/sso-ticket`)
-        .reply(500, {});
-
-      return selfServiceProfileManager
-        .postSsoTicket(requestParameters, requestBody)
-        .catch((err) => {
-          expect(err).toBeDefined();
-        });
-    });
-
-    // this unit test is for the postSsoTicket() method
-    it('should set sso ticket for one sso profile', async () => {
-      const nockedResponse: SsoAccessTicketResponse = {
-        ticket: 'https://example.com/ticket',
-      };
-
-      // eslint-disable-next-line prettier/prettier
-      nockedRequest = nock(API_URL)
-        .post(`/self-service-profiles/${requestParameters.id}/sso-ticket`)
-        .reply(200, nockedResponse);
-
-      const result = await selfServiceProfileManager.postSsoTicket(requestParameters, requestBody);
-
-      expect(result.data).toEqual(nockedResponse);
-    });
+    checkMethod({ operation, uri, method, expectedResponse: {} });
   });
 });

--- a/test/management/self-service-profiles.test.ts
+++ b/test/management/self-service-profiles.test.ts
@@ -1,10 +1,5 @@
-import {
-  ManagementClient,
-  SelfServiceProfilesManager,
-  SsProfileCreate,
-  SsProfileUpdate,
-} from '../../src/index.js';
-import { checkMethod, CheckMethodParams } from './tests.util.js';
+import { ManagementClient, SelfServiceProfilesManager, SsProfileCreate } from '../../src/index.js';
+import { checkMethod } from './tests.util.js';
 
 const DOMAIN = `tenant.auth0.com`;
 const token = 'TOKEN';


### PR DESCRIPTION
### Changes

Updated SelfServiceProfilesManager method names

| Path | HTTP Method | Method Name |
| --- | --- | --- |
| /self-service-profiles | GET | getAll |
| /self-service-profiles | POST | create |
| /self-service-profiles/{id} | GET | get |
| /self-service-profiles/{id} | DELETE | delete |
| /self-service-profiles/{id} | PATCH | update |
| /self-service-profiles/{id}/sso-ticket | POST | createSsoTicket |
| /self-service-profiles/{id}/custom-text/{language}/{page} | GET | getCustomText |
| /self-service-profiles/{id}/custom-text/{language}/{page} | PUT | updateCustomText |
| /self-service-profiles/{profileId}/sso-ticket/{id}/revoke | POST | revokeSsoTicket |

More details below:  

#### Modified: `POST /api/v2/self-service-profiles`

- **New Query Parameters:**
  - **`name`** (string) **Required**  
    - *Length:* `1 <= length <= 100`  
    - Description: The name of the self-service profile.

  - **`description`** (string)  
    - *Length:* `1 <= length <= 140`  
    - Description: The description of the self-service profile.

  - **`allowed_strategies`** (string[])  
    - Description: List of IdP strategies shown to users during the Self-Service SSO flow.  
    - Possible values: [`oidc`, `samlp`, `waad`, `google-apps`, `adfs`, `okta`, `keycloak-samlp`, `pingfederate`]

---

#### New: `PUT /api/v2/self-service-profiles/{id}/custom-text/{language}/{page}`

Updates text customizations for a given self-service profile, language, and Self-Service SSO flow page.

- **Scope:** `update:self_service_profile_custom_texts`

- **Path Parameters:**
  - **`id`** (string) **Required**: The ID of the self-service profile.  
  - **`language`** (string) **Required**: The language of the custom text.  
  - **`page`** (string) **Required**: The page where the custom text is shown.

- **Body Parameters:**
  - Returns an object containing key/value pairs.  
  - Contains text keys and values for customizing the self-service SSO page. Values can be plain text or rich HTML (limited to basic styling tags and hyperlinks).  
  - Each value can be up to 2000 characters.  
  - Currently supported languages: `en`.  
  - Supported pages: `get-started`.  
  - Supported keys for `get-started`: `introduction`.

> **Note:** Language, page, and key support can change at any time and should be treated as text fields from the SDK's perspective.

---

#### New: `GET /api/v2/self-service-profiles/{id}/custom-text/{language}/{page}`

Retrieves custom text for a self-service profile.

- **Scope:** `read:self_service_profile_custom_texts`

- **Path Parameters:**
  - **`id`** (string) **Required**: The ID of the self-service profile.  
  - **`language`** (string) **Required**: The language of the custom text.  
  - **`page`** (string) **Required**: The page where the custom text is shown.

- **Response:** Returns a list of key/value pairs, or an empty object `{}` if none are set.

---

#### Modified: `POST /api/v2/self-service-profiles/{id}/sso-ticket`

- **New Query Parameters:** When creating a new SSO ticket, the following optional parameters are supported:

  - **Connections:**
    - `domain_aliases`
    - `display_name`
    - `is_domain_connection`
    - `show_as_button`
    - `metadata`
    - `icon_url`

  - **Organizations:**
    - `assign_membership_on_login`
    - `show_as_button`

  - **`ttl_sec`**  
    - Maximum: 5 days.  
    - Default: 5 days (432,000 seconds) if not specified.

- **Sample Request Body:**

  ```json
  {
    "connection_config": {
      "name": "string",
      "display_name": "string",
      "is_domain_connection": true,
      "show_as_button": true,
      "metadata": {
        "key1": "value1",
        "key2": "value2"
      },
      "options": {
        "icon_url": "string",
        "domain_aliases": ["acme.corp", "okta.com"]
      }
    },
    "enabled_clients": ["string"],
    "enabled_organizations": [
      {
        "organization_id": "string",
        "assign_membership_on_login": true,
        "show_as_button": true
      }
    ],
    "ttl_sec": 0
  }

#### New: `POST /api/v2/self-service-profiles/{id}/sso-ticket/{id}/revoke`


- **Scope:** `delete:sso_access_tickets`

- **Description:**  
  Revokes a ticket.  

  - Returns `202 Accepted` with no body content.


### References

https://auth0.com/docs/api/management/v2/self-service-profiles/get-self-service-profiles

### Testing

We will release guides to use this features separately that can help in manual testing.

```
Test Suites: 43 passed, 43 total
Tests:       1413 passed, 1413 total
Snapshots:   0 total
Time:        6.702 s
```

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
