### PR TITLE
Feat: Added Support for Connected Accounts

### DIFF
--- a/src/management/__generated/managers/users-manager.ts
+++ b/src/management/__generated/managers/users-manager.ts
@@ -16,6 +16,7 @@ import type {
   GetUserOrganizations200Response,
   GetUsers200Response,
   GetUsers200ResponseOneOfInner,
+  ListUserConnectedAccountsResponseContent,
   PatchAuthenticationMethodsByAuthenticationMethodIdRequest,
   PostAuthenticationMethods201Response,
   PostAuthenticationMethodsRequest,
@@ -52,6 +53,7 @@ import type {
   DeleteUsersByIdRequest,
   GetAuthenticationMethodsRequest,
   GetAuthenticationMethodsByAuthenticationMethodIdRequest,
+  GetConnectedAccountsRequest,
   GetEnrollmentsRequest,
   GetFederatedConnectionsTokensetsRequest,
   GetLogsByUserRequest,
@@ -440,6 +442,44 @@ export class UsersManager extends BaseAPI {
             encodeURIComponent(String(requestParameters.authentication_method_id))
           ),
         method: 'GET',
+      },
+      initOverrides
+    );
+
+    return runtime.JSONApiResponse.fromResponse(response);
+  }
+
+  /**
+   * Retrieve all connected accounts associated with the user.
+   * Get a User's Connected Accounts
+   *
+   * @throws {RequiredError}
+   */
+  async getConnectedAccounts(
+    requestParameters: GetConnectedAccountsRequest,
+    initOverrides?: InitOverride
+  ): Promise<ApiResponse<ListUserConnectedAccountsResponseContent>> {
+    runtime.validateRequiredRequestParams(requestParameters, ['id']);
+
+    const queryParameters = runtime.applyQueryParams(requestParameters, [
+      {
+        key: 'from',
+        config: {},
+      },
+      {
+        key: 'take',
+        config: {},
+      },
+    ]);
+
+    const response = await this.request(
+      {
+        path: `/users/{id}/connected-accounts`.replace(
+          '{id}',
+          encodeURIComponent(String(requestParameters.id))
+        ),
+        method: 'GET',
+        query: queryParameters,
       },
       initOverrides
     );

--- a/src/management/__generated/models/index.ts
+++ b/src/management/__generated/models/index.ts
@@ -3220,6 +3220,59 @@ export interface ClientUpdateSignedRequestObject {
 /**
  *
  */
+export interface ConnectedAccount {
+  /**
+   * The unique identifier for the connected account.
+   *
+   */
+  id: string;
+  /**
+   * The name of the connection associated with the account.
+   *
+   */
+  connection: string;
+  /**
+   * The unique identifier of the connection associated with the account.
+   *
+   */
+  connection_id: string;
+  /**
+   * The authentication strategy used by the connection.
+   *
+   */
+  strategy: string;
+  /**
+   */
+  access_type: ConnectedAccountAccessTypeEnum;
+  /**
+   * The scopes granted for this connected account.
+   *
+   */
+  scopes?: Array<string>;
+  /**
+   * ISO 8601 timestamp when the connected account was created.
+   *
+   */
+  created_at: string;
+  /**
+   * ISO 8601 timestamp when the connected account expires.
+   *
+   */
+  expires_at?: string;
+}
+
+/**
+ * The access type for the connected account.
+ */
+export const ConnectedAccountAccessTypeEnum = {
+  offline: 'offline',
+} as const;
+export type ConnectedAccountAccessTypeEnum =
+  (typeof ConnectedAccountAccessTypeEnum)[keyof typeof ConnectedAccountAccessTypeEnum];
+
+/**
+ *
+ */
 export interface Connection {
   /**
    * The name of the connection
@@ -10015,6 +10068,19 @@ export interface ListUserAttributeProfilesPaginatedResponseContent {
   /**
    */
   user_attribute_profiles?: Array<UserAttributeProfile>;
+}
+/**
+ *
+ */
+export interface ListUserConnectedAccountsResponseContent {
+  /**
+   */
+  connected_accounts: Array<ConnectedAccount>;
+  /**
+   * The token to retrieve the next page of connected accounts (if there is one)
+   *
+   */
+  next?: string;
 }
 /**
  *
@@ -23735,6 +23801,26 @@ export interface GetAuthenticationMethodsByAuthenticationMethodIdRequest {
    *
    */
   authentication_method_id: string;
+}
+/**
+ *
+ */
+export interface GetConnectedAccountsRequest {
+  /**
+   * ID of the user to list connected accounts for.
+   *
+   */
+  id: string;
+  /**
+   * Optional Id from which to start selection.
+   *
+   */
+  from?: string;
+  /**
+   * Number of results to return.  Defaults to 10 with a maximum of 20
+   *
+   */
+  take?: number;
 }
 /**
  *


### PR DESCRIPTION
### Changes

Added Support for below Endpoint: 

| Path                         | Method Type | Method Name            |
|-----------------------------|-------------|-------------------------|
| `/users/{id}/connected-accounts` | GET         | `getConnectedAccounts`   |


### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Manual Testing Snippets

1. Install node autho using npm install auth0
2. Initialize your client class with a client ID, client secret and a domain from auth0 dashboard

```
// Get Connected Accounts

async function connectedAccounts() {
  const client = new ManagementClient({
    domain: "<DOMIAN>",
    clientId: "<CLIENT_ID>",
    clientSecret: "<CLIENT_SECRET>"
  });

  const getConnectedAccounts = await client.users.getConnectedAccounts({ id: "<USER_ID>", take: 2 });
  console.log("getConnectedAccounts", getConnectedAccounts);
}

```

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
