### PR TITLE
Feat: Added Support for M2M Token Quota FF

### DIFF
--- a/src/management/__generated/managers/client-grants-manager.ts
+++ b/src/management/__generated/managers/client-grants-manager.ts
@@ -3,10 +3,14 @@ import type { InitOverride, ApiResponse } from '../../../lib/runtime.js';
 import type {
   ClientGrant,
   ClientGrantCreate,
+  GetClientGrantOrganizations200Response,
   GetClientGrants200Response,
   PatchClientGrantsByIdRequest,
+  GetClientGrantOrganizations200ResponseOneOf,
+  GetClientGrantOrganizations200ResponseOneOfInner,
   GetClientGrants200ResponseOneOf,
   DeleteClientGrantsByIdRequest,
+  GetClientGrantOrganizationsRequest,
   GetClientGrantsRequest,
   PatchClientGrantsByIdOperationRequest,
 } from '../models/index.js';
@@ -41,6 +45,63 @@ export class ClientGrantsManager extends BaseAPI {
     );
 
     return runtime.VoidApiResponse.fromResponse(response);
+  }
+
+  /**
+   * Get the organizations associated to a client grant
+   *
+   * @throws {RequiredError}
+   */
+  async getAllOrganizations(
+    requestParameters: GetClientGrantOrganizationsRequest & { include_totals: true },
+    initOverrides?: InitOverride
+  ): Promise<ApiResponse<GetClientGrantOrganizations200ResponseOneOf>>;
+  async getAllOrganizations(
+    requestParameters?: GetClientGrantOrganizationsRequest,
+    initOverrides?: InitOverride
+  ): Promise<ApiResponse<Array<GetClientGrantOrganizations200ResponseOneOfInner>>>;
+  async getAllOrganizations(
+    requestParameters: GetClientGrantOrganizationsRequest,
+    initOverrides?: InitOverride
+  ): Promise<ApiResponse<GetClientGrantOrganizations200Response>> {
+    runtime.validateRequiredRequestParams(requestParameters, ['id']);
+
+    const queryParameters = runtime.applyQueryParams(requestParameters, [
+      {
+        key: 'page',
+        config: {},
+      },
+      {
+        key: 'per_page',
+        config: {},
+      },
+      {
+        key: 'include_totals',
+        config: {},
+      },
+      {
+        key: 'from',
+        config: {},
+      },
+      {
+        key: 'take',
+        config: {},
+      },
+    ]);
+
+    const response = await this.request(
+      {
+        path: `/client-grants/{id}/organizations`.replace(
+          '{id}',
+          encodeURIComponent(String(requestParameters.id))
+        ),
+        method: 'GET',
+        query: queryParameters,
+      },
+      initOverrides
+    );
+
+    return runtime.JSONApiResponse.fromResponse(response);
   }
 
   /**

--- a/src/management/__generated/models/index.ts
+++ b/src/management/__generated/models/index.ts
@@ -5744,6 +5744,73 @@ export interface GetClientConnections200Response {
 /**
  *
  */
+export type GetClientGrantOrganizations200Response =
+  | Array<GetClientGrantOrganizations200ResponseOneOfInner>
+  | GetClientGrantOrganizations200ResponseOneOf
+  | GetClientGrantOrganizations200ResponseOneOf1;
+/**
+ *
+ */
+export interface GetClientGrantOrganizations200ResponseOneOf {
+  /**
+   */
+  start?: number;
+  /**
+   */
+  limit?: number;
+  /**
+   */
+  total?: number;
+  /**
+   */
+  organizations?: Array<GetClientGrantOrganizations200ResponseOneOfInner>;
+}
+/**
+ *
+ */
+export interface GetClientGrantOrganizations200ResponseOneOf1 {
+  /**
+   * Opaque identifier for use with the <i>from</i> query parameter for the next page of results.<br/>This identifier is valid for 24 hours.
+   *
+   */
+  next?: string;
+  /**
+   */
+  organizations?: Array<GetClientGrantOrganizations200ResponseOneOfInner>;
+}
+/**
+ *
+ */
+export interface GetClientGrantOrganizations200ResponseOneOfInner {
+  [key: string]: any | any;
+  /**
+   * Organization identifier.
+   *
+   */
+  id?: string;
+  /**
+   * The name of this organization.
+   *
+   */
+  name?: string;
+  /**
+   * Friendly name of this organization.
+   *
+   */
+  display_name?: string;
+  /**
+   */
+  branding?: OrganizationBranding;
+  /**
+   */
+  metadata?: OrganizationMetadata;
+  /**
+   */
+  token_quota?: TokenQuota;
+}
+/**
+ *
+ */
 export type GetClientGrants200Response = Array<ClientGrant> | GetClientGrants200ResponseOneOf;
 /**
  *
@@ -9924,6 +9991,40 @@ export interface LogLocationInfo {
    *
    */
   continent_code: string;
+}
+/**
+ * Theme defines how to style the login pages.
+ */
+export interface OrganizationBranding {
+  /**
+   * URL of logo to display on login page.
+   *
+   */
+  logo_url?: string;
+  /**
+   */
+  colors?: OrganizationBrandingColors;
+}
+/**
+ * Color scheme used to customize the login pages.
+ */
+export interface OrganizationBrandingColors {
+  /**
+   * HEX Color for primary elements.
+   *
+   */
+  primary: string;
+  /**
+   * HEX Color for background.
+   *
+   */
+  page_background: string;
+}
+/**
+ * Metadata associated with the organization, in the form of an object with string values (max 255 chars). Maximum of 25 metadata properties allowed.
+ */
+export interface OrganizationMetadata {
+  [key: string]: any;
 }
 /**
  *
@@ -19246,6 +19347,41 @@ export interface DeleteClientGrantsByIdRequest {
    *
    */
   id: string;
+}
+/**
+ *
+ */
+export interface GetClientGrantOrganizationsRequest {
+  /**
+   * ID of the client grant
+   *
+   */
+  id: string;
+  /**
+   * Page index of the results to return. First page is 0.
+   *
+   */
+  page?: number;
+  /**
+   * Number of results per page. Defaults to 50.
+   *
+   */
+  per_page?: number;
+  /**
+   * Return results inside an object that contains the total result count (true) or as a direct array of results (false, default).
+   *
+   */
+  include_totals?: boolean;
+  /**
+   * Optional Id from which to start selection.
+   *
+   */
+  from?: string;
+  /**
+   * Number of results per page. Defaults to 50.
+   *
+   */
+  take?: number;
 }
 
 /**

--- a/test/management/client-grants.test.ts
+++ b/test/management/client-grants.test.ts
@@ -234,4 +234,49 @@ describe('ClientGrantsManager', () => {
       });
     });
   });
+
+  describe('#getAllOrganizations', () => {
+    const data = {
+      id: 'client_grant_id',
+    };
+
+    let scope: nock.Scope;
+
+    beforeEach(() => {
+      scope = nock(API_URL).get(`/client-grants/${data.id}/organizations`).reply(200, []);
+    });
+
+    it('should return a promise when no callback is given', (done) => {
+      expect(grants.getAllOrganizations(data).then(() => done())).toBeInstanceOf(Promise);
+    });
+
+    it('should perform a GET request to /api/v2/client-grants/client_grant_id/organizations', async () => {
+      await grants.getAllOrganizations(data);
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it('should pass any errors to the promise catch handler', async () => {
+      nock.cleanAll();
+
+      nock(API_URL).get(`/client-grants/${data.id}/organizations`).reply(500, {});
+
+      try {
+        await grants.getAllOrganizations(data);
+      } catch (err) {
+        expect(err).toBeDefined();
+      }
+    });
+
+    it('should include the token in the authorization header', async () => {
+      nock.cleanAll();
+
+      const request = nock(API_URL)
+        .get(`/client-grants/${data.id}/organizations`)
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, []);
+
+      await grants.getAllOrganizations(data);
+      expect(request.isDone()).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
### Changes

Added Below Endpoint

/api/v2/client-grants/{id}/organizations

### References

https://auth0.com/docs/api/management/v2/client-grants/get-client-grant-organizations

### Manual Testing Code

1. Securely store your Domain and Management API token.
2. Install the SDK: npm install auth0
3. Add below code snippets

```
const auth = new ManagementClient({
    domain: '<DOMAIN>',
    token: "<TOKEN>",
  
});

// Endpoint - GET : /api/v2/client-grants/{id}/organizations
const getClientGrantOrganizations = await auth0.clientGrants.getAllOrganizations({id: "<ID>"});
```

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
