### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This client can be used to access Auth0's [Authentication API](https://auth0.com
 import { AuthenticationClient } from 'auth0';
 
 const auth0 = new AuthenticationClient({
-  domain: '{YOUR_ACCOUNT}.auth0.com',
+  domain: '{YOUR_TENANT_AND REGION}.auth0.com',
   clientId: '{OPTIONAL_CLIENT_ID}',
   clientSecret: '{OPTIONAL_CLIENT_SECRET}',
 });


### PR DESCRIPTION
### Changes

Updated README for the Authentication API Client example in Configure the SDK section.

Earlier the domain field in the Constructor initialization had just the tenant name and not the region which was inconsistent with `AuthenticationClient`'s  [more examples](https://github.com/auth0/node-auth0/blob/master/EXAMPLES.md#authentication-client)

This was slightly misleading for me. Thought I could fix it for others.
