### PR TITLE
add optional organization parameter in ClientCredentialsGrantRequest of clientCredentialsGrant call of oauth of authenticationClient

### DIFF
--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -85,11 +85,18 @@ export interface AuthorizationCodeGrantWithPKCERequest extends AuthorizationCode
   code_verifier: string;
 }
 
+/**
+ * Represents a request for a client credentials grant in the OAuth 2.0 framework, specific to Auth0 implementation.
+ *
+ * @property audience - The unique identifier of the target API you want to access.
+ * @property organization - The identifier of the organization for which the request is being made.
+ */
 export interface ClientCredentialsGrantRequest extends ClientCredentials {
   /**
    * The unique identifier of the target API you want to access.
    */
   audience: string;
+  organization?: string;
 }
 
 export interface PushedAuthorizationRequest extends ClientCredentials {


### PR DESCRIPTION
## Changes:
Added `organization?: string;` to `ClientCredentialsGrantRequest` for `clientCredentialsGrant` method of `AuthenticationClient`

Allows the following usage:
```
import { AuthenticationClient } from 'auth0';

const auth = new AuthenticationClient({
  domain: env.AUTH0_DOMAIN,
  clientId: env.AUTH0_CLIENT_ID,
  clientSecret: env.AUTH0_CLIENT_SECRET,
});

const { data: { access_token } } = await auth.oauth.clientCredentialsGrant({
  audience: 'urn:myapi',
  organization: 'org_123?'
});
```

## Tests
*Passing*