### PR TITLE
Added Support for ACUL R7 on GetAllRendering Endpoint

### DIFF
--- a/src/management/__generated/models/index.ts
+++ b/src/management/__generated/models/index.ts
@@ -4957,6 +4957,14 @@ export interface GetAllRendering200ResponseOneOfInner {
    *
    */
   head_tags: Array<GetRendering200ResponseHeadTagsInner>;
+  /**
+   */
+  filters?: GetRendering200ResponseFilters | null;
+  /**
+   * Use page template with ACUL
+   *
+   */
+  use_page_template?: boolean | null;
 }
 
 export const GetAllRendering200ResponseOneOfInnerRenderingModeEnum = {

--- a/test/management/prompts.test.ts
+++ b/test/management/prompts.test.ts
@@ -484,6 +484,7 @@ describe('PromptsManager', () => {
     const data: Partial<GetAllRendering200ResponseOneOfInner>[] = [
       {
         default_head_tags_disabled: true,
+        use_page_template: false,
       },
     ];
     let request: nock.Scope;
@@ -517,6 +518,7 @@ describe('PromptsManager', () => {
         expect(provider.data[0].default_head_tags_disabled).toEqual(
           data[0].default_head_tags_disabled
         );
+        expect(provider.data[0].use_page_template).toEqual(data[0].use_page_template);
         done();
       });
     });


### PR DESCRIPTION
### Changes

Updated below Endpoint - 

| Path | HTTP Method | Method Name
| -- | -- | --
|/prompts/rendering | GET | getAllRenderingSettings

Added two new fields `filters` and `use_page_template`

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
