### PR TITLE
updated email template manager, added reset_email_by_code to multiple places

### DIFF
--- a/src/management/__generated/managers/email-templates-manager.ts
+++ b/src/management/__generated/managers/email-templates-manager.ts
@@ -17,7 +17,7 @@ const { BaseAPI } = runtime;
  */
 export class EmailTemplatesManager extends BaseAPI {
   /**
-   * Retrieve an email template by pre-defined name. These names are `verify_email`, `verify_email_by_code`, `reset_email`, `welcome_email`, `blocked_account`, `stolen_credentials`, `enrollment_email`, `mfa_oob_code`, and `user_invitation`. The names `change_password`, and `password_reset` are also supported for legacy scenarios.
+   * Retrieve an email template by pre-defined name. These names are `verify_email`, `verify_email_by_code`, `reset_email`, `reset_email_by_code`, `welcome_email`, `blocked_account`, `stolen_credentials`, `enrollment_email`, `mfa_oob_code`, and `user_invitation`. The names `change_password`, and `password_reset` are also supported for legacy scenarios.
    * Get an email template
    *
    * @throws {RequiredError}

--- a/src/management/__generated/managers/emails-manager.ts
+++ b/src/management/__generated/managers/emails-manager.ts
@@ -48,46 +48,10 @@ export class EmailsManager extends BaseAPI {
   }
 
   /**
-   * Update an <a href="https://auth0.com/docs/email/providers">email provider</a>. The <code>credentials</code> object
-   * requires different properties depending on the email provider (which is specified using the <code>name</code> property):
-   * <ul>
-   *   <li><code>mandrill</code> requires <code>api_key</code></li>
-   *   <li><code>sendgrid</code> requires <code>api_key</code></li>
-   *   <li>
-   *     <code>sparkpost</code> requires <code>api_key</code>. Optionally, set <code>region</code> to <code>eu</code> to use
-   *     the SparkPost service hosted in Western Europe; set to <code>null</code> to use the SparkPost service hosted in
-   *     North America. <code>eu</code> or <code>null</code> are the only valid values for <code>region</code>.
-   *   </li>
-   *   <li>
-   *     <code>mailgun</code> requires <code>api_key</code> and <code>domain</code>. Optionally, set <code>region</code> to
-   *     <code>eu</code> to use the Mailgun service hosted in Europe; set to <code>null</code> otherwise. <code>eu</code> or
-   *     <code>null</code> are the only valid values for <code>region</code>.
-   *   </li>
-   *   <li><code>ses</code> requires <code>accessKeyId</code>, <code>secretAccessKey</code>, and <code>region</code></li>
-   *   <li>
-   *     <code>smtp</code> requires <code>smtp_host</code>, <code>smtp_port</code>, <code>smtp_user</code>, and
-   *     <code>smtp_pass</code>
-   *   </li>
-   * </ul>
-   * Depending on the type of provider it is possible to specify <code>settings</code> object with different configuration
-   * options, which will be used when sending an email:
-   * <ul>
-   *   <li>
-   *     <code>smtp</code> provider, <code>settings</code> may contain <code>headers</code> object.
-   *     <ul>
-   *       <li>
-   *         When using AWS SES SMTP host, you may provide a name of configuration set in
-   *         <code>X-SES-Configuration-Set</code> header. Value must be a string.
-   *       </li>
-   *       <li>
-   *         When using Sparkpost host, you may provide value for
-   *         <code>X-MSYS_API</code> header. Value must be an object.
-   *       </li>
-   *     </ul>
-   *     for <code>ses</code> provider, <code>settings</code> may contain <code>message</code> object, where you can provide
-   *     a name of configuration set in <code>configuration_set_name</code> property. Value must be a string.
-   *   </li>
-   * </ul>
+   * Update an <a href="https://auth0.com/docs/email/providers">email provider</a>.
+   * The <code>credentials</code> object requires different properties depending on the email provider (which is specified using the <code>name</code> property):
+   * <ul><li><code>mandrill</code> requires <code>api_key</code></li><li><code>sendgrid</code> requires <code>api_key</code></li><li><code>sparkpost</code> requires <code>api_key</code>. Optionally, set <code>region</code> to <code>eu</code> to use the SparkPost service hosted in Western Europe; set to <code>null</code> to use the SparkPost service hosted in North America. <code>eu</code> or <code>null</code> are the only valid values for <code>region</code>.</li><li><code>mailgun</code> requires <code>api_key</code> and <code>domain</code>. Optionally, set <code>region</code> to <code>eu</code> to use the Mailgun service hosted in Europe; set to <code>null</code> otherwise. <code>eu</code> or <code>null</code> are the only valid values for <code>region</code>.</li><li><code>ses</code> requires <code>accessKeyId</code>, <code>secretAccessKey</code>, and <code>region</code></li><li><code>smtp</code> requires <code>smtp_host</code>, <code>smtp_port</code>, <code>smtp_user</code>, and <code>smtp_pass</code></li></ul>Depending on the type of provider it is possible to specify <code>settings</code> object with different configuration options, which will be used when sending an email:
+   * <ul><li><code>smtp</code> provider, <code>settings</code> may contain <code>headers</code> object. When using AWS SES SMTP host, you may provide a name of configuration set in <code>X-SES-Configuration-Set</code> header. Value must be a string.</li><li>for <code>ses</code> provider, <code>settings</code> may contain <code>message</code> object, where you can provide a name of configuration set in <code>configuration_set_name</code> property. Value must be a string.</li></ul>
    *
    * Update the email provider
    *
@@ -115,48 +79,10 @@ export class EmailsManager extends BaseAPI {
   }
 
   /**
-   * Create an <a href="https://auth0.com/docs/email/providers">email provider</a>. The <code>credentials</code> object
-   * requires different properties depending on the email provider (which is specified using the <code>name</code> property):
-   * <ul>
-   *   <li><code>mandrill</code> requires <code>api_key</code></li>
-   *   <li><code>sendgrid</code> requires <code>api_key</code></li>
-   *   <li>
-   *     <code>sparkpost</code> requires <code>api_key</code>. Optionally, set <code>region</code> to <code>eu</code> to use
-   *     the SparkPost service hosted in Western Europe; set to <code>null</code> to use the SparkPost service hosted in
-   *     North America. <code>eu</code> or <code>null</code> are the only valid values for <code>region</code>.
-   *   </li>
-   *   <li>
-   *     <code>mailgun</code> requires <code>api_key</code> and <code>domain</code>. Optionally, set <code>region</code> to
-   *     <code>eu</code> to use the Mailgun service hosted in Europe; set to <code>null</code> otherwise. <code>eu</code> or
-   *     <code>null</code> are the only valid values for <code>region</code>.
-   *   </li>
-   *   <li><code>ses</code> requires <code>accessKeyId</code>, <code>secretAccessKey</code>, and <code>region</code></li>
-   *   <li>
-   *     <code>smtp</code> requires <code>smtp_host</code>, <code>smtp_port</code>, <code>smtp_user</code>, and
-   *     <code>smtp_pass</code>
-   *   </li>
-   * </ul>
-   * Depending on the type of provider it is possible to specify <code>settings</code> object with different configuration
-   * options, which will be used when sending an email:
-   * <ul>
-   *   <li>
-   *     <code>smtp</code> provider, <code>settings</code> may contain <code>headers</code> object.
-   *     <ul>
-   *       <li>
-   *         When using AWS SES SMTP host, you may provide a name of configuration set in
-   *         <code>X-SES-Configuration-Set</code> header. Value must be a string.
-   *       </li>
-   *       <li>
-   *         When using Sparkpost host, you may provide value for
-   *         <code>X-MSYS_API</code> header. Value must be an object.
-   *       </li>
-   *     </ul>
-   *   </li>
-   *   <li>
-   *     for <code>ses</code> provider, <code>settings</code> may contain <code>message</code> object, where you can provide
-   *     a name of configuration set in <code>configuration_set_name</code> property. Value must be a string.
-   *   </li>
-   * </ul>
+   * Create an <a href="https://auth0.com/docs/email/providers">email provider</a>.
+   * The <code>credentials</code> object requires different properties depending on the email provider (which is specified using the <code>name</code> property):
+   * <ul><li><code>mandrill</code> requires <code>api_key</code></li><li><code>sendgrid</code> requires <code>api_key</code></li><li><code>sparkpost</code> requires <code>api_key</code>. Optionally, set <code>region</code> to <code>eu</code> to use the SparkPost service hosted in Western Europe; set to <code>null</code> to use the SparkPost service hosted in North America. <code>eu</code> or <code>null</code> are the only valid values for <code>region</code>.</li><li><code>mailgun</code> requires <code>api_key</code> and <code>domain</code>. Optionally, set <code>region</code> to <code>eu</code> to use the Mailgun service hosted in Europe; set to <code>null</code> otherwise. <code>eu</code> or <code>null</code> are the only valid values for <code>region</code>.</li><li><code>ses</code> requires <code>accessKeyId</code>, <code>secretAccessKey</code>, and <code>region</code></li><li><code>smtp</code> requires <code>smtp_host</code>, <code>smtp_port</code>, <code>smtp_user</code>, and <code>smtp_pass</code></li></ul>Depending on the type of provider it is possible to specify <code>settings</code> object with different configuration options, which will be used when sending an email:
+   * <ul><li><code>smtp</code> provider, <code>settings</code> may contain <code>headers</code> object. When using AWS SES SMTP host, you may provide a name of configuration set in <code>X-SES-Configuration-Set</code> header. Value must be a string.</li><li>for <code>ses</code> provider, <code>settings</code> may contain <code>message</code> object, where you can provide a name of configuration set in <code>configuration_set_name</code> property. Value must be a string.</li></ul>
    *
    * Configure the email provider
    *

--- a/src/management/__generated/managers/prompts-manager.ts
+++ b/src/management/__generated/managers/prompts-manager.ts
@@ -2,6 +2,7 @@ import * as runtime from '../../../lib/runtime.js';
 import type { InitOverride, ApiResponse } from '../../../lib/runtime.js';
 import type {
   GetRendering200Response,
+  PatchRendering200Response,
   PatchRenderingRequest,
   PromptsSettings,
   PromptsSettingsUpdate,
@@ -89,8 +90,8 @@ export class PromptsManager extends BaseAPI {
   }
 
   /**
-   * View the render settings for a specific screen
-   * Get render settings for a prompt
+   * Get render settings for a screen.
+   * Get render settings for a screen
    *
    * @throws {RequiredError}
    */
@@ -141,8 +142,36 @@ export class PromptsManager extends BaseAPI {
   }
 
   /**
-   * Configure the render settings for a specific screen
-   * Configure render settings for a prompt
+   * Learn more about <a href='https://auth0.com/docs/customize/login-pages/advanced-customizations/getting-started/configure-acul-screens'>configuring render settings</a> for advanced customization.
+   *
+   * <p>
+   *   Example <code>head_tags</code> array. See our <a href='https://auth0.com/docs/customize/login-pages/advanced-customizations/getting-started/configure-acul-screens'>documentation</a> on using Liquid variables within head tags.
+   * </p>
+   * <pre>{
+   *   "head_tags": [
+   *     {
+   *       "tag": "script",
+   *       "attributes": {
+   *         "defer": true,
+   *         "src": "URL_TO_ASSET",
+   *         "async": true,
+   *         "integrity": [
+   *           "ASSET_SHA"
+   *         ]
+   *       }
+   *     },
+   *     {
+   *       "tag": "link",
+   *       "attributes": {
+   *         "href": "URL_TO_ASSET",
+   *         "rel": "stylesheet"
+   *       }
+   *     }
+   *   ]
+   * }
+   * </pre>
+   *
+   * Update render settings for a screen
    *
    * @throws {RequiredError}
    */
@@ -150,7 +179,7 @@ export class PromptsManager extends BaseAPI {
     requestParameters: PatchRenderingOperationRequest,
     bodyParameters: PatchRenderingRequest,
     initOverrides?: InitOverride
-  ): Promise<ApiResponse<void>> {
+  ): Promise<ApiResponse<PatchRendering200Response>> {
     runtime.validateRequiredRequestParams(requestParameters, ['prompt', 'screen']);
 
     const headerParameters: runtime.HTTPHeaders = {};
@@ -169,7 +198,7 @@ export class PromptsManager extends BaseAPI {
       initOverrides
     );
 
-    return runtime.VoidApiResponse.fromResponse(response);
+    return runtime.JSONApiResponse.fromResponse(response);
   }
 
   /**

--- a/src/management/__generated/models/index.ts
+++ b/src/management/__generated/models/index.ts
@@ -3783,7 +3783,7 @@ export type DeviceCredentialCreateTypeEnum =
  */
 export interface EmailProvider {
   /**
-   * Name of the email provider. Can be `mailgun`, `mandrill`, `sendgrid`, `ses`, `sparkpost`, `smtp`, `azure_cs`, `ms365`, or `custom`.
+   * Name of the email provider. Can be `mailgun`, `mandrill`, `sendgrid`, `ses`, `sparkpost`, `smtp`, `azure_cs`, or `ms365`, or `custom`.
    *
    */
   name: string;
@@ -3811,7 +3811,7 @@ export interface EmailProvider {
  */
 export interface EmailProviderCreate {
   /**
-   * Name of the email provider. Can be `mailgun`, `mandrill`, `sendgrid`, `ses`, `sparkpost`, `smtp`, `azure_cs`, `ms365`, or `custom`.
+   * Name of the email provider. Can be `mailgun`, `mandrill`, `sendgrid`, `ses`, `sparkpost`, `smtp`, `azure_cs`, or `ms365`, or `custom`.
    *
    */
   name: EmailProviderCreateNameEnum;
@@ -5268,7 +5268,7 @@ export interface GetDeviceCredentials200ResponseOneOf {
  */
 export interface GetEmailTemplatesByTemplateName200Response {
   /**
-   * Template name. Can be `verify_email`, `verify_email_by_code`, `reset_email`, `welcome_email`, `blocked_account`, `stolen_credentials`, `enrollment_email`, `mfa_oob_code`, `user_invitation`, `change_password` (legacy), or `password_reset` (legacy).
+   * Template name. Can be `verify_email`, `verify_email_by_code`, `reset_email`, `reset_email_by_code`, `welcome_email`, `blocked_account`, `stolen_credentials`, `enrollment_email`, `mfa_oob_code`, `user_invitation`, `change_password` (legacy), or `password_reset` (legacy).
    *
    */
   template: GetEmailTemplatesByTemplateName200ResponseTemplateEnum;
@@ -5318,6 +5318,7 @@ export const GetEmailTemplatesByTemplateName200ResponseTemplateEnum = {
   verify_email: 'verify_email',
   verify_email_by_code: 'verify_email_by_code',
   reset_email: 'reset_email',
+  reset_email_by_code: 'reset_email_by_code',
   welcome_email: 'welcome_email',
   blocked_account: 'blocked_account',
   stolen_credentials: 'stolen_credentials',
@@ -7241,7 +7242,7 @@ export interface GetRendering200Response {
    * An array of head tags
    *
    */
-  head_tags: Array<{ [key: string]: any }>;
+  head_tags: Array<GetRendering200ResponseHeadTagsInner>;
 }
 
 export const GetRendering200ResponseRenderingModeEnum = {
@@ -7251,6 +7252,35 @@ export const GetRendering200ResponseRenderingModeEnum = {
 export type GetRendering200ResponseRenderingModeEnum =
   (typeof GetRendering200ResponseRenderingModeEnum)[keyof typeof GetRendering200ResponseRenderingModeEnum];
 
+/**
+ *
+ */
+export interface GetRendering200ResponseHeadTagsInner {
+  [key: string]: any | any;
+  /**
+   * Any HTML element valid for use in the head tag
+   *
+   */
+  tag: string;
+  /**
+   */
+  attributes: GetRendering200ResponseHeadTagsInnerAttributes;
+  /**
+   * Text/content within the opening and closing tags of the element.
+   * See <a href="https://auth0.com/docs/customize/login-pages/advanced-customizations/getting-started/configure-acul-screens">documentation</a> on using context variables
+   *
+   */
+  content: string;
+}
+/**
+ * Attributes of the HTML tag
+ */
+export interface GetRendering200ResponseHeadTagsInnerAttributes {
+  [key: string]: any | any;
+  /**
+   */
+  integrity: Array<string>;
+}
 /**
  *
  */
@@ -8875,7 +8905,7 @@ export type PatchCustomDomainsByIdRequestCustomClientIpHeaderEnum =
  */
 export interface PatchEmailTemplatesByTemplateNameRequest {
   /**
-   * Template name. Can be `verify_email`, `verify_email_by_code`, `reset_email`, `welcome_email`, `blocked_account`, `stolen_credentials`, `enrollment_email`, `mfa_oob_code`, `user_invitation`, `change_password` (legacy), or `password_reset` (legacy).
+   * Template name. Can be `verify_email`, `verify_email_by_code`, `reset_email`, `reset_email_by_code`, `welcome_email`, `blocked_account`, `stolen_credentials`, `enrollment_email`, `mfa_oob_code`, `user_invitation`, `change_password` (legacy), or `password_reset` (legacy).
    *
    */
   template?: PatchEmailTemplatesByTemplateNameRequestTemplateEnum;
@@ -8925,6 +8955,7 @@ export const PatchEmailTemplatesByTemplateNameRequestTemplateEnum = {
   verify_email: 'verify_email',
   verify_email_by_code: 'verify_email_by_code',
   reset_email: 'reset_email',
+  reset_email_by_code: 'reset_email_by_code',
   welcome_email: 'welcome_email',
   blocked_account: 'blocked_account',
   stolen_credentials: 'stolen_credentials',
@@ -9200,7 +9231,41 @@ export interface PatchOrganizationsByIdRequestBranding {
   colors?: GetOrganizations200ResponseOneOfInnerBrandingColors;
 }
 /**
- * ACUL settings for the given screen.
+ *
+ */
+export interface PatchRendering200Response {
+  [key: string]: any | any;
+  /**
+   * Rendering mode
+   *
+   */
+  rendering_mode: PatchRendering200ResponseRenderingModeEnum;
+  /**
+   * Context values to make available
+   *
+   */
+  context_configuration: Array<string>;
+  /**
+   * Override Universal Login default head tags
+   *
+   */
+  default_head_tags_disabled: boolean;
+  /**
+   * An array of head tags
+   *
+   */
+  head_tags: Array<GetRendering200ResponseHeadTagsInner>;
+}
+
+export const PatchRendering200ResponseRenderingModeEnum = {
+  advanced: 'advanced',
+  standard: 'standard',
+} as const;
+export type PatchRendering200ResponseRenderingModeEnum =
+  (typeof PatchRendering200ResponseRenderingModeEnum)[keyof typeof PatchRendering200ResponseRenderingModeEnum];
+
+/**
+ * Render settings for the given screen
  */
 export interface PatchRenderingRequest {
   /**
@@ -9222,7 +9287,7 @@ export interface PatchRenderingRequest {
    * An array of head tags
    *
    */
-  head_tags?: Array<{ [key: string]: any }>;
+  head_tags?: Array<PatchRenderingRequestHeadTagsInner>;
 }
 
 export const PatchRenderingRequestRenderingModeEnum = {
@@ -9232,6 +9297,35 @@ export const PatchRenderingRequestRenderingModeEnum = {
 export type PatchRenderingRequestRenderingModeEnum =
   (typeof PatchRenderingRequestRenderingModeEnum)[keyof typeof PatchRenderingRequestRenderingModeEnum];
 
+/**
+ *
+ */
+export interface PatchRenderingRequestHeadTagsInner {
+  [key: string]: any | any;
+  /**
+   * Any HTML element valid for use in the head tag
+   *
+   */
+  tag?: string;
+  /**
+   */
+  attributes?: PatchRenderingRequestHeadTagsInnerAttributes;
+  /**
+   * Text/content within the opening and closing tags of the element
+   * See <a href="https://auth0.com/docs/customize/login-pages/advanced-customizations/getting-started/configure-acul-screens">documentation</a> on using context variables
+   *
+   */
+  content?: string;
+}
+/**
+ * Attributes of the HTML tag
+ */
+export interface PatchRenderingRequestHeadTagsInnerAttributes {
+  [key: string]: any | any;
+  /**
+   */
+  integrity?: Array<string>;
+}
 /**
  *
  */
@@ -10200,7 +10294,7 @@ export interface PostDeviceCredentials201Response {
  */
 export interface PostEmailTemplatesRequest {
   /**
-   * Template name. Can be `verify_email`, `verify_email_by_code`, `reset_email`, `welcome_email`, `blocked_account`, `stolen_credentials`, `enrollment_email`, `mfa_oob_code`, `user_invitation`, `change_password` (legacy), or `password_reset` (legacy).
+   * Template name. Can be `verify_email`, `verify_email_by_code`, `reset_email`, `reset_email_by_code`, `welcome_email`, `blocked_account`, `stolen_credentials`, `enrollment_email`, `mfa_oob_code`, `user_invitation`, `change_password` (legacy), or `password_reset` (legacy).
    *
    */
   template: PostEmailTemplatesRequestTemplateEnum;
@@ -10250,6 +10344,7 @@ export const PostEmailTemplatesRequestTemplateEnum = {
   verify_email: 'verify_email',
   verify_email_by_code: 'verify_email_by_code',
   reset_email: 'reset_email',
+  reset_email_by_code: 'reset_email_by_code',
   welcome_email: 'welcome_email',
   blocked_account: 'blocked_account',
   stolen_credentials: 'stolen_credentials',
@@ -17163,6 +17258,7 @@ export const GetEmailTemplatesByTemplateNameTemplateNameEnum = {
   verify_email: 'verify_email',
   verify_email_by_code: 'verify_email_by_code',
   reset_email: 'reset_email',
+  reset_email_by_code: 'reset_email_by_code',
   welcome_email: 'welcome_email',
   blocked_account: 'blocked_account',
   stolen_credentials: 'stolen_credentials',
@@ -17180,7 +17276,7 @@ export type GetEmailTemplatesByTemplateNameTemplateNameEnum =
  */
 export interface GetEmailTemplatesByTemplateNameRequest {
   /**
-   * Template name. Can be `verify_email`, `verify_email_by_code`, `reset_email`, `welcome_email`, `blocked_account`, `stolen_credentials`, `enrollment_email`, `mfa_oob_code`, `user_invitation`, `change_password` (legacy), or `password_reset` (legacy).
+   * Template name. Can be `verify_email`, `verify_email_by_code`, `reset_email`, `reset_email_by_code`, `welcome_email`, `blocked_account`, `stolen_credentials`, `enrollment_email`, `mfa_oob_code`, `user_invitation`, `change_password` (legacy), or `password_reset` (legacy).
    *
    */
   templateName: GetEmailTemplatesByTemplateNameTemplateNameEnum;
@@ -17193,6 +17289,7 @@ export const PatchEmailTemplatesByTemplateNameOperationTemplateNameEnum = {
   verify_email: 'verify_email',
   verify_email_by_code: 'verify_email_by_code',
   reset_email: 'reset_email',
+  reset_email_by_code: 'reset_email_by_code',
   welcome_email: 'welcome_email',
   blocked_account: 'blocked_account',
   stolen_credentials: 'stolen_credentials',
@@ -17210,7 +17307,7 @@ export type PatchEmailTemplatesByTemplateNameOperationTemplateNameEnum =
  */
 export interface PatchEmailTemplatesByTemplateNameOperationRequest {
   /**
-   * Template name. Can be `verify_email`, `verify_email_by_code`, `reset_email`, `welcome_email`, `blocked_account`, `stolen_credentials`, `enrollment_email`, `mfa_oob_code`, `user_invitation`, `change_password` (legacy), or `password_reset` (legacy).
+   * Template name. Can be `verify_email`, `verify_email_by_code`, `reset_email`, `reset_email_by_code`, `welcome_email`, `blocked_account`, `stolen_credentials`, `enrollment_email`, `mfa_oob_code`, `user_invitation`, `change_password` (legacy), or `password_reset` (legacy).
    *
    */
   templateName: PatchEmailTemplatesByTemplateNameOperationTemplateNameEnum;
@@ -17223,6 +17320,7 @@ export const PutEmailTemplatesByTemplateNameTemplateNameEnum = {
   verify_email: 'verify_email',
   verify_email_by_code: 'verify_email_by_code',
   reset_email: 'reset_email',
+  reset_email_by_code: 'reset_email_by_code',
   welcome_email: 'welcome_email',
   blocked_account: 'blocked_account',
   stolen_credentials: 'stolen_credentials',
@@ -17240,7 +17338,7 @@ export type PutEmailTemplatesByTemplateNameTemplateNameEnum =
  */
 export interface PutEmailTemplatesByTemplateNameRequest {
   /**
-   * Template name. Can be `verify_email`, `verify_email_by_code`, `reset_email`, `welcome_email`, `blocked_account`, `stolen_credentials`, `enrollment_email`, `mfa_oob_code`, `user_invitation`, `change_password` (legacy), or `password_reset` (legacy).
+   * Template name. Can be `verify_email`, `verify_email_by_code`, `reset_email`, `reset_email_by_code`, `welcome_email`, `blocked_account`, `stolen_credentials`, `enrollment_email`, `mfa_oob_code`, `user_invitation`, `change_password` (legacy), or `password_reset` (legacy).
    *
    */
   templateName: PutEmailTemplatesByTemplateNameTemplateNameEnum;
@@ -18648,12 +18746,12 @@ export type GetRenderingScreenEnum =
  */
 export interface GetRenderingRequest {
   /**
-   * Name of the prompt.
+   * Name of the prompt
    *
    */
   prompt: GetRenderingPromptEnum;
   /**
-   * Name of the screen.
+   * Name of the screen
    *
    */
   screen: GetRenderingScreenEnum;
@@ -18794,12 +18892,12 @@ export type PatchRenderingOperationScreenEnum =
  */
 export interface PatchRenderingOperationRequest {
   /**
-   * Name of the prompt.
+   * Name of the prompt
    *
    */
   prompt: PatchRenderingOperationPromptEnum;
   /**
-   * Name of the screen.
+   * Name of the screen
    *
    */
   screen: PatchRenderingOperationScreenEnum;


### PR DESCRIPTION
This PR adds some minor changes to already existing methods:
- support for `reset_email_by_code` for email template methods
- support for 'custom' as email provider
- Updated PATCH response type for ACUL methods.

Changed endpoint methods:

| Path                                             | Method | Alias          |
|--------------------------------------------------|--------|----------------|
| `/prompts/{prompt}/screen/{screen}/rendering`    | GET    | `getRendering` |
| `/prompts/{prompt}/screen/{screen}/rendering`    | PATCH  | `updateRendering` |
| `/connections`                                   | POST   | `create`       |
| `/email-templates`                               | POST   | `create`       |
| `/email-templates/{templateName}`                | GET    | `get`          |
| `/email-templates/{templateName}`                | PATCH  | `update`       |
| `/email-templates/{templateName}`                | PUT    | `put`          |