### PR TITLE
feat: add prepare script to ensure builds before publishing

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -28,7 +28,7 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: npm ci --include=dev
+      run: npm ci --include=dev --ignore-scripts
 
     - name: Build package
       if: inputs.require-build == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
     needs: rl-scanner
     with:
       node-version: 18
-      require-build: true
+      require-build: false
     secrets:
       npm-token: ${{ secrets.NPM_TOKEN }}
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rl-secure.yml
+++ b/.github/workflows/rl-secure.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install dependencies
         shell: bash
-        run: npm ci --include=dev
+        run: npm ci --include=dev --ignore-scripts
 
       - name: Build
         shell: bash
@@ -56,8 +56,8 @@ jobs:
         id: rl-scan-conclusion
         uses: ./.github/actions/rl-scanner
         with:
-          artifact-path: "$(pwd)/${{ inputs.artifact-name }}"
-          version: "${{ steps.get_version.outputs.version }}"
+          artifact-path: '$(pwd)/${{ inputs.artifact-name }}'
+          version: '${{ steps.get_version.outputs.version }}'
         env:
           RLSECURE_LICENSE: ${{ secrets.RLSECURE_LICENSE }}
           RLSECURE_SITE_KEY: ${{ secrets.RLSECURE_SITE_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install dependencies
         shell: bash
-        run: npm ci --include=dev
+        run: npm ci --include=dev --ignore-scripts
 
       - name: ESLint
         shell: bash

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "precommit": "pretty-quick --staged",
     "lint": "eslint ./src ./test --ext ts",
     "lint:package": "publint",
+    "prepare": "npm run build",
     "start:playground": "node --experimental-specifier-resolution=node --no-warnings --loader ts-node/esm playground/index.ts"
   },
   "repository": {


### PR DESCRIPTION
### Changes

This PR adds a `prepare` script to automatically build the package before publishing and optimizes CI workflows to eliminate duplicate builds.

**What's changing:**
- **Added new `prepare` script** to `package.json` that runs `npm run build` before publishing
- **Updated CI workflows** to use `--ignore-scripts` flag during dependency installation
- **Set `require-build: false`** in release workflow to prevent explicit builds

**No breaking changes** - end users installing the package are unaffected as they receive pre-built artifacts.

### References

- [npm prepare script documentation](https://docs.npmjs.com/cli/v10/using-npm/scripts#prepare-and-prepublish)
- [npm ignore-scripts documentation](https://docs.npmjs.com/cli/v10/commands/npm-ci#ignore-scripts)

### Testing

This change can be tested by:

1. **Verifying CI workflows run successfully** with the new `--ignore-scripts` flag
2. **Testing package publishing** with `npm publish --dry-run` to ensure prepare script runs
3. **Confirming build artifacts** are correctly generated before publishing
4. **Validating no functionality changes** for end users installing the package

**Testing performed:**
- ✅ `npm publish --dry-run` confirmed prepare script builds package correctly
- ✅ `npm ci --ignore-scripts` confirmed dependencies install without running prepare script
- ✅ Verified no dependencies have critical postinstall scripts that would be affected

- [ ] This change adds unit test coverage - N/A (build infrastructure change)
- [ ] This change adds integration test coverage - N/A (build infrastructure change)

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors