### PR TITLE
fix(auth): authorization_details type in TokenResponse (v4)

### DIFF
--- a/src/auth/backchannel.ts
+++ b/src/auth/backchannel.ts
@@ -110,6 +110,11 @@ type AuthorizeRequest = Omit<AuthorizeOptions, 'userId'> &
     login_hint: string;
   };
 
+export interface AuthorizationDetails {
+  readonly type: string;
+  readonly [parameter: string]: unknown;
+}
+
 /**
  * The response from the token endpoint.
  */
@@ -142,7 +147,7 @@ export type TokenResponse = {
    * Optional authorization details when using Rich Authorization Requests (RAR).
    * @see https://auth0.com/docs/get-started/apis/configure-rich-authorization-requests
    */
-  authorization_details?: string;
+  authorization_details?: AuthorizationDetails[];
 };
 
 /**


### PR DESCRIPTION
### Changes

v4 patch of: https://github.com/auth0/node-auth0/pull/1176

Fixes the return type of the `authorization_details` property in `TokenResponse`.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
