### PR TITLE
Add support for RAR when using CIBA

### DIFF
--- a/src/auth/backchannel.ts
+++ b/src/auth/backchannel.ts
@@ -98,6 +98,11 @@ export type AuthorizeOptions = {
    * Optional parameter for subject issuer context.
    */
   subjectIssuerContext?: string;
+  /**
+   * Optional authorization details to use Rich Authorization Requests (RAR).
+   * @see https://auth0.com/docs/get-started/apis/configure-rich-authorization-requests
+   */
+  authorization_details?: string;
 };
 
 type AuthorizeRequest = Omit<AuthorizeOptions, 'userId'> &
@@ -133,6 +138,11 @@ export type TokenResponse = {
    * The scopes associated with the token.
    */
   scope: string;
+  /**
+   * Optional authorization details when using Rich Authorization Requests (RAR).
+   * @see https://auth0.com/docs/get-started/apis/configure-rich-authorization-requests
+   */
+  authorization_details?: string;
 };
 
 /**

--- a/src/auth/backchannel.ts
+++ b/src/auth/backchannel.ts
@@ -103,7 +103,7 @@ export type AuthorizeOptions = {
    * @see https://auth0.com/docs/get-started/apis/configure-rich-authorization-requests
    */
   authorization_details?: string;
-};
+} & Record<string, string>;
 
 type AuthorizeRequest = Omit<AuthorizeOptions, 'userId'> &
   AuthorizeCredentialsPartial & {

--- a/test/auth/backchannel.test.ts
+++ b/test/auth/backchannel.test.ts
@@ -1,4 +1,5 @@
 import nock from 'nock';
+import querystring from 'querystring';
 
 import { AuthorizeOptions, Backchannel } from '../../src/auth/backchannel.js';
 
@@ -88,6 +89,31 @@ describe('Backchannel', () => {
         expires_in: 300,
         interval: 5,
       });
+    });
+
+    it('should pass authorization_details to /bc-authorize', async () => {
+      let receivedAuthorizationDetails: { type: string }[] = [];
+      nock(`https://${opts.domain}`)
+        .post('/bc-authorize')
+        .reply(201, (uri, requestBody, cb) => {
+          receivedAuthorizationDetails = JSON.parse(
+            querystring.parse(requestBody as any)['authorization_details'] as string
+          );
+          cb(null, {
+            auth_req_id: 'test-auth-req-id',
+            expires_in: 300,
+            interval: 5,
+          });
+        });
+
+      await backchannel.authorize({
+        userId: 'auth0|test-user-id',
+        binding_message: 'Test binding message',
+        scope: 'openid',
+        authorization_details: JSON.stringify([{ type: 'test-type' }]),
+      });
+
+      expect(receivedAuthorizationDetails[0].type).toBe('test-type');
     });
 
     it('should throw for invalid request', async () => {
@@ -185,6 +211,29 @@ describe('Backchannel', () => {
         id_token: 'test-id-token',
         expires_in: 86400,
         scope: 'openid',
+      });
+    });
+
+    it('should return token response, including authorization_details when available', async () => {
+      const authorization_details = JSON.stringify([{ type: 'test-type' }]);
+      nock(`https://${opts.domain}`).post('/oauth/token').reply(200, {
+        access_token: 'test-access-token',
+        id_token: 'test-id-token',
+        expires_in: 86400,
+        scope: 'openid',
+        authorization_details,
+      });
+
+      await expect(
+        backchannel.backchannelGrant({
+          auth_req_id: 'test-auth-req-id',
+        })
+      ).resolves.toMatchObject({
+        access_token: 'test-access-token',
+        id_token: 'test-id-token',
+        expires_in: 86400,
+        scope: 'openid',
+        authorization_details,
       });
     });
 

--- a/test/auth/backchannel.test.ts
+++ b/test/auth/backchannel.test.ts
@@ -116,6 +116,29 @@ describe('Backchannel', () => {
       expect(receivedAuthorizationDetails[0].type).toBe('test-type');
     });
 
+    it('should pass custom parameters to /bc-authorize', async () => {
+      let receivedCustomParam = '';
+      nock(`https://${opts.domain}`)
+        .post('/bc-authorize')
+        .reply(201, (uri, requestBody, cb) => {
+          receivedCustomParam = querystring.parse(requestBody as any)['custom_param'] as string;
+          cb(null, {
+            auth_req_id: 'test-auth-req-id',
+            expires_in: 300,
+            interval: 5,
+          });
+        });
+
+      await backchannel.authorize({
+        userId: 'auth0|test-user-id',
+        binding_message: 'Test binding message',
+        scope: 'openid',
+        custom_param: '<custom_param>',
+      });
+
+      expect(receivedCustomParam).toBe('<custom_param>');
+    });
+
     it('should throw for invalid request', async () => {
       nock(`https://${opts.domain}`).post('/bc-authorize').reply(400, {
         error: 'invalid_request',


### PR DESCRIPTION
### Changes

Adding support for RAR when using CIBA by allowing for the `authorization_details` to be passed as a string, set to a stringified JSON array.

Additionally, also adding support for any arbitrary property to be sent to Auth0.

### References

N/A

### Testing

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
