### PR TITLE
fix(auth): fix the requested_expiry param (v4)

### DIFF
--- a/src/auth/backchannel.ts
+++ b/src/auth/backchannel.ts
@@ -88,8 +88,13 @@ export type AuthorizeOptions = {
   audience?: string;
   /**
    * Custom expiry time in seconds for this request.
+   * @deprecated Use {@link AuthorizeOptions.requested_expiry} instead.
    */
   request_expiry?: string;
+  /**
+   * Custom expiry time in seconds for this request.
+   */
+  requested_expiry?: string;
   /**
    * The user ID.
    */
@@ -190,6 +195,12 @@ export class Backchannel extends BaseAuthAPI implements IBackchannel {
       login_hint: getLoginHint(userId, this.domain),
       client_id: this.clientId,
     };
+
+    // The correct parameter is `requested_expiry`, but we also accept the deprecated `request_expiry` for backwards compatibility
+    const requestedExpiry = options.requested_expiry || options.request_expiry;
+    if (requestedExpiry) {
+      body.requested_expiry = requestedExpiry;
+    }
 
     await this.addClientAuthentication(body);
 

--- a/test/auth/backchannel.test.ts
+++ b/test/auth/backchannel.test.ts
@@ -201,6 +201,61 @@ describe('Backchannel', () => {
         interval: 5,
       });
     });
+
+    it('should pass requested_expiry to /bc-authorize', async () => {
+      let receivedRequestedExpiry = 0;
+      nock(`https://${opts.domain}`)
+        .post('/bc-authorize')
+        .reply(201, (uri, requestBody, cb) => {
+          receivedRequestedExpiry = JSON.parse(
+            querystring.parse(requestBody as any)['requested_expiry'] as string
+          );
+          cb(null, {
+            auth_req_id: 'test-auth-req-id',
+            expires_in: 300,
+            interval: 5,
+          });
+        });
+
+      await backchannel.authorize({
+        userId: 'auth0|test-user-id',
+        binding_message: 'Test binding message',
+        scope: 'openid',
+        requested_expiry: '999',
+      });
+
+      expect(receivedRequestedExpiry).toBe(999);
+    });
+
+    it('should pass request_expiry as requested_expiry and retain the request_expiry param for backwards compatibility', async () => {
+      let receivedRequestedExpiry = 0;
+      let receivedRequestExpiry = 0;
+      nock(`https://${opts.domain}`)
+        .post('/bc-authorize')
+        .reply(201, (uri, requestBody, cb) => {
+          receivedRequestedExpiry = JSON.parse(
+            querystring.parse(requestBody as any)['requested_expiry'] as string
+          );
+          receivedRequestExpiry = JSON.parse(
+            querystring.parse(requestBody as any)['request_expiry'] as string
+          );
+          cb(null, {
+            auth_req_id: 'test-auth-req-id',
+            expires_in: 300,
+            interval: 5,
+          });
+        });
+
+      await backchannel.authorize({
+        userId: 'auth0|test-user-id',
+        binding_message: 'Test binding message',
+        scope: 'openid',
+        request_expiry: '999',
+      });
+
+      expect(receivedRequestedExpiry).toBe(999);
+      expect(receivedRequestExpiry).toBe(999);
+    });
   });
 
   describe('#backchannelGrant', () => {


### PR DESCRIPTION
### Changes

v4 patch for: https://github.com/auth0/node-auth0/pull/1171

Correct the parameter used in backchannel authentication to be `requested_expiry` instead of the previously incorrect `request_expiry`.

To maintain backwards compatibility, the parameter has been marked as deprecated and it used as an alias for `requested_expiry` while retaining it when being passed to the `/bc-authorize` endpoint.

### References

This was previously based on the following incorrect version in the docs:

<img width="884" height="482" alt="sh" src="https://github.com/user-attachments/assets/5cb7ebae-e447-49b0-82b5-310a2d1307a5" />

https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-initiated-backchannel-authentication-flow/user-authorization-with-ciba#step-1-client-application-initiates-a-ciba-request

### Testing

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
