### PR TITLE
Added Support for DPOP in Resource Server

### DIFF
--- a/src/management/__generated/models/index.ts
+++ b/src/management/__generated/models/index.ts
@@ -15972,6 +15972,7 @@ export interface ResourceServerProofOfPossession {
 
 export const ResourceServerProofOfPossessionMechanismEnum = {
   mtls: 'mtls',
+  dpop: 'dpop',
 } as const;
 export type ResourceServerProofOfPossessionMechanismEnum =
   (typeof ResourceServerProofOfPossessionMechanismEnum)[keyof typeof ResourceServerProofOfPossessionMechanismEnum];

--- a/test/management/resource-servers.test.ts
+++ b/test/management/resource-servers.test.ts
@@ -3,7 +3,11 @@ import queryString from 'querystring';
 
 const API_URL = 'https://tenant.auth0.com/api/v2';
 
-import { ResourceServersManager, ManagementClient } from '../../src/index.js';
+import {
+  ResourceServersManager,
+  ManagementClient,
+  ResourceServerProofOfPossessionMechanismEnum,
+} from '../../src/index.js';
 
 describe('ResourceServersManager', () => {
   let resourceServers: ResourceServersManager;
@@ -60,7 +64,15 @@ describe('ResourceServersManager', () => {
     it('should pass the body of the response to the "then" handler', (done) => {
       nock.cleanAll();
 
-      const data = [{ id: '123' }];
+      const data = [
+        {
+          id: '123',
+          proof_of_possession: {
+            mechanism: ResourceServerProofOfPossessionMechanismEnum.dpop,
+            required: true,
+          },
+        },
+      ];
       nock(API_URL).get('/resource-servers').reply(200, data);
 
       resourceServers.getAll().then((resourceServers) => {
@@ -69,6 +81,12 @@ describe('ResourceServersManager', () => {
         expect(resourceServers.data.length).toBe(data.length);
 
         expect(resourceServers.data[0].id).toBe(data[0].id);
+        expect(resourceServers.data[0].proof_of_possession?.mechanism).toBe(
+          data[0].proof_of_possession.mechanism
+        );
+        expect(resourceServers.data[0].proof_of_possession?.required).toBe(
+          data[0].proof_of_possession.required
+        );
 
         done();
       });
@@ -109,6 +127,10 @@ describe('ResourceServersManager', () => {
     const data = {
       id: params.id,
       name: 'Test Resource Server',
+      proof_of_possession: {
+        mechanism: ResourceServerProofOfPossessionMechanismEnum.dpop,
+        required: true,
+      },
     };
     let request: nock.Scope;
 
@@ -139,6 +161,12 @@ describe('ResourceServersManager', () => {
 
       resourceServers.get(params).then((resourceServer) => {
         expect(resourceServer.data.id).toBe(data.id);
+        expect(resourceServer.data.proof_of_possession?.mechanism).toBe(
+          data.proof_of_possession.mechanism
+        );
+        expect(resourceServer.data.proof_of_possession?.required).toBe(
+          data.proof_of_possession.required
+        );
 
         done();
       });
@@ -173,6 +201,10 @@ describe('ResourceServersManager', () => {
       name: 'Acme Backend API',
       options: {},
       identifier: '123',
+      proof_of_possession: {
+        mechanism: ResourceServerProofOfPossessionMechanismEnum.dpop,
+        required: true,
+      },
     };
     let request: nock.Scope;
 
@@ -238,6 +270,10 @@ describe('ResourceServersManager', () => {
       id: '5',
       name: 'Acme Backend API',
       options: {},
+      proof_of_possession: {
+        mechanism: ResourceServerProofOfPossessionMechanismEnum.dpop, // use the enum value
+        required: true,
+      },
     };
     let request: nock.Scope;
 


### PR DESCRIPTION
### Changes

Updated below Endpoint - 

| Path | HTTP Method | Method Name
| -- | -- | -- |
| /resource-servers | GET | getAll |
| /resource-servers | POST | create |
| /resource-servers | GET | get |
| /resource-servers | PATCH | update |

Added "dpop" as mechanism for Proof-of-Possession

### References

https://auth0.com/docs/api/management/v2/resource-servers/get-resource-servers
https://auth0.com/docs/api/management/v2/resource-servers/post-resource-servers
https://auth0.com/docs/api/management/v2/resource-servers/get-resource-servers-by-id
https://auth0.com/docs/api/management/v2/resource-servers/patch-resource-servers-by-id

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
