### PR TITLE
fix(auth): fix the requested_expiry param

### DIFF
--- a/src/auth/backchannel.ts
+++ b/src/auth/backchannel.ts
@@ -211,7 +211,7 @@ export class Backchannel extends BaseAuthAPI implements IBackchannel {
                 headers: { "Content-Type": "application/x-www-form-urlencoded" },
                 body: new URLSearchParams(body),
             },
-            {}
+            {},
         );
 
         const r: JSONApiResponse<AuthorizeResponse> = await JSONApiResponse.fromResponse(response);
@@ -266,7 +266,7 @@ export class Backchannel extends BaseAuthAPI implements IBackchannel {
                 headers: { "Content-Type": "application/x-www-form-urlencoded" },
                 body: new URLSearchParams(body),
             },
-            {}
+            {},
         );
 
         const r: JSONApiResponse<TokenResponse> = await JSONApiResponse.fromResponse(response);

--- a/tests/auth/backchannel.test.ts
+++ b/tests/auth/backchannel.test.ts
@@ -40,7 +40,7 @@ describe("Backchannel", () => {
             });
 
             await expect(backchannel.authorize({} as AuthorizeOptions)).rejects.toThrow(
-                'login_hint parameter validation failed: "sub" contains unsupported format'
+                'login_hint parameter validation failed: "sub" contains unsupported format',
             );
         });
 
@@ -51,7 +51,7 @@ describe("Backchannel", () => {
             });
 
             await expect(backchannel.authorize({ userId: "auth0|test-user-id" } as AuthorizeOptions)).rejects.toThrow(
-                "binding_message is required"
+                "binding_message is required",
             );
         });
 
@@ -66,7 +66,7 @@ describe("Backchannel", () => {
                     userId: "auth0|test-user-id",
                     binding_message: "Test binding message",
                     scope: "invalid_scope",
-                } as AuthorizeOptions)
+                } as AuthorizeOptions),
             ).rejects.toThrow("openid scope must be requested");
         });
 
@@ -82,7 +82,7 @@ describe("Backchannel", () => {
                     userId: "auth0|test-user-id",
                     binding_message: "Test binding message",
                     scope: "openid",
-                })
+                }),
             ).resolves.toMatchObject({
                 auth_req_id: "test-auth-req-id",
                 expires_in: 300,
@@ -96,7 +96,7 @@ describe("Backchannel", () => {
                 .post("/bc-authorize")
                 .reply(201, (uri, requestBody, cb) => {
                     receivedRequestedExpiry = JSON.parse(
-                        querystring.parse(requestBody as any)["requested_expiry"] as string
+                        querystring.parse(requestBody as any)["requested_expiry"] as string,
                     );
                     cb(null, {
                         auth_req_id: "test-auth-req-id",
@@ -122,10 +122,10 @@ describe("Backchannel", () => {
                 .post("/bc-authorize")
                 .reply(201, (uri, requestBody, cb) => {
                     receivedRequestedExpiry = JSON.parse(
-                        querystring.parse(requestBody as any)["requested_expiry"] as string
+                        querystring.parse(requestBody as any)["requested_expiry"] as string,
                     );
                     receivedRequestExpiry = JSON.parse(
-                        querystring.parse(requestBody as any)["request_expiry"] as string
+                        querystring.parse(requestBody as any)["request_expiry"] as string,
                     );
                     cb(null, {
                         auth_req_id: "test-auth-req-id",
@@ -151,7 +151,7 @@ describe("Backchannel", () => {
                 .post("/bc-authorize")
                 .reply(201, (uri, requestBody, cb) => {
                     receivedAuthorizationDetails = JSON.parse(
-                        querystring.parse(requestBody as any)["authorization_details"] as string
+                        querystring.parse(requestBody as any)["authorization_details"] as string,
                     );
                     cb(null, {
                         auth_req_id: "test-auth-req-id",
@@ -204,11 +204,11 @@ describe("Backchannel", () => {
                     userId: "auth0|test-user-id",
                     binding_message: "Test binding message",
                     scope: "openid",
-                })
+                }),
             ).rejects.toThrowError(
                 expect.objectContaining({
                     body: expect.anything(),
-                })
+                }),
             );
         });
 
@@ -226,7 +226,7 @@ describe("Backchannel", () => {
                     userId: "auth0|test-user-id",
                     binding_message: "Test binding message",
                     scope: "openid",
-                })
+                }),
             ).resolves.toMatchObject({
                 auth_req_id: "test-auth-req-id",
                 expires_in: 300,
@@ -248,7 +248,7 @@ describe("Backchannel", () => {
                     userId: "auth0|test-user-id",
                     binding_message: "Test binding message",
                     scope: "openid",
-                })
+                }),
             ).resolves.toMatchObject({
                 auth_req_id: "test-auth-req-id",
                 expires_in: 300,
@@ -267,7 +267,7 @@ describe("Backchannel", () => {
             await expect(
                 backchannel.backchannelGrant({
                     auth_req_id: "invalid-auth-req-id",
-                })
+                }),
             ).rejects.toThrow("Invalid or expired auth_req_id");
         });
 
@@ -282,7 +282,7 @@ describe("Backchannel", () => {
             await expect(
                 backchannel.backchannelGrant({
                     auth_req_id: "test-auth-req-id",
-                })
+                }),
             ).resolves.toMatchObject({
                 access_token: "test-access-token",
                 id_token: "test-id-token",
@@ -304,7 +304,7 @@ describe("Backchannel", () => {
             await expect(
                 backchannel.backchannelGrant({
                     auth_req_id: "test-auth-req-id",
-                })
+                }),
             ).resolves.toMatchObject({
                 access_token: "test-access-token",
                 id_token: "test-id-token",
@@ -323,11 +323,11 @@ describe("Backchannel", () => {
             await expect(
                 backchannel.backchannelGrant({
                     auth_req_id: "test-auth-req-id",
-                })
+                }),
             ).rejects.toThrowError(
                 expect.objectContaining({
                     body: expect.anything(),
-                })
+                }),
             );
         });
 
@@ -340,11 +340,11 @@ describe("Backchannel", () => {
             await expect(
                 backchannel.backchannelGrant({
                     auth_req_id: "test-auth-req-id",
-                })
+                }),
             ).rejects.toThrowError(
                 expect.objectContaining({
                     body: expect.anything(),
-                })
+                }),
             );
         });
 
@@ -357,11 +357,11 @@ describe("Backchannel", () => {
             await expect(
                 backchannel.backchannelGrant({
                     auth_req_id: "test-auth-req-id",
-                })
+                }),
             ).rejects.toThrowError(
                 expect.objectContaining({
                     body: expect.anything(),
-                })
+                }),
             );
         });
 
@@ -378,7 +378,7 @@ describe("Backchannel", () => {
             await expect(
                 jwtBackchannel.backchannelGrant({
                     auth_req_id: "test-auth-req-id",
-                })
+                }),
             ).resolves.toMatchObject({
                 access_token: "test-access-token",
                 id_token: "test-id-token",
@@ -400,7 +400,7 @@ describe("Backchannel", () => {
             await expect(
                 mtlsBackchannel.backchannelGrant({
                     auth_req_id: "test-auth-req-id",
-                })
+                }),
             ).resolves.toMatchObject({
                 access_token: "test-access-token",
                 id_token: "test-id-token",


### PR DESCRIPTION
### Changes

Correct the parameter used in backchannel authentication to be `requested_expiry` instead of the previously incorrect `request_expiry`.

To maintain backwards compatibility, the parameter has been marked as deprecated and it used as an alias for `requested_expiry` while retaining it when being passed to the `/bc-authorize` endpoint.

### References

This was previously based on the following incorrect version in the docs:

<img width="884" height="482" alt="sh" src="https://github.com/user-attachments/assets/5cb7ebae-e447-49b0-82b5-310a2d1307a5" />

https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-initiated-backchannel-authentication-flow/user-authorization-with-ciba#step-1-client-application-initiates-a-ciba-request

### Testing

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
