### PR TITLE
Updated logger

### DIFF
--- a/src/lib/runtime.ts
+++ b/src/lib/runtime.ts
@@ -151,7 +151,8 @@ export class BaseAPI {
       if (response === undefined) {
         throw new FetchError(
           error as Error,
-          'The request failed and the interceptors did not return an alternative response'
+          error?.message ??
+            'The request failed and the interceptors did not return an alternative response'
         );
       }
     } else {


### PR DESCRIPTION
While parsing FetchError when response is undefined, the static message overrides the actual error message