### PR TITLE
Added support for ACUL Prompt Rendering Endpoint

### DIFF
--- a/src/management/__generated/managers/prompts-manager.ts
+++ b/src/management/__generated/managers/prompts-manager.ts
@@ -1,11 +1,15 @@
 import * as runtime from '../../../lib/runtime.js';
 import type { InitOverride, ApiResponse } from '../../../lib/runtime.js';
 import type {
+  GetAllRendering200Response,
   GetRendering200Response,
   PatchRendering200Response,
   PatchRenderingRequest,
   PromptsSettings,
   PromptsSettingsUpdate,
+  GetAllRendering200ResponseOneOf,
+  GetAllRendering200ResponseOneOfInner,
+  GetAllRenderingRequest,
   GetCustomTextByLanguageRequest,
   GetPartialsRequest,
   GetRenderingRequest,
@@ -20,6 +24,71 @@ const { BaseAPI } = runtime;
  *
  */
 export class PromptsManager extends BaseAPI {
+  /**
+   * Get render setting configurations for all screens.
+   * Get render setting configurations for all screens
+   *
+   * @throws {RequiredError}
+   */
+  async getAllRenderingSettings(
+    requestParameters: GetAllRenderingRequest & { include_totals: true },
+    initOverrides?: InitOverride
+  ): Promise<ApiResponse<GetAllRendering200ResponseOneOf>>;
+  async getAllRenderingSettings(
+    requestParameters?: GetAllRenderingRequest,
+    initOverrides?: InitOverride
+  ): Promise<ApiResponse<Array<GetAllRendering200ResponseOneOfInner>>>;
+  async getAllRenderingSettings(
+    requestParameters: GetAllRenderingRequest = {},
+    initOverrides?: InitOverride
+  ): Promise<ApiResponse<GetAllRendering200Response>> {
+    const queryParameters = runtime.applyQueryParams(requestParameters, [
+      {
+        key: 'fields',
+        config: {},
+      },
+      {
+        key: 'include_fields',
+        config: {},
+      },
+      {
+        key: 'page',
+        config: {},
+      },
+      {
+        key: 'per_page',
+        config: {},
+      },
+      {
+        key: 'include_totals',
+        config: {},
+      },
+      {
+        key: 'prompt',
+        config: {},
+      },
+      {
+        key: 'screen',
+        config: {},
+      },
+      {
+        key: 'rendering_mode',
+        config: {},
+      },
+    ]);
+
+    const response = await this.request(
+      {
+        path: `/prompts/rendering`,
+        method: 'GET',
+        query: queryParameters,
+      },
+      initOverrides
+    );
+
+    return runtime.JSONApiResponse.fromResponse(response);
+  }
+
   /**
    * Retrieve custom text for a specific prompt and language.
    * Get custom text for a prompt

--- a/src/management/__generated/models/index.ts
+++ b/src/management/__generated/models/index.ts
@@ -4788,6 +4788,69 @@ export type GetActions200ResponseActionsInnerSupportedTriggersInnerIdAnyOf =
 /**
  *
  */
+export type GetAllRendering200Response =
+  | Array<GetAllRendering200ResponseOneOfInner>
+  | GetAllRendering200ResponseOneOf;
+/**
+ *
+ */
+export interface GetAllRendering200ResponseOneOf {
+  /**
+   */
+  configs: Array<GetAllRendering200ResponseOneOfInner>;
+  /**
+   * the index of the first configuration in the response (before filtering)
+   *
+   */
+  start: number;
+  /**
+   * the maximum number of configurations shown per page (before filtering)
+   *
+   */
+  limit: number;
+  /**
+   * the total number of configurations on this tenant
+   *
+   */
+  total: number;
+}
+/**
+ *
+ */
+export interface GetAllRendering200ResponseOneOfInner {
+  [key: string]: any | any;
+  /**
+   * Rendering mode
+   *
+   */
+  rendering_mode: GetAllRendering200ResponseOneOfInnerRenderingModeEnum;
+  /**
+   * Context values to make available
+   *
+   */
+  context_configuration: Array<string>;
+  /**
+   * Override Universal Login default head tags
+   *
+   */
+  default_head_tags_disabled: boolean | null;
+  /**
+   * An array of head tags
+   *
+   */
+  head_tags: Array<GetRendering200ResponseHeadTagsInner>;
+}
+
+export const GetAllRendering200ResponseOneOfInnerRenderingModeEnum = {
+  advanced: 'advanced',
+  standard: 'standard',
+} as const;
+export type GetAllRendering200ResponseOneOfInnerRenderingModeEnum =
+  (typeof GetAllRendering200ResponseOneOfInnerRenderingModeEnum)[keyof typeof GetAllRendering200ResponseOneOfInnerRenderingModeEnum];
+
+/**
+ *
+ */
 export interface GetApns200Response {
   /**
    */
@@ -19612,6 +19675,62 @@ export interface PostOrganizationMemberRolesOperationRequest {
    *
    */
   user_id: string;
+}
+
+/**
+ *
+ */
+export const GetAllRenderingRenderingModeEnum = {
+  advanced: 'advanced',
+  standard: 'standard',
+} as const;
+export type GetAllRenderingRenderingModeEnum =
+  (typeof GetAllRenderingRenderingModeEnum)[keyof typeof GetAllRenderingRenderingModeEnum];
+
+/**
+ *
+ */
+export interface GetAllRenderingRequest {
+  /**
+   * Comma-separated list of fields to include or exclude (based on value provided for include_fields) in the result. Leave empty to retrieve all fields.
+   *
+   */
+  fields?: string;
+  /**
+   * Whether specified fields are to be included (default: true) or excluded (false).
+   *
+   */
+  include_fields?: boolean;
+  /**
+   * Page index of the results to return. First page is 0.
+   *
+   */
+  page?: number;
+  /**
+   * Number of results per page. Maximum value is 100, default value is 50.
+   *
+   */
+  per_page?: number;
+  /**
+   * Return results inside an object that contains the total configuration count (true) or as a direct array of results (false, default).
+   *
+   */
+  include_totals?: boolean;
+  /**
+   * Name of the prompt to filter by
+   *
+   */
+  prompt?: string;
+  /**
+   * Name of the screen to filter by
+   *
+   */
+  screen?: string;
+  /**
+   * Rendering mode to filter by
+   *
+   */
+  rendering_mode?: GetAllRenderingRenderingModeEnum;
 }
 
 /**

--- a/test/management/prompts.test.ts
+++ b/test/management/prompts.test.ts
@@ -14,6 +14,7 @@ import {
   PutPartialsPromptEnum,
   GetRendering200Response,
   PatchRenderingRequest,
+  GetAllRendering200ResponseOneOfInner,
 } from '../../src/index.js';
 
 import { checkMethod } from './tests.util.js';
@@ -474,5 +475,70 @@ describe('PromptsManager', () => {
     const uri = `/prompts/login/screen/consent/rendering`;
     const method = 'patch';
     checkMethod({ operation, uri, method });
+  });
+
+  describe('#getAllRenderingSettings', () => {
+    const data: Partial<GetAllRendering200ResponseOneOfInner>[] = [
+      {
+        default_head_tags_disabled: true,
+      },
+    ];
+    let request: nock.Scope;
+
+    beforeEach(() => {
+      request = nock(API_URL).get('/prompts/rendering').reply(200, data);
+    });
+
+    it('should return a promise if no callback is given', (done) => {
+      prompts.getAllRenderingSettings().then(done.bind(null, null)).catch(done.bind(null, null));
+    });
+
+    it('should pass any errors to the promise catch handler', (done) => {
+      nock.cleanAll();
+
+      nock(API_URL).get('/prompts/rendering').reply(500, {});
+
+      prompts.getAllRenderingSettings().catch((err) => {
+        expect(err).toBeDefined();
+
+        done();
+      });
+    });
+
+    it('should pass the body of the response to the "then" handler', (done) => {
+      nock.cleanAll();
+
+      nock(API_URL).get('/prompts/rendering').reply(200, data);
+
+      prompts.getAllRenderingSettings().then((provider) => {
+        expect(provider.data[0].default_head_tags_disabled).toEqual(
+          data[0].default_head_tags_disabled
+        );
+        done();
+      });
+    });
+
+    it('should perform a GET request to /api/v2/prompts/rendering', (done) => {
+      prompts.getAllRenderingSettings().then(() => {
+        expect(request.isDone()).toBe(true);
+
+        done();
+      });
+    });
+
+    it('should include the token in the Authorization header', (done) => {
+      nock.cleanAll();
+
+      const request = nock(API_URL)
+        .get('/prompts/rendering')
+        .matchHeader('Authorization', `Bearer ${token}`)
+        .reply(200, {});
+
+      prompts.getAllRenderingSettings().then(() => {
+        expect(request.isDone()).toBe(true);
+
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
### Changes

**New method in PromptsManager**: Added **getAllRenderingSettings** to fetch rendering configurations for prompts and screens.

**New types and interfaces**:

1. GetAllRendering200Response: Represents the response for rendering settings.
2. GetAllRendering200ResponseOneOf and GetAllRendering200ResponseOneOfInner: Define structure for rendering configuration details.
3. GetAllRenderingRequest: Specifies request parameters for the new API.
4. Enum for rendering mode: Added GetAllRenderingRenderingModeEnum with values advanced and standard.

### References

https://oktawiki.atlassian.net/wiki/spaces/IULX/pages/3232859634/RFC+API+endpoint+to+get+all+ACUL+configured+screens

### Manual Testing 

Securely store your Client ID, Client Secret, and Management API token.
Install the SDK: npm install auth0

```
var auth0 = new ManagementClient({
domain: '{YOUR_TENANT_AND REGION}.auth0.com',
clientId: '{YOUR_CLIENT_ID}',
clientSecret: '{YOUR_CLIENT_SECRET}',
});

const resp = auth01.prompts.getAllRenderingSettings();
console.log("resp", resp.then((data) => {
  console.log("data", data);
}))
```

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
