### PR TITLE
Fix default retry limit description

### DIFF
--- a/src/lib/retry.ts
+++ b/src/lib/retry.ts
@@ -29,7 +29,7 @@ async function pause(delay: number) {
 
 /**
  * Configure the retry logic for http calls.
- * By default, this retries any request that returns a 429 3 times.
+ * By default, this retries any request that returns an HTTP 429 response.
  */
 export interface RetryConfiguration {
   /**

--- a/src/lib/retry.ts
+++ b/src/lib/retry.ts
@@ -39,7 +39,7 @@ export interface RetryConfiguration {
   enabled?: boolean;
   /**
    * Configure the max amount of retries the SDK should do.
-   * Defaults to 5.
+   * Defaults to 3.
    */
   maxRetries?: number;
   /**


### PR DESCRIPTION
### Changes

The `RetryConfiguration` interface previously mentioned a default of 3 retries for failing requests, while the `maxRetries` property description stated a default of 5, creating a mismatch. To simplify maintenance, I removed the default value note from the interface so that the single source of truth is the `maxRetries` description.

I also corrected the `maxRetries` default value in its description to 3 (not 5), aligning it with the `DEFAULT_NUMBER_RETRIES` constant: https://github.com/auth0/node-auth0/blob/v4.26.0/src/lib/retry.ts#L3