### PR TITLE
Fix crash on edge runtimes #996

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,8 +6,10 @@ import { version } from './version.js';
 export const generateClientInfo = () => ({
   name: 'node-auth0',
   version: version,
-  env: {
+  env: 'version' in process ? {
     node: process.version.replace('v', ''),
+  } : {
+    edge: true,
   },
 });
 


### PR DESCRIPTION
### Changes

This library crashes on edge runtimes such as Vercel and Cloudflare because it tries to reference `process.version` which doesn't exist and causes an exception.

### References

Please include relevant links supporting this change such as a:

https://github.com/auth0/node-auth0/issues/996

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
