### PR TITLE
feature/customEmailProvider

### DIFF
--- a/src/management/__generated/managers/emails-manager.ts
+++ b/src/management/__generated/managers/emails-manager.ts
@@ -48,10 +48,46 @@ export class EmailsManager extends BaseAPI {
   }
 
   /**
-   * Update an <a href="https://auth0.com/docs/email/providers">email provider</a>.
-   * The <code>credentials</code> object requires different properties depending on the email provider (which is specified using the <code>name</code> property):
-   * <ul><li><code>mandrill</code> requires <code>api_key</code></li><li><code>sendgrid</code> requires <code>api_key</code></li><li><code>sparkpost</code> requires <code>api_key</code>. Optionally, set <code>region</code> to <code>eu</code> to use the SparkPost service hosted in Western Europe; set to <code>null</code> to use the SparkPost service hosted in North America. <code>eu</code> or <code>null</code> are the only valid values for <code>region</code>.</li><li><code>mailgun</code> requires <code>api_key</code> and <code>domain</code>. Optionally, set <code>region</code> to <code>eu</code> to use the Mailgun service hosted in Europe; set to <code>null</code> otherwise. <code>eu</code> or <code>null</code> are the only valid values for <code>region</code>.</li><li><code>ses</code> requires <code>accessKeyId</code>, <code>secretAccessKey</code>, and <code>region</code></li><li><code>smtp</code> requires <code>smtp_host</code>, <code>smtp_port</code>, <code>smtp_user</code>, and <code>smtp_pass</code></li></ul>Depending on the type of provider it is possible to specify <code>settings</code> object with different configuration options, which will be used when sending an email:
-   * <ul><li><code>smtp</code> provider, <code>settings</code> may contain <code>headers</code> object. When using AWS SES SMTP host, you may provide a name of configuration set in <code>X-SES-Configuration-Set</code> header. Value must be a string.</li><li>for <code>ses</code> provider, <code>settings</code> may contain <code>message</code> object, where you can provide a name of configuration set in <code>configuration_set_name</code> property. Value must be a string.</li></ul>
+   * Update an <a href="https://auth0.com/docs/email/providers">email provider</a>. The <code>credentials</code> object
+   * requires different properties depending on the email provider (which is specified using the <code>name</code> property):
+   * <ul>
+   *   <li><code>mandrill</code> requires <code>api_key</code></li>
+   *   <li><code>sendgrid</code> requires <code>api_key</code></li>
+   *   <li>
+   *     <code>sparkpost</code> requires <code>api_key</code>. Optionally, set <code>region</code> to <code>eu</code> to use
+   *     the SparkPost service hosted in Western Europe; set to <code>null</code> to use the SparkPost service hosted in
+   *     North America. <code>eu</code> or <code>null</code> are the only valid values for <code>region</code>.
+   *   </li>
+   *   <li>
+   *     <code>mailgun</code> requires <code>api_key</code> and <code>domain</code>. Optionally, set <code>region</code> to
+   *     <code>eu</code> to use the Mailgun service hosted in Europe; set to <code>null</code> otherwise. <code>eu</code> or
+   *     <code>null</code> are the only valid values for <code>region</code>.
+   *   </li>
+   *   <li><code>ses</code> requires <code>accessKeyId</code>, <code>secretAccessKey</code>, and <code>region</code></li>
+   *   <li>
+   *     <code>smtp</code> requires <code>smtp_host</code>, <code>smtp_port</code>, <code>smtp_user</code>, and
+   *     <code>smtp_pass</code>
+   *   </li>
+   * </ul>
+   * Depending on the type of provider it is possible to specify <code>settings</code> object with different configuration
+   * options, which will be used when sending an email:
+   * <ul>
+   *   <li>
+   *     <code>smtp</code> provider, <code>settings</code> may contain <code>headers</code> object.
+   *     <ul>
+   *       <li>
+   *         When using AWS SES SMTP host, you may provide a name of configuration set in
+   *         <code>X-SES-Configuration-Set</code> header. Value must be a string.
+   *       </li>
+   *       <li>
+   *         When using Sparkpost host, you may provide value for
+   *         <code>X-MSYS_API</code> header. Value must be an object.
+   *       </li>
+   *     </ul>
+   *     for <code>ses</code> provider, <code>settings</code> may contain <code>message</code> object, where you can provide
+   *     a name of configuration set in <code>configuration_set_name</code> property. Value must be a string.
+   *   </li>
+   * </ul>
    *
    * Update the email provider
    *
@@ -79,10 +115,48 @@ export class EmailsManager extends BaseAPI {
   }
 
   /**
-   * Create an <a href="https://auth0.com/docs/email/providers">email provider</a>.
-   * The <code>credentials</code> object requires different properties depending on the email provider (which is specified using the <code>name</code> property):
-   * <ul><li><code>mandrill</code> requires <code>api_key</code></li><li><code>sendgrid</code> requires <code>api_key</code></li><li><code>sparkpost</code> requires <code>api_key</code>. Optionally, set <code>region</code> to <code>eu</code> to use the SparkPost service hosted in Western Europe; set to <code>null</code> to use the SparkPost service hosted in North America. <code>eu</code> or <code>null</code> are the only valid values for <code>region</code>.</li><li><code>mailgun</code> requires <code>api_key</code> and <code>domain</code>. Optionally, set <code>region</code> to <code>eu</code> to use the Mailgun service hosted in Europe; set to <code>null</code> otherwise. <code>eu</code> or <code>null</code> are the only valid values for <code>region</code>.</li><li><code>ses</code> requires <code>accessKeyId</code>, <code>secretAccessKey</code>, and <code>region</code></li><li><code>smtp</code> requires <code>smtp_host</code>, <code>smtp_port</code>, <code>smtp_user</code>, and <code>smtp_pass</code></li></ul>Depending on the type of provider it is possible to specify <code>settings</code> object with different configuration options, which will be used when sending an email:
-   * <ul><li><code>smtp</code> provider, <code>settings</code> may contain <code>headers</code> object. When using AWS SES SMTP host, you may provide a name of configuration set in <code>X-SES-Configuration-Set</code> header. Value must be a string.</li><li>for <code>ses</code> provider, <code>settings</code> may contain <code>message</code> object, where you can provide a name of configuration set in <code>configuration_set_name</code> property. Value must be a string.</li></ul>
+   * Create an <a href="https://auth0.com/docs/email/providers">email provider</a>. The <code>credentials</code> object
+   * requires different properties depending on the email provider (which is specified using the <code>name</code> property):
+   * <ul>
+   *   <li><code>mandrill</code> requires <code>api_key</code></li>
+   *   <li><code>sendgrid</code> requires <code>api_key</code></li>
+   *   <li>
+   *     <code>sparkpost</code> requires <code>api_key</code>. Optionally, set <code>region</code> to <code>eu</code> to use
+   *     the SparkPost service hosted in Western Europe; set to <code>null</code> to use the SparkPost service hosted in
+   *     North America. <code>eu</code> or <code>null</code> are the only valid values for <code>region</code>.
+   *   </li>
+   *   <li>
+   *     <code>mailgun</code> requires <code>api_key</code> and <code>domain</code>. Optionally, set <code>region</code> to
+   *     <code>eu</code> to use the Mailgun service hosted in Europe; set to <code>null</code> otherwise. <code>eu</code> or
+   *     <code>null</code> are the only valid values for <code>region</code>.
+   *   </li>
+   *   <li><code>ses</code> requires <code>accessKeyId</code>, <code>secretAccessKey</code>, and <code>region</code></li>
+   *   <li>
+   *     <code>smtp</code> requires <code>smtp_host</code>, <code>smtp_port</code>, <code>smtp_user</code>, and
+   *     <code>smtp_pass</code>
+   *   </li>
+   * </ul>
+   * Depending on the type of provider it is possible to specify <code>settings</code> object with different configuration
+   * options, which will be used when sending an email:
+   * <ul>
+   *   <li>
+   *     <code>smtp</code> provider, <code>settings</code> may contain <code>headers</code> object.
+   *     <ul>
+   *       <li>
+   *         When using AWS SES SMTP host, you may provide a name of configuration set in
+   *         <code>X-SES-Configuration-Set</code> header. Value must be a string.
+   *       </li>
+   *       <li>
+   *         When using Sparkpost host, you may provide value for
+   *         <code>X-MSYS_API</code> header. Value must be an object.
+   *       </li>
+   *     </ul>
+   *   </li>
+   *   <li>
+   *     for <code>ses</code> provider, <code>settings</code> may contain <code>message</code> object, where you can provide
+   *     a name of configuration set in <code>configuration_set_name</code> property. Value must be a string.
+   *   </li>
+   * </ul>
    *
    * Configure the email provider
    *

--- a/src/management/__generated/models/index.ts
+++ b/src/management/__generated/models/index.ts
@@ -3883,7 +3883,7 @@ export interface EmailProviderCredentials {
  */
 export interface EmailProviderUpdate {
   /**
-   * Name of the email provider. Can be `mailgun`, `mandrill`, `sendgrid`, `ses`, `sparkpost`, `smtp`, `azure_cs`, or `ms365`.
+   * Name of the email provider. Can be `mailgun`, `mandrill`, `sendgrid`, `ses`, `sparkpost`, `smtp`, `azure_cs`, `ms365`, or `custom`.
    *
    */
   name?: EmailProviderUpdateNameEnum;
@@ -3916,6 +3916,7 @@ export const EmailProviderUpdateNameEnum = {
   smtp: 'smtp',
   azure_cs: 'azure_cs',
   ms365: 'ms365',
+  custom: 'custom',
 } as const;
 export type EmailProviderUpdateNameEnum =
   (typeof EmailProviderUpdateNameEnum)[keyof typeof EmailProviderUpdateNameEnum];
@@ -4629,7 +4630,7 @@ export interface GetActions200ResponseActionsInnerSupportedTriggersInnerCompatib
   version: string;
 }
 /**
- * An actions extensibility point. Acceptable values: <code>post-login, credentials-exchange, pre-user-registration, post-user-registration, post-change-password, send-phone-message, password-reset-post-challenge</code>
+ * An actions extensibility point. Acceptable values: <code>post-login, credentials-exchange, pre-user-registration, post-user-registration, post-change-password, send-phone-message, custom-email-provider, password-reset-post-challenge</code>
  */
 export type GetActions200ResponseActionsInnerSupportedTriggersInnerId =
   GetActions200ResponseActionsInnerSupportedTriggersInnerIdAnyOf;
@@ -4648,6 +4649,7 @@ export const GetActions200ResponseActionsInnerSupportedTriggersInnerIdAnyOf = {
   iga_certification: 'iga-certification',
   iga_fulfillment_assignment: 'iga-fulfillment-assignment',
   iga_fulfillment_execution: 'iga-fulfillment-execution',
+  custom_email_provider: 'custom-email-provider',
   password_reset_post_challenge: 'password-reset-post-challenge',
 } as const;
 export type GetActions200ResponseActionsInnerSupportedTriggersInnerIdAnyOf =
@@ -16404,7 +16406,7 @@ export interface GetActionsRequest {
  */
 export interface GetBindingsRequest {
   /**
-   * An actions extensibility point. Acceptable values: <code>post-login, credentials-exchange, pre-user-registration, post-user-registration, post-change-password, send-phone-message, password-reset-post-challenge</code>
+   * An actions extensibility point. Acceptable values: <code>post-login, credentials-exchange, pre-user-registration, post-user-registration, post-change-password, send-phone-message, custom-email-provider, password-reset-post-challenge</code>
    *
    */
   triggerId: string;
@@ -16444,7 +16446,7 @@ export interface PatchActionOperationRequest {
  */
 export interface PatchBindingsOperationRequest {
   /**
-   * An actions extensibility point. Acceptable values: <code>post-login, credentials-exchange, pre-user-registration, post-user-registration, post-change-password, send-phone-message, password-reset-post-challenge</code>
+   * An actions extensibility point. Acceptable values: <code>post-login, credentials-exchange, pre-user-registration, post-user-registration, post-change-password, send-phone-message, custom-email-provider, password-reset-post-challenge</code>
    *
    */
   triggerId: string;

--- a/src/management/__generated/models/index.ts
+++ b/src/management/__generated/models/index.ts
@@ -3783,7 +3783,7 @@ export type DeviceCredentialCreateTypeEnum =
  */
 export interface EmailProvider {
   /**
-   * Name of the email provider. Can be `mailgun`, `mandrill`, `sendgrid`, `ses`, `sparkpost`, `smtp`, `azure_cs`, or `ms365`.
+   * Name of the email provider. Can be `mailgun`, `mandrill`, `sendgrid`, `ses`, `sparkpost`, `smtp`, `azure_cs`, `ms365`, or `custom`.
    *
    */
   name: string;
@@ -3811,7 +3811,7 @@ export interface EmailProvider {
  */
 export interface EmailProviderCreate {
   /**
-   * Name of the email provider. Can be `mailgun`, `mandrill`, `sendgrid`, `ses`, `sparkpost`, `smtp`, `azure_cs`, or `ms365`.
+   * Name of the email provider. Can be `mailgun`, `mandrill`, `sendgrid`, `ses`, `sparkpost`, `smtp`, `azure_cs`, `ms365`, or `custom`.
    *
    */
   name: EmailProviderCreateNameEnum;
@@ -3844,6 +3844,7 @@ export const EmailProviderCreateNameEnum = {
   smtp: 'smtp',
   azure_cs: 'azure_cs',
   ms365: 'ms365',
+  custom: 'custom',
 } as const;
 export type EmailProviderCreateNameEnum =
   (typeof EmailProviderCreateNameEnum)[keyof typeof EmailProviderCreateNameEnum];

--- a/test/management/email-provider.test.ts
+++ b/test/management/email-provider.test.ts
@@ -248,6 +248,87 @@ describe('EmailProviderManager', () => {
     });
   });
 
+  describe('#configure.custom', () => {
+    const data: PostProviderRequest = {
+      name: PostProviderRequestNameEnum.custom,
+      enabled: true,
+      default_from_address: 'from@test.com',
+      credentials: {},
+    };
+    const response = {
+      name: PostProviderRequestNameEnum.custom,
+      enabled: true,
+      default_from_address: 'from@test.com',
+      credentials: {},
+    };
+    let request: nock.Scope;
+
+    beforeEach(() => {
+      request = nock(API_URL)
+        .post('/emails/provider', data as any)
+        .reply(200, response);
+    });
+
+    it('should return a promise if no callback is given', (done) => {
+      emails.configure(data).then(done.bind(null, null)).catch(done.bind(null, null));
+    });
+
+    it('should pass any errors to the promise catch handler', (done) => {
+      nock.cleanAll();
+
+      nock(API_URL).post('/emails/provider').reply(500, {});
+
+      emails.configure(data).catch((err) => {
+        expect(err).toBeDefined();
+
+        done();
+      });
+    });
+
+    it('should perform a POST request to /api/v2/emails/provider', (done) => {
+      emails.configure(data).then(() => {
+        expect(request.isDone()).toBe(true);
+
+        done();
+      });
+    });
+
+    it('should pass the data in the body of the request', (done) => {
+      emails.configure(data).then(() => {
+        expect(request.isDone()).toBe(true);
+
+        done();
+      });
+    });
+
+    it('should pass the body of the response to the "then" handler', (done) => {
+      emails.configure(data).then((provider) => {
+        expect(provider.data.name).toBe(response.name);
+        expect(provider.data.enabled).toBe(response.enabled);
+        expect(provider.data.default_from_address).toBe(response.default_from_address);
+
+        expect(provider.data.credentials).toStrictEqual(response.credentials);
+
+        done();
+      });
+    });
+
+    it('should include the token in the Authorization header', (done) => {
+      nock.cleanAll();
+
+      const request = nock(API_URL)
+        .post('/emails/provider')
+        .matchHeader('Authorization', `Bearer ${token}`)
+        .reply(200, response);
+
+      emails.configure(data).then(() => {
+        expect(request.isDone()).toBe(true);
+
+        done();
+      });
+    });
+  });
+
   describe('#update', () => {
     const data: PatchProviderRequest = {
       name: PatchProviderRequestNameEnum.smtp,


### PR DESCRIPTION
This PR adds support for the custom email provider
### Changes
- **SDK-5186 update api for custom email provider support**
- **fix tests for email provider**

Copy of #1065, builds on work already done by @acwest 

### References
https://auth0.com/docs/api/management/v2/emails/post-provider

### Tests
*PASSING*
```
Test Suites: 45 passed, 45 total
Tests:       1447 passed, 1447 total
Snapshots:   0 total
Time:        7.402 s, estimated 9 s
Ran all test suites.
```

### Sample code / manual testing
```typescript
import { EmailProviderCreate } from 'auth0';

const data: EmailProviderCreate = {
  name: 'custom',
  enabled: true,
  default_from_address: 'string',
  credentials: {},
  settings: {}
};

managementClient.emails.configure(data)
  .then(response => {
    console.log('Email provider configured successfully:', response);
  })
  .catch(error => {
    console.error('Error configuring email provider:', error);
  });
```