### PR TITLE
Ensure v4 branch publishes using v4 branch

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -44,7 +44,7 @@ runs:
         elif [[ "${VERSION}" == *"alpha"* ]]; then
           TAG="alpha"
         else
-          TAG="v4"
+          TAG="legacy-v4"
         fi
         npm publish --provenance --tag $TAG
       env:


### PR DESCRIPTION
### Changes

With v5 moving towards GA, we want to ensure we do not publish v4 release tagged with `latest`, instead, we tag with `legacy-v4`.

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
