### PR TITLE
accept a function as token

### DIFF
--- a/src/management/management-client-options.ts
+++ b/src/management/management-client-options.ts
@@ -6,7 +6,7 @@ export interface ManagementClientOptions extends ClientOptions {
 }
 
 export interface ManagementClientOptionsWithToken extends ManagementClientOptions {
-  token: string;
+  token: string | (() => Promise<string>) | (() => string);
 }
 
 export interface ManagementClientOptionsWithClientSecret extends ManagementClientOptions {

--- a/src/management/token-provider-middleware.ts
+++ b/src/management/token-provider-middleware.ts
@@ -7,14 +7,16 @@ import {
 } from './management-client-options.js';
 import { TokenProvider } from './token-provider.js';
 
+import { resolveValueToPromise } from '../utils.js';
+
 export class TokenProviderMiddleware implements Middleware {
-  private tokenProvider: { getAccessToken: () => Promise<string> };
+  private readonly tokenProvider: { getAccessToken: () => Promise<string> };
   constructor(
     options: ManagementClientOptionsWithToken | ManagementClientOptionsWithClientCredentials
   ) {
     if ('token' in options) {
       this.tokenProvider = {
-        getAccessToken: () => Promise.resolve(options.token),
+        getAccessToken: () => resolveValueToPromise<string>(options.token),
       };
     } else {
       this.tokenProvider = new TokenProvider({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,3 +15,25 @@ export const generateClientInfo = () => ({
  * @private
  */
 export const mtlsPrefix = 'mtls';
+
+type SyncGetter<T> = () => T;
+type AsyncGetter<T> = () => Promise<T>;
+/**
+ * Resolves a value that can be a static value, a synchronous function, or an asynchronous function.
+ *
+ * @template T - The type of the value to be resolved.
+ * @param {T | SyncGetter<T> | AsyncGetter<T>} value - The value to be resolved. It can be:
+ *   - A static value of type T.
+ *   - A synchronous function that returns a value of type T.
+ *   - An asynchronous function that returns a Promise of type T.
+ * @returns {Promise<T>} A promise that resolves to the value of type T.
+ */
+export const resolveValueToPromise = async <T>(
+  value: T | SyncGetter<T> | AsyncGetter<T>
+): Promise<T> => {
+  if (typeof value === 'function') {
+    const result = (value as SyncGetter<T> | AsyncGetter<T>)(); // Call the function
+    return result instanceof Promise ? result : Promise.resolve(result); // Handle sync/async
+  }
+  return Promise.resolve(value); // Static value
+};

--- a/test/lib/utils.test.ts
+++ b/test/lib/utils.test.ts
@@ -1,0 +1,23 @@
+import { resolveValueToPromise } from '../../src/utils.js';
+
+describe('resolveValueToPromise', () => {
+  it('should resolve a static string value', async () => {
+    const value = 'staticValue';
+    const result = await resolveValueToPromise(value);
+    expect(result).toBe(value);
+  });
+
+  it('should resolve a synchronous function returning a string', async () => {
+    const value = 'syncValue';
+    const syncFunction = () => value;
+    const result = await resolveValueToPromise(syncFunction);
+    expect(result).toBe(value);
+  });
+
+  it('should resolve an asynchronous function returning a string', async () => {
+    const value = 'asyncValue';
+    const asyncFunction = async () => value;
+    const result = await resolveValueToPromise(asyncFunction);
+    expect(result).toBe(value);
+  });
+});

--- a/test/management/token-provider-middleware.test.ts
+++ b/test/management/token-provider-middleware.test.ts
@@ -99,4 +99,59 @@ describe('TokenProviderMiddleware', () => {
     ).resolves.toMatchObject({});
     expect(customFetch).toHaveBeenCalled();
   });
+
+  it('should use provided access token as a string', async () => {
+    await expect(tokenClient.testRequest({ path: '/foo', method: 'GET' })).resolves.toMatchObject(
+      {}
+    );
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorization: 'Bearer token',
+      })
+    );
+  });
+
+  it('should use provided access token as a sync function', async () => {
+    const syncTokenClient = new TestClient({
+      ...opts,
+      middleware: [
+        new TokenProviderMiddleware({
+          ...opts,
+          domain,
+          token: () => 'sync-token',
+        }),
+      ],
+    });
+
+    await expect(
+      syncTokenClient.testRequest({ path: '/foo', method: 'GET' })
+    ).resolves.toMatchObject({});
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorization: 'Bearer sync-token',
+      })
+    );
+  });
+
+  it('should use provided access token as an async function', async () => {
+    const asyncTokenClient = new TestClient({
+      ...opts,
+      middleware: [
+        new TokenProviderMiddleware({
+          ...opts,
+          domain,
+          token: async () => 'async-token',
+        }),
+      ],
+    });
+
+    await expect(
+      asyncTokenClient.testRequest({ path: '/foo', method: 'GET' })
+    ).resolves.toMatchObject({});
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorization: 'Bearer async-token',
+      })
+    );
+  });
 });


### PR DESCRIPTION
Allow a sync/async function as token.

### Changes
- Modified management client options and management client middleware to accept a function as a token.

### Context
This was removed in [this commit](https://github.com/auth0/node-auth0/commit/d5902d740b533e9830a4f9222daf9eb20f93719d)

Fixes #1050 

### Tests:
*PASSING*
```
Test Suites: 45 passed, 45 total
Tests:       1441 passed, 1441 total
Snapshots:   0 total
Time:        6.842 s, estimated 7 s
Ran all test suites.
```

Sample:
```typescript
const managementClient: ManagementClient = new ManagementClient({
    domain: `testdomain`,
    token: async () => 'testtoken',
});
```