### PR TITLE
Added pre-change-password field in attackprotection-manager

### DIFF
--- a/src/management/__generated/managers/attack-protection-manager.ts
+++ b/src/management/__generated/managers/attack-protection-manager.ts
@@ -16,7 +16,8 @@ const { BaseAPI } = runtime;
  */
 export class AttackProtectionManager extends BaseAPI {
   /**
-   * Get breached password detection settings
+   * Retrieve details of the Breached Password Detection configuration of your tenant.
+   * Get Breached Password Detection settings
    *
    * @throws {RequiredError}
    */
@@ -73,7 +74,8 @@ export class AttackProtectionManager extends BaseAPI {
   }
 
   /**
-   * Update breached password detection settings
+   * Update details of the Breached Password Detection configuration of your tenant.
+   * Update Breached Password Detection settings
    *
    * @throws {RequiredError}
    */

--- a/src/management/__generated/models/index.ts
+++ b/src/management/__generated/models/index.ts
@@ -5172,7 +5172,29 @@ export interface GetBreachedPasswordDetection200ResponseStage {
   /**
    */
   'pre-user-registration': GetBreachedPasswordDetection200ResponseStagePreUserRegistration;
+  /**
+   */
+  'pre-change-password': GetBreachedPasswordDetection200ResponseStagePreChangePassword;
 }
+/**
+ *
+ */
+export interface GetBreachedPasswordDetection200ResponseStagePreChangePassword {
+  /**
+   * Action to take when a breached password is detected during a password reset.
+   *               Possible values: <code>block</code>, <code>admin_notification</code>.
+   *
+   */
+  shields: Array<GetBreachedPasswordDetection200ResponseStagePreChangePasswordShieldsEnum>;
+}
+
+export const GetBreachedPasswordDetection200ResponseStagePreChangePasswordShieldsEnum = {
+  block: 'block',
+  admin_notification: 'admin_notification',
+} as const;
+export type GetBreachedPasswordDetection200ResponseStagePreChangePasswordShieldsEnum =
+  (typeof GetBreachedPasswordDetection200ResponseStagePreChangePasswordShieldsEnum)[keyof typeof GetBreachedPasswordDetection200ResponseStagePreChangePasswordShieldsEnum];
+
 /**
  *
  */
@@ -9082,7 +9104,29 @@ export interface PatchBreachedPasswordDetectionRequestStage {
   /**
    */
   'pre-user-registration'?: PatchBreachedPasswordDetectionRequestStagePreUserRegistration;
+  /**
+   */
+  'pre-change-password'?: PatchBreachedPasswordDetectionRequestStagePreChangePassword;
 }
+/**
+ *
+ */
+export interface PatchBreachedPasswordDetectionRequestStagePreChangePassword {
+  /**
+   * Action to take when a breached password is detected during a password reset.
+   *               Possible values: <code>block</code>, <code>admin_notification</code>.
+   *
+   */
+  shields?: Array<PatchBreachedPasswordDetectionRequestStagePreChangePasswordShieldsEnum>;
+}
+
+export const PatchBreachedPasswordDetectionRequestStagePreChangePasswordShieldsEnum = {
+  block: 'block',
+  admin_notification: 'admin_notification',
+} as const;
+export type PatchBreachedPasswordDetectionRequestStagePreChangePasswordShieldsEnum =
+  (typeof PatchBreachedPasswordDetectionRequestStagePreChangePasswordShieldsEnum)[keyof typeof PatchBreachedPasswordDetectionRequestStagePreChangePasswordShieldsEnum];
+
 /**
  *
  */


### PR DESCRIPTION
### Changes

Added pre-change-password field in Attack Protection Manager

| Path                                          | HTTP Method | Method Name                        |
|-----------------------------------------------|-------------|------------------------------------|
| /attack-protection/breached-password-detection | PATCH       | updateBreachedPasswordDetectionConfig |
| /attack-protection/breached-password-detection | GET         | getBreachedPasswordDetectionConfig    |
 
### References

https://oktawiki.atlassian.net/wiki/spaces/~71202061d7c7239fdb49caa9a56b9ff980bdee/pages/3225781013/BPD+Schema

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
