### PR TITLE
Add Support For Extensibility as Custom Provider in BrandingManager

### DIFF
--- a/src/management/__generated/managers/branding-manager.ts
+++ b/src/management/__generated/managers/branding-manager.ts
@@ -1,15 +1,23 @@
 import * as runtime from '../../../lib/runtime.js';
 import type { InitOverride, ApiResponse } from '../../../lib/runtime.js';
 import type {
+  CreatePhoneProviderRequest,
   GetBranding200Response,
+  GetBrandingPhoneProviders200Response,
+  GetBrandingPhoneProviders200ResponseProvidersInner,
   GetUniversalLogin200Response,
   PatchBrandingRequest,
   PostBrandingTheme200Response,
   PostBrandingThemeRequest,
   PutUniversalLoginRequest,
+  UpdatePhoneProviderRequest,
   DeleteBrandingThemeRequest,
+  DeletePhoneProviderRequest,
+  GetBrandingPhoneProvidersRequest,
   GetBrandingThemeRequest,
+  GetPhoneProviderRequest,
   PatchBrandingThemeRequest,
+  UpdatePhoneProviderOperationRequest,
 } from '../models/index.js';
 
 const { BaseAPI } = runtime;
@@ -18,6 +26,35 @@ const { BaseAPI } = runtime;
  *
  */
 export class BrandingManager extends BaseAPI {
+  /**
+   * Create an <a href="https://auth0.com/docs/phone/providers">phone provider</a>.
+   * The <code>credentials</code> object requires different properties depending on the phone provider (which is specified using the <code>name</code> property).
+   *
+   * Configure the phone provider
+   *
+   * @throws {RequiredError}
+   */
+  async configurePhoneProvider(
+    bodyParameters: CreatePhoneProviderRequest,
+    initOverrides?: InitOverride
+  ): Promise<ApiResponse<GetBrandingPhoneProviders200ResponseProvidersInner>> {
+    const headerParameters: runtime.HTTPHeaders = {};
+
+    headerParameters['Content-Type'] = 'application/json';
+
+    const response = await this.request(
+      {
+        path: `/branding/phone/providers`,
+        method: 'POST',
+        headers: headerParameters,
+        body: bodyParameters,
+      },
+      initOverrides
+    );
+
+    return runtime.JSONApiResponse.fromResponse(response);
+  }
+
   /**
    * Delete branding theme.
    * Delete branding theme
@@ -35,6 +72,33 @@ export class BrandingManager extends BaseAPI {
         path: `/branding/themes/{themeId}`.replace(
           '{themeId}',
           encodeURIComponent(String(requestParameters.themeId))
+        ),
+        method: 'DELETE',
+      },
+      initOverrides
+    );
+
+    return runtime.VoidApiResponse.fromResponse(response);
+  }
+
+  /**
+   * Delete the configured phone provider.
+   *
+   * Deletes a Phone Provider
+   *
+   * @throws {RequiredError}
+   */
+  async deletePhoneProvider(
+    requestParameters: DeletePhoneProviderRequest,
+    initOverrides?: InitOverride
+  ): Promise<ApiResponse<void>> {
+    runtime.validateRequiredRequestParams(requestParameters, ['id']);
+
+    const response = await this.request(
+      {
+        path: `/branding/phone/providers/{id}`.replace(
+          '{id}',
+          encodeURIComponent(String(requestParameters.id))
         ),
         method: 'DELETE',
       },
@@ -80,6 +144,36 @@ export class BrandingManager extends BaseAPI {
   }
 
   /**
+   * Retrieve a list of<a href="https://auth0.com/docs/phone/providers">phone providers</a> details set for a Tenant. A list of fields to include or exclude may also be specified.
+   *
+   * Get the phone providers set for a Tenant
+   *
+   * @throws {RequiredError}
+   */
+  async getAllPhoneProviders(
+    requestParameters: GetBrandingPhoneProvidersRequest = {},
+    initOverrides?: InitOverride
+  ): Promise<ApiResponse<GetBrandingPhoneProviders200Response>> {
+    const queryParameters = runtime.applyQueryParams(requestParameters, [
+      {
+        key: 'disabled',
+        config: {},
+      },
+    ]);
+
+    const response = await this.request(
+      {
+        path: `/branding/phone/providers`,
+        method: 'GET',
+        query: queryParameters,
+      },
+      initOverrides
+    );
+
+    return runtime.JSONApiResponse.fromResponse(response);
+  }
+
+  /**
    * Retrieve branding theme.
    * Get branding theme
    *
@@ -117,6 +211,33 @@ export class BrandingManager extends BaseAPI {
     const response = await this.request(
       {
         path: `/branding/themes/default`,
+        method: 'GET',
+      },
+      initOverrides
+    );
+
+    return runtime.JSONApiResponse.fromResponse(response);
+  }
+
+  /**
+   * Retrieve <a href="https://auth0.com/docs/phone/providers">phone provider</a> details. A list of fields to include or exclude may also be specified.
+   *
+   * Get the phone provider
+   *
+   * @throws {RequiredError}
+   */
+  async getPhoneProvider(
+    requestParameters: GetPhoneProviderRequest,
+    initOverrides?: InitOverride
+  ): Promise<ApiResponse<GetBrandingPhoneProviders200ResponseProvidersInner>> {
+    runtime.validateRequiredRequestParams(requestParameters, ['id']);
+
+    const response = await this.request(
+      {
+        path: `/branding/phone/providers/{id}`.replace(
+          '{id}',
+          encodeURIComponent(String(requestParameters.id))
+        ),
         method: 'GET',
       },
       initOverrides
@@ -281,5 +402,40 @@ export class BrandingManager extends BaseAPI {
     );
 
     return runtime.VoidApiResponse.fromResponse(response);
+  }
+
+  /**
+   * Update an <a href="https://auth0.com/docs/phone/providers">phone provider</a>.
+   * The <code>credentials</code> object requires different properties depending on the email provider (which is specified using the <code>name</code> property).
+   *
+   * Update the phone provider
+   *
+   * @throws {RequiredError}
+   */
+  async updatePhoneProvider(
+    requestParameters: UpdatePhoneProviderOperationRequest,
+    bodyParameters: UpdatePhoneProviderRequest,
+    initOverrides?: InitOverride
+  ): Promise<ApiResponse<GetBrandingPhoneProviders200ResponseProvidersInner>> {
+    runtime.validateRequiredRequestParams(requestParameters, ['id']);
+
+    const headerParameters: runtime.HTTPHeaders = {};
+
+    headerParameters['Content-Type'] = 'application/json';
+
+    const response = await this.request(
+      {
+        path: `/branding/phone/providers/{id}`.replace(
+          '{id}',
+          encodeURIComponent(String(requestParameters.id))
+        ),
+        method: 'PATCH',
+        headers: headerParameters,
+        body: bodyParameters,
+      },
+      initOverrides
+    );
+
+    return runtime.JSONApiResponse.fromResponse(response);
   }
 }

--- a/src/management/__generated/managers/clients-manager.ts
+++ b/src/management/__generated/managers/clients-manager.ts
@@ -171,6 +171,10 @@ export class ClientsManager extends BaseAPI {
         config: {},
       },
       {
+        key: 'client_ids',
+        config: {},
+      },
+      {
         key: 'q',
         config: {},
       },

--- a/src/management/__generated/models/index.ts
+++ b/src/management/__generated/models/index.ts
@@ -3549,6 +3549,50 @@ export type ConnectionUpdateOptionsSetUserRootAttributesEnum =
   (typeof ConnectionUpdateOptionsSetUserRootAttributesEnum)[keyof typeof ConnectionUpdateOptionsSetUserRootAttributesEnum];
 
 /**
+ * Phone provider configuration schema
+ */
+export interface CreatePhoneProviderRequest {
+  [key: string]: any | any;
+  /**
+   * Name of the phone notification provider
+   *
+   */
+  name: CreatePhoneProviderRequestNameEnum;
+  /**
+   * Whether the provider is enabled (false) or disabled (true).
+   *
+   */
+  disabled?: boolean;
+  /**
+   */
+  configuration?: GetBrandingPhoneProviders200ResponseProvidersInnerConfiguration;
+  /**
+   */
+  credentials: CreatePhoneProviderRequestCredentials;
+}
+
+export const CreatePhoneProviderRequestNameEnum = {
+  twilio: 'twilio',
+  custom: 'custom',
+} as const;
+export type CreatePhoneProviderRequestNameEnum =
+  (typeof CreatePhoneProviderRequestNameEnum)[keyof typeof CreatePhoneProviderRequestNameEnum];
+
+/**
+ * Provider credentials required to use authenticate to the provider.
+ */
+export type CreatePhoneProviderRequestCredentials =
+  | CreatePhoneProviderRequestCredentialsAnyOf
+  | object;
+/**
+ *
+ */
+export interface CreatePhoneProviderRequestCredentialsAnyOf {
+  /**
+   */
+  auth_token: string;
+}
+/**
  *
  */
 export interface CustomDomain {
@@ -4955,6 +4999,93 @@ export interface GetBranding200ResponseFont {
 /**
  *
  */
+export interface GetBrandingPhoneProviders200Response {
+  [key: string]: any | any;
+  /**
+   */
+  providers: Array<GetBrandingPhoneProviders200ResponseProvidersInner>;
+}
+/**
+ * Phone provider configuration schema
+ */
+export interface GetBrandingPhoneProviders200ResponseProvidersInner {
+  /**
+   */
+  id?: string;
+  /**
+   * Name of the phone notification provider
+   *
+   */
+  name: GetBrandingPhoneProviders200ResponseProvidersInnerNameEnum;
+  /**
+   * Whether the provider is enabled (false) or disabled (true).
+   *
+   */
+  disabled?: boolean;
+  /**
+   */
+  configuration?: GetBrandingPhoneProviders200ResponseProvidersInnerConfiguration;
+}
+
+export const GetBrandingPhoneProviders200ResponseProvidersInnerNameEnum = {
+  twilio: 'twilio',
+  custom: 'custom',
+} as const;
+export type GetBrandingPhoneProviders200ResponseProvidersInnerNameEnum =
+  (typeof GetBrandingPhoneProviders200ResponseProvidersInnerNameEnum)[keyof typeof GetBrandingPhoneProviders200ResponseProvidersInnerNameEnum];
+
+/**
+ *
+ */
+export type GetBrandingPhoneProviders200ResponseProvidersInnerConfiguration =
+  | GetBrandingPhoneProviders200ResponseProvidersInnerConfigurationAnyOf
+  | GetBrandingPhoneProviders200ResponseProvidersInnerConfigurationAnyOf1;
+/**
+ *
+ */
+export interface GetBrandingPhoneProviders200ResponseProvidersInnerConfigurationAnyOf {
+  /**
+   */
+  default_from?: string;
+  /**
+   */
+  mssid?: string;
+  /**
+   */
+  sid: string;
+  /**
+   */
+  delivery_methods: Array<GetBrandingPhoneProviders200ResponseProvidersInnerConfigurationAnyOfDeliveryMethodsEnum>;
+}
+
+export const GetBrandingPhoneProviders200ResponseProvidersInnerConfigurationAnyOfDeliveryMethodsEnum =
+  {
+    text: 'text',
+    voice: 'voice',
+  } as const;
+export type GetBrandingPhoneProviders200ResponseProvidersInnerConfigurationAnyOfDeliveryMethodsEnum =
+  (typeof GetBrandingPhoneProviders200ResponseProvidersInnerConfigurationAnyOfDeliveryMethodsEnum)[keyof typeof GetBrandingPhoneProviders200ResponseProvidersInnerConfigurationAnyOfDeliveryMethodsEnum];
+
+/**
+ *
+ */
+export interface GetBrandingPhoneProviders200ResponseProvidersInnerConfigurationAnyOf1 {
+  /**
+   */
+  delivery_methods: Array<GetBrandingPhoneProviders200ResponseProvidersInnerConfigurationAnyOf1DeliveryMethodsEnum>;
+}
+
+export const GetBrandingPhoneProviders200ResponseProvidersInnerConfigurationAnyOf1DeliveryMethodsEnum =
+  {
+    text: 'text',
+    voice: 'voice',
+  } as const;
+export type GetBrandingPhoneProviders200ResponseProvidersInnerConfigurationAnyOf1DeliveryMethodsEnum =
+  (typeof GetBrandingPhoneProviders200ResponseProvidersInnerConfigurationAnyOf1DeliveryMethodsEnum)[keyof typeof GetBrandingPhoneProviders200ResponseProvidersInnerConfigurationAnyOf1DeliveryMethodsEnum];
+
+/**
+ *
+ */
 export interface GetBreachedPasswordDetection200Response {
   [key: string]: any | any;
   /**
@@ -5138,8 +5269,6 @@ export interface GetClients200ResponseOneOf {
  */
 export interface GetClients200ResponseOneOf1 {
   /**
-   * Opaque identifier for use with the <i>from</i> query parameter for the next page of results.<br/>This identifier is valid for 24 hours.
-   *
    */
   next: string;
   /**
@@ -16056,6 +16185,35 @@ export interface TwilioFactorProvider {
 /**
  *
  */
+export interface UpdatePhoneProviderRequest {
+  /**
+   * Name of the phone notification provider
+   *
+   */
+  name?: UpdatePhoneProviderRequestNameEnum;
+  /**
+   * Whether the provider is enabled (false) or disabled (true).
+   *
+   */
+  disabled?: boolean;
+  /**
+   */
+  credentials?: CreatePhoneProviderRequestCredentials;
+  /**
+   */
+  configuration?: GetBrandingPhoneProviders200ResponseProvidersInnerConfiguration;
+}
+
+export const UpdatePhoneProviderRequestNameEnum = {
+  twilio: 'twilio',
+  custom: 'custom',
+} as const;
+export type UpdatePhoneProviderRequestNameEnum =
+  (typeof UpdatePhoneProviderRequestNameEnum)[keyof typeof UpdatePhoneProviderRequestNameEnum];
+
+/**
+ *
+ */
 export interface UserBlock {
   /**
    * Array of identifier + IP address pairs.  IP address is optional, and may be omitted in certain circumstances (such as Account Lockout mode).
@@ -16733,6 +16891,24 @@ export interface DeleteBrandingThemeRequest {
 /**
  *
  */
+export interface DeletePhoneProviderRequest {
+  /**
+   */
+  id: string;
+}
+/**
+ *
+ */
+export interface GetBrandingPhoneProvidersRequest {
+  /**
+   * Whether the provider is enabled (false) or disabled (true).
+   *
+   */
+  disabled?: boolean;
+}
+/**
+ *
+ */
 export interface GetBrandingThemeRequest {
   /**
    * The ID of the theme
@@ -16743,12 +16919,28 @@ export interface GetBrandingThemeRequest {
 /**
  *
  */
+export interface GetPhoneProviderRequest {
+  /**
+   */
+  id: string;
+}
+/**
+ *
+ */
 export interface PatchBrandingThemeRequest {
   /**
    * The ID of the theme
    *
    */
   themeId: string;
+}
+/**
+ *
+ */
+export interface UpdatePhoneProviderOperationRequest {
+  /**
+   */
+  id: string;
 }
 /**
  *
@@ -16880,7 +17072,12 @@ export interface GetClientsRequest {
    */
   app_type?: string;
   /**
-   * Advanced Query in <a href="http://www.lucenetutorial.com/lucene-query-syntax.html">Lucene</a> syntax.<br /><b>Permitted Queries</b>:<br /><ul><li><i>client_grant.organization_id:{organization_id}</i></li><li><i>client_grant.allow_any_organization:true</i></li></ul><b>Additional Restrictions</b>:<br /><ul><li>Cannot be used in combination with other filters</li><li>Requires use of the <i>from</i> and <i>take</i> paging parameters (checkpoint paginatinon)</li><li>Reduced rate limits apply. See <a href="https://auth0.com/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy/rate-limit-configurations/enterprise-public">Rate Limit Configurations</a></li></ul><i><b>Note</b>: Recent updates may not be immediately reflected in query results</i>
+   * A comma separated list of client_ids used to filter the returned clients
+   *
+   */
+  client_ids?: string;
+  /**
+   * Query in <a href ="http://www.lucenetutorial.com/lucene-query-syntax.html">Lucene query string syntax</a>.
    *
    */
   q?: string;

--- a/test/management/branding.test.ts
+++ b/test/management/branding.test.ts
@@ -946,9 +946,7 @@ describe('BrandingManager', () => {
     };
 
     beforeEach(() => {
-      const request = nock(API_URL)
-        .delete(`/branding/phone/providers/${requestParameters.id}`)
-        .reply(200, {});
+      nock(API_URL).delete(`/branding/phone/providers/${requestParameters.id}`).reply(200, {});
     });
 
     it('should return a promise when no callback is given', (done) => {

--- a/test/management/branding.test.ts
+++ b/test/management/branding.test.ts
@@ -17,6 +17,14 @@ import {
   PostBrandingTheme200Response,
   PostBrandingThemeRequest,
   ManagementClient,
+  CreatePhoneProviderRequest,
+  GetBrandingPhoneProviders200ResponseProvidersInner,
+  CreatePhoneProviderRequestNameEnum,
+  UpdatePhoneProviderOperationRequest,
+  UpdatePhoneProviderRequest,
+  DeletePhoneProviderRequest,
+  GetPhoneProviderRequest,
+  GetBrandingPhoneProviders200ResponseProvidersInnerConfigurationAnyOf,
 } from '../../src/index.js';
 
 describe('BrandingManager', () => {
@@ -730,6 +738,380 @@ describe('BrandingManager', () => {
 
       await branding.deleteTheme(params);
       expect(request.isDone()).toBe(true);
+    });
+  });
+
+  describe('#configurePhoneProvider', () => {
+    const data: CreatePhoneProviderRequest = {
+      name: 'twilio' as CreatePhoneProviderRequestNameEnum,
+      credentials: {
+        account_sid: 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        auth_token: 'your_auth_token',
+      },
+      configuration: {
+        default_from: 'default',
+        mssid: 'mssid1',
+        sid: 'sid1',
+        delivery_methods: [],
+      },
+    };
+    const response: GetBrandingPhoneProviders200ResponseProvidersInner = {
+      id: 'provider_id',
+      name: 'twilio',
+      disabled: true,
+      configuration: {
+        default_from: 'default',
+        mssid: 'mssid1',
+        sid: 'sid1',
+        delivery_methods: [],
+      },
+    };
+    let request: nock.Scope;
+
+    beforeEach(() => {
+      request = nock(API_URL).post('/branding/phone/providers', data).reply(200, response);
+    });
+
+    afterEach(() => {
+      nock.cleanAll();
+    });
+
+    it('should return a promise if no callback is given', (done) => {
+      branding
+        .configurePhoneProvider(data)
+        .then(done.bind(null, null))
+        .catch(done.bind(null, null));
+    });
+
+    it('should pass any errors to the promise catch handler', (done) => {
+      nock.cleanAll();
+
+      nock(API_URL).post('/branding/phone/providers').reply(500, {});
+
+      branding.configurePhoneProvider(data).catch((err) => {
+        expect(err).toBeDefined();
+        done();
+      });
+    });
+
+    it('should perform a POST request to /api/v2/branding/phone/providers', (done) => {
+      branding.configurePhoneProvider(data).then(() => {
+        expect(request.isDone()).toBe(true);
+        done();
+      });
+    });
+
+    it('should include the token in the Authorization header', (done) => {
+      nock.cleanAll();
+
+      const request = nock(API_URL)
+        .post('/branding/phone/providers', data)
+        .matchHeader('Authorization', `Bearer ${token}`)
+        .reply(200, response);
+
+      branding.configurePhoneProvider(data).then(() => {
+        expect(request.isDone()).toBe(true);
+        done();
+      });
+    });
+
+    it('should pass the body of the response to the "then" handler', (done) => {
+      branding.configurePhoneProvider(data).then((provider) => {
+        expect(provider.data.id).toBe(response.id);
+        expect(provider.data.name).toBe(response.name);
+        expect(provider.data.disabled).toBe(response.disabled);
+
+        const providerConfig = provider.data
+          .configuration as GetBrandingPhoneProviders200ResponseProvidersInnerConfigurationAnyOf;
+        const responseConfig =
+          response.configuration as GetBrandingPhoneProviders200ResponseProvidersInnerConfigurationAnyOf;
+
+        expect(providerConfig.default_from).toBe(responseConfig.default_from);
+        expect(providerConfig.mssid).toBe(responseConfig.mssid);
+        expect(providerConfig.sid).toBe(responseConfig.sid);
+        expect(providerConfig.delivery_methods).toEqual(responseConfig.delivery_methods);
+
+        done();
+      });
+    });
+  });
+
+  describe('#updatePhoneProvider', () => {
+    const requestParameters: UpdatePhoneProviderOperationRequest = {
+      id: 'provider_id',
+    };
+    const bodyParameters: UpdatePhoneProviderRequest = {
+      name: 'twilio' as CreatePhoneProviderRequestNameEnum,
+      credentials: {
+        account_sid: 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        auth_token: 'your_auth_token',
+      },
+      configuration: {
+        default_from: 'default',
+        mssid: 'mssid1',
+        sid: 'sid1',
+        delivery_methods: [],
+      },
+    };
+    const response: GetBrandingPhoneProviders200ResponseProvidersInner = {
+      id: 'provider_id',
+      name: 'twilio',
+      disabled: true,
+      configuration: {
+        default_from: 'default',
+        mssid: 'mssid1',
+        sid: 'sid1',
+        delivery_methods: [], // Add the required delivery_methods field
+      },
+    };
+    let request: nock.Scope;
+
+    beforeEach(() => {
+      request = nock(API_URL)
+        .patch(`/branding/phone/providers/${requestParameters.id}`)
+        .reply(200, response);
+    });
+
+    it('should return a promise if no callback is given', (done) => {
+      branding
+        .updatePhoneProvider(requestParameters, bodyParameters)
+        .then(done.bind(null, null))
+        .catch(done.bind(null, null));
+    });
+
+    it('should pass any errors to the promise catch handler', (done) => {
+      nock.cleanAll();
+
+      nock(API_URL).patch(`/branding/phone/providers/${requestParameters.id}`).reply(500, {});
+
+      branding.updatePhoneProvider(requestParameters, bodyParameters).catch((err) => {
+        expect(err).toBeInstanceOf(Error);
+
+        done();
+      });
+    });
+
+    it('should perform a PATCH request to /branding/phone/providers/:id', (done) => {
+      nock.cleanAll();
+
+      request = nock(API_URL)
+        .patch(`/branding/phone/providers/${requestParameters.id}`, bodyParameters as any)
+        .reply(200, response);
+
+      branding.updatePhoneProvider(requestParameters, bodyParameters).then(() => {
+        expect(request.isDone()).toBe(true);
+
+        done();
+      });
+    });
+
+    it('should pass the data in the body of the request', (done) => {
+      nock.cleanAll();
+
+      const request = nock(API_URL)
+        .patch(`/branding/phone/providers/${requestParameters.id}`, bodyParameters as any)
+        .reply(200, response);
+
+      branding.updatePhoneProvider(requestParameters, bodyParameters).then(() => {
+        expect(request.isDone()).toBe(true);
+
+        done();
+      });
+    });
+
+    it('should pass the body of the response to the "then" handler', (done) => {
+      branding.updatePhoneProvider(requestParameters, bodyParameters).then((provider) => {
+        expect(provider.data.id).toBe(response.id);
+        expect(provider.data.name).toBe(response.name);
+        expect(provider.data.disabled).toBe(response.disabled);
+
+        const providerConfig = provider.data
+          .configuration as GetBrandingPhoneProviders200ResponseProvidersInnerConfigurationAnyOf;
+        const responseConfig =
+          response.configuration as GetBrandingPhoneProviders200ResponseProvidersInnerConfigurationAnyOf;
+
+        expect(providerConfig.default_from).toBe(responseConfig.default_from);
+        expect(providerConfig.mssid).toBe(responseConfig.mssid);
+        expect(providerConfig.sid).toBe(responseConfig.sid);
+        expect(providerConfig.delivery_methods).toEqual(responseConfig.delivery_methods);
+
+        done();
+      });
+    });
+  });
+
+  describe('#deletePhoneProvider', () => {
+    const requestParameters: DeletePhoneProviderRequest = {
+      id: 'provider_id',
+    };
+
+    beforeEach(() => {
+      const request = nock(API_URL)
+        .delete(`/branding/phone/providers/${requestParameters.id}`)
+        .reply(200, {});
+    });
+
+    it('should return a promise when no callback is given', (done) => {
+      branding.deletePhoneProvider(requestParameters).then(done.bind(null, null));
+    });
+
+    it('should perform a DELETE request to /branding/phone/providers/:id', (done) => {
+      nock.cleanAll();
+
+      const request = nock(API_URL)
+        .delete(`/branding/phone/providers/${requestParameters.id}`)
+        .reply(204);
+
+      branding.deletePhoneProvider(requestParameters).then(() => {
+        expect(request.isDone()).toBe(true);
+
+        done();
+      });
+    });
+  });
+
+  describe('#getAllPhoneProviders', () => {
+    let request: nock.Scope;
+
+    beforeEach(() => {
+      nock.cleanAll();
+      request = nock(API_URL).get('/branding/phone/providers').reply(200, []);
+    });
+
+    it('should return a promise if no callback is given', (done) => {
+      branding.getAllPhoneProviders().then(done.bind(null, null)).catch(done.bind(null, null));
+    });
+
+    it('should pass any errors to the promise catch handler', (done) => {
+      nock.cleanAll();
+
+      nock(API_URL).get('/branding/phone/providers').reply(500, {});
+
+      branding.getAllPhoneProviders().catch((err) => {
+        expect(err).toBeDefined();
+        done();
+      });
+    });
+
+    it('should pass the body of the response to the "then" handler', (done) => {
+      nock.cleanAll();
+
+      const data = [{ name: 'twilio' }];
+      nock(API_URL).get('/branding/phone/providers').reply(200, data);
+
+      branding.getAllPhoneProviders().then((result) => {
+        expect(result.data).toBeInstanceOf(Array);
+
+        expect(result.data.length).toBe(data.length);
+
+        expect(result.data[0].name).toBe(data[0].name);
+
+        done();
+      });
+    });
+
+    it('should perform a GET request to /branding/phone/providers', (done) => {
+      branding.getAllPhoneProviders().then(() => {
+        expect(request.isDone()).toBe(true);
+        done();
+      });
+    });
+
+    it('should include the token in the Authorization header', (done) => {
+      nock.cleanAll();
+
+      const request = nock(API_URL)
+        .get('/branding/phone/providers')
+        .matchHeader('Authorization', `Bearer ${token}`)
+        .reply(200, []);
+
+      branding.getAllPhoneProviders().then(() => {
+        expect(request.isDone()).toBe(true);
+        done();
+      });
+    });
+  });
+
+  describe('#getPhoneProvider', () => {
+    const requestParameters: GetPhoneProviderRequest = {
+      id: 'provider_id',
+    };
+    const response: GetBrandingPhoneProviders200ResponseProvidersInner = {
+      id: 'provider_id',
+      name: 'twilio',
+      disabled: true,
+      configuration: {
+        default_from: 'deafult',
+        mssid: 'mssid1',
+        sid: 'sid1',
+        delivery_methods: [],
+      },
+    };
+
+    let request: nock.Scope;
+
+    beforeEach(() => {
+      nock.cleanAll();
+      request = nock(API_URL)
+        .get(`/branding/phone/providers/${requestParameters.id}`)
+        .reply(200, response);
+    });
+
+    it('should return a promise if no callback is given', (done) => {
+      branding
+        .getPhoneProvider(requestParameters)
+        .then(done.bind(null, null))
+        .catch(done.bind(null, null));
+    });
+
+    it('should pass any errors to the promise catch handler', (done) => {
+      nock.cleanAll();
+      request = nock(API_URL)
+        .get(`/branding/phone/providers/${requestParameters.id}`)
+        .reply(500, {});
+
+      branding.getPhoneProvider(requestParameters).catch((err) => {
+        expect(err).toBeDefined();
+        done();
+      });
+    });
+
+    it('should perform a GET request to /branding/phone/providers/:id', (done) => {
+      branding
+        .getPhoneProvider(requestParameters)
+        .then(() => {
+          expect(request.isDone()).toBe(true);
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should include the token in the Authorization header', (done) => {
+      nock.cleanAll();
+      const request = nock(API_URL)
+        .get(`/branding/phone/providers/${requestParameters.id}`)
+        .matchHeader('Authorization', `Bearer ${token}`)
+        .reply(200, response);
+
+      branding
+        .getPhoneProvider(requestParameters)
+        .then(() => {
+          expect(request.isDone()).toBe(true);
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should pass the body of the response to the "then" handler', (done) => {
+      branding
+        .getPhoneProvider(requestParameters)
+        .then((result) => {
+          expect(result.data.id).toBe(response.id);
+          expect(result.data.name).toBe(response.name);
+          expect(result.data.disabled).toBe(response.disabled);
+          done();
+        })
+        .catch(done);
     });
   });
 });


### PR DESCRIPTION
### Changes

Added support for extensibility as a custom provider in BrandingManager.

New Methods Added:
ListPhoneProviders
ReadPhoneProvider
CreatePhoneProvider
DeletePhoneProvider
UpdatePhoneProvider

### References

[List Phone Providers](https://auth0.com/docs/api/management/v2/branding/get-branding-phone-providers)
[Create Phone Provider](https://auth0.com/docs/api/management/v2/branding/create-phone-provider)
[Get Phone Provider](https://auth0.com/docs/api/management/v2/branding/get-phone-provider)
[Delete Phone Provider](https://auth0.com/docs/api/management/v2/branding/delete-phone-provider)
[Update Phone Provider](https://auth0.com/docs/api/management/v2/branding/update-phone-provider)

### Testing

Verified new API endpoints by making requests to Auth0 Management API.
Ensured coverage with unit tests for new methods.

### Manual Testing guide

1. Securely store your Client ID, Client Secret, and Management API token.
2. Install the SDK: npm install auth0

var management = new ManagementClient({
  domain: '{YOUR_TENANT_AND REGION}.auth0.com',
  clientId: '{YOUR_CLIENT_ID}',
  clientSecret: '{YOUR_CLIENT_SECRET}',
});

const phoneProviders = await management.getAllPhoneProviders();
const phoneProvider = await management.getPhoneProvider('{YOUR_PROVIDER_ID');

###  Checklist

 All new/changed/fixed functionality is covered by tests (or N/A)
 I have added documentation for all new/changed functionality (or N/A)
