### PR TITLE
Demonstrate changes needed to Supplier and Fetcher to be Scope-Aware

### DIFF
--- a/src/management/core/fetcher/Fetcher.ts
+++ b/src/management/core/fetcher/Fetcher.ts
@@ -27,6 +27,7 @@ export declare namespace Fetcher {
         requestType?: "json" | "file" | "bytes";
         responseType?: "json" | "blob" | "sse" | "streaming" | "text" | "arrayBuffer" | "binary-response";
         duplex?: "half";
+        scope?: string[];
     }
 
     export type Error = FailedStatusCodeError | NonJsonError | TimeoutError | UnknownError;

--- a/src/management/core/fetcher/Supplier.ts
+++ b/src/management/core/fetcher/Supplier.ts
@@ -1,9 +1,12 @@
-export type Supplier<T> = T | Promise<T> | (() => T | Promise<T>);
+export type SupplierContext = { scope: string[] | undefined };
+export type SupplierFn<T> = (context?: SupplierContext) => T | Promise<T>;
+export type Supplier<T> = T | Promise<T> | SupplierFn<T>;
 
 export const Supplier = {
-    get: async <T>(supplier: Supplier<T>): Promise<T> => {
+    // Marked context as optional to not have to update all snippets.
+    get: async <T>(supplier: Supplier<T>, context?: SupplierContext): Promise<T> => {
         if (typeof supplier === "function") {
-            return (supplier as () => T)();
+            return (supplier as SupplierFn<T>)(context);
         } else {
             return supplier;
         }

--- a/src/management/tests/unit/management-client-fetch-with-auth.test.ts
+++ b/src/management/tests/unit/management-client-fetch-with-auth.test.ts
@@ -1,0 +1,51 @@
+import { ManagementClient } from "../../wrapper/ManagementClient.js";
+
+describe("ManagementClient with Scope-Aware Supplier and Fetcher", () => {
+    it("handle custom changes to demonstrate", async () => {
+        const consoleSpy = jest.spyOn(console, "log").mockImplementation();
+
+        const client = new ManagementClient({
+            domain: "your-tenant.auth0.com",
+            clientId: "your-client-id",
+            clientSecret: "your-client-secret",
+            token: (context) => {
+                console.log(`Scope passed to token supplier: ${context?.scope?.join(", ")}`);
+                return "your-static-token";
+            },
+            fetcher: async (args) => {
+                console.log(`Scope passed to fetcher: ${args.scope?.join(", ")}`);
+                const response = await fetch(args.url, {
+                    method: args.method,
+                    headers: args.headers as Record<string, string>,
+                    body: args.body ? JSON.stringify(args.body) : undefined,
+                });
+
+                if (response.ok) {
+                    return {
+                        ok: true as const,
+                        body: await response.json(),
+                        headers: response.headers,
+                        rawResponse: response,
+                    };
+                } else {
+                    return {
+                        ok: false as const,
+                        error: {
+                            reason: "status-code" as const,
+                            statusCode: response.status,
+                            body: await response.text(),
+                        },
+                        rawResponse: response,
+                    };
+                }
+            },
+        });
+
+        try {
+            await client.actions.versions.list("action123");
+        } catch {}
+
+        expect(consoleSpy).toHaveBeenNthCalledWith(1, "Scope passed to token supplier: read:actions_versions");
+        expect(consoleSpy).toHaveBeenNthCalledWith(2, "Scope passed to fetcher: read:actions_versions");
+    });
+});


### PR DESCRIPTION
### Changes

This PR shows the changes needed to make both Supplier and Fetcher scope aware, enabling a more granual control of tokens and their permissions.

Additionally, it also enables for the fetcher to take full control. To do so, we would set the token to `''`, and ensure it gets filtered out by `mergeOnlyDefinedHeaders`.

### References

N/A

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
