### PR TITLE
Added Support for skip_non_verifiable_callback_uri_confirmation_prompt Field

### DIFF
--- a/src/management/__generated/models/index.ts
+++ b/src/management/__generated/models/index.ts
@@ -290,6 +290,13 @@ export interface Client {
   /**
    */
   token_quota: TokenQuota;
+  /**
+   * Controls whether a confirmation prompt is shown during login flows when the redirect URI uses non-verifiable callback URIs (for example, a custom URI schema such as `myapp://`, or `localhost`).
+   * If set to true, a confirmation prompt will not be shown. We recommend that this is set to false for improved protection from malicious apps.
+   * See {{DOCS LINK}} for more information.
+   *
+   */
+  skip_non_verifiable_callback_uri_confirmation_prompt?: boolean;
 }
 
 export const ClientAppTypeEnum = {
@@ -1224,6 +1231,13 @@ export interface ClientCreate {
    *
    */
   resource_server_identifier?: string;
+  /**
+   * Controls whether a confirmation prompt is shown during login flows when the redirect URI uses non-verifiable callback URIs (for example, a custom URI schema such as `myapp://`, or `localhost`).
+   * If set to true, a confirmation prompt will not be shown. We recommend that this is set to false for improved protection from malicious apps.
+   * See {{DOCS LINK}} for more information.
+   *
+   */
+  skip_non_verifiable_callback_uri_confirmation_prompt?: boolean;
 }
 
 export const ClientCreateTokenEndpointAuthMethodEnum = {
@@ -2810,6 +2824,13 @@ export interface ClientUpdate {
    *
    */
   compliance_level?: ClientUpdateComplianceLevelEnum;
+  /**
+   * Controls whether a confirmation prompt is shown during login flows when the redirect URI uses non-verifiable callback URIs (for example, a custom URI schema such as `myapp://`, or `localhost`).
+   * If set to true, a confirmation prompt will not be shown. We recommend that this is set to false for improved protection from malicious apps.
+   * See {{DOCS LINK}} for more information.
+   *
+   */
+  skip_non_verifiable_callback_uri_confirmation_prompt?: boolean;
 }
 
 export const ClientUpdateTokenEndpointAuthMethodEnum = {
@@ -17858,6 +17879,13 @@ export interface TenantSettings {
    *
    */
   authorization_response_iss_parameter_supported: boolean | null;
+  /**
+   * Controls whether a confirmation prompt is shown during login flows when the redirect URI uses non-verifiable callback URIs (for example, a custom URI schema such as `myapp://`, or `localhost`).
+   * If set to true, a confirmation prompt will not be shown. We recommend that this is set to false for improved protection from malicious apps.
+   * See {{DOCS LINK}} for more information.
+   *
+   */
+  skip_non_verifiable_callback_uri_confirmation_prompt?: boolean | null;
 }
 
 export const TenantSettingsEnabledLocalesEnum = {
@@ -18341,6 +18369,13 @@ export interface TenantSettingsUpdate {
    *
    */
   authorization_response_iss_parameter_supported?: boolean | null;
+  /**
+   * Controls whether a confirmation prompt is shown during login flows when the redirect URI uses non-verifiable callback URIs (for example, a custom URI schema such as `myapp://`, or `localhost`).
+   * If set to true, a confirmation prompt will not be shown. We recommend that this is set to false for improved protection from malicious apps.
+   * See {{DOCS LINK}} for more information.
+   *
+   */
+  skip_non_verifiable_callback_uri_confirmation_prompt?: boolean | null;
 }
 
 export const TenantSettingsUpdateEnabledLocalesEnum = {


### PR DESCRIPTION
### Changes

Added field `skip_non_verifiable_callback_uri_confirmation_prompt` for Client and Tenant Endpoints

### Manual Testing Code

- Install node autho using npm install auth0
- Initialize your client class with a client ID, client secret and a domain from auth0 dashboard

 ```
 const client = new ManagementClient({
    domain: "<DOMIAN>",
    clientId: "<CLIENT_ID>",
    clientSecret: "<CLIENT_SECRET>"
  });
  
  // Update Client 
  const updateClientPayload: ClientUpdate = {
    skip_non_verifiable_callback_uri_confirmation_prompt: true
  }

  const resp = await auth0.clients.update({client_id: "<CLIENT_ID"}, updateClientPayload);
  console.log("Updated Client : ", resp.data)
  
  //Update tenant Setting with skip_non_verifiable_callback_uri_confirmation_prompt
    const tenantSettingsUpdatePayload: TenantSettingsUpdate = {
    skip_non_verifiable_callback_uri_confirmation_prompt: true 
  };

const updateTenantSetting = await auth0.tenants.updateSettings(tenantSettingsUpdatePayload);
console.log("Updated Tenant Settings : ", updateTenantSetting.data)
```