### PR TITLE
Feat: Added Support for Organization Domain Discovery

### DIFF
--- a/src/management/__generated/managers/organizations-manager.ts
+++ b/src/management/__generated/managers/organizations-manager.ts
@@ -1,6 +1,8 @@
 import * as runtime from '../../../lib/runtime.js';
 import type { InitOverride, ApiResponse } from '../../../lib/runtime.js';
 import type {
+  CreateOrganizationDiscoveryDomainRequestContent,
+  CreateOrganizationDiscoveryDomainResponseContent,
   DeleteMembersRequest,
   DeleteOrganizationMemberRolesRequest,
   GetEnabledConnections200Response,
@@ -10,9 +12,11 @@ import type {
   GetMembers200Response,
   GetOrganizationClientGrants200Response,
   GetOrganizationClientGrants200ResponseOneOfInner,
+  GetOrganizationDiscoveryDomainResponseContent,
   GetOrganizationMemberRoles200Response,
   GetOrganizations200Response,
   GetOrganizations200ResponseOneOfInner,
+  ListOrganizationDiscoveryDomainsResponseContent,
   PatchEnabledConnectionsByConnectionIdRequest,
   PatchOrganizationsByIdRequest,
   PostEnabledConnectionsRequest,
@@ -22,6 +26,8 @@ import type {
   PostOrganizationMemberRolesRequest,
   PostOrganizations201Response,
   PostOrganizationsRequest,
+  UpdateOrganizationDiscoveryDomainRequestContent,
+  UpdateOrganizationDiscoveryDomainResponseContent,
   GetEnabledConnections200ResponseOneOf,
   GetInvitations200ResponseOneOf,
   GetMembers200ResponseOneOf,
@@ -31,11 +37,14 @@ import type {
   GetOrganizationMemberRoles200ResponseOneOfInner,
   GetOrganizations200ResponseOneOf,
   DeleteClientGrantsByGrantIdRequest,
+  DeleteDiscoveryDomainsByDiscoveryDomainIdRequest,
   DeleteEnabledConnectionsByConnectionIdRequest,
   DeleteInvitationsByInvitationIdRequest,
   DeleteMembersOperationRequest,
   DeleteOrganizationMemberRolesOperationRequest,
   DeleteOrganizationsByIdRequest,
+  GetDiscoveryDomainsRequest,
+  GetDiscoveryDomainsByDiscoveryDomainIdRequest,
   GetEnabledConnectionsRequest,
   GetEnabledConnectionsByConnectionIdRequest,
   GetInvitationsRequest,
@@ -46,8 +55,10 @@ import type {
   GetOrganizationMemberRolesRequest,
   GetOrganizationsRequest,
   GetOrganizationsByIdRequest,
+  PatchDiscoveryDomainsByDiscoveryDomainIdRequest,
   PatchEnabledConnectionsByConnectionIdOperationRequest,
   PatchOrganizationsByIdOperationRequest,
+  PostDiscoveryDomainsRequest,
   PostEnabledConnectionsOperationRequest,
   PostInvitationsOperationRequest,
   PostMembersOperationRequest,
@@ -77,6 +88,34 @@ export class OrganizationsManager extends BaseAPI {
         path: `/organizations/{id}/client-grants/{grant_id}`
           .replace('{id}', encodeURIComponent(String(requestParameters.id)))
           .replace('{grant_id}', encodeURIComponent(String(requestParameters.grant_id))),
+        method: 'DELETE',
+      },
+      initOverrides
+    );
+
+    return runtime.VoidApiResponse.fromResponse(response);
+  }
+
+  /**
+   * Remove a discovery domain from an organization. This action cannot be undone.
+   * Delete an organization discovery domain
+   *
+   * @throws {RequiredError}
+   */
+  async deleteDiscoveryDomain(
+    requestParameters: DeleteDiscoveryDomainsByDiscoveryDomainIdRequest,
+    initOverrides?: InitOverride
+  ): Promise<ApiResponse<void>> {
+    runtime.validateRequiredRequestParams(requestParameters, ['id', 'discovery_domain_id']);
+
+    const response = await this.request(
+      {
+        path: `/organizations/{id}/discovery-domains/{discovery_domain_id}`
+          .replace('{id}', encodeURIComponent(String(requestParameters.id)))
+          .replace(
+            '{discovery_domain_id}',
+            encodeURIComponent(String(requestParameters.discovery_domain_id))
+          ),
         method: 'DELETE',
       },
       initOverrides
@@ -221,6 +260,74 @@ export class OrganizationsManager extends BaseAPI {
     );
 
     return runtime.VoidApiResponse.fromResponse(response);
+  }
+
+  /**
+   * Retrieve list of all organization discovery domains associated with the specified organization.
+   *
+   * Retrieve all organization discovery domains
+   *
+   * @throws {RequiredError}
+   */
+  async getAllDiscoveryDomains(
+    requestParameters: GetDiscoveryDomainsRequest,
+    initOverrides?: InitOverride
+  ): Promise<ApiResponse<ListOrganizationDiscoveryDomainsResponseContent>> {
+    runtime.validateRequiredRequestParams(requestParameters, ['id']);
+
+    const queryParameters = runtime.applyQueryParams(requestParameters, [
+      {
+        key: 'from',
+        config: {},
+      },
+      {
+        key: 'take',
+        config: {},
+      },
+    ]);
+
+    const response = await this.request(
+      {
+        path: `/organizations/{id}/discovery-domains`.replace(
+          '{id}',
+          encodeURIComponent(String(requestParameters.id))
+        ),
+        method: 'GET',
+        query: queryParameters,
+      },
+      initOverrides
+    );
+
+    return runtime.JSONApiResponse.fromResponse(response);
+  }
+
+  /**
+   * Retrieve details about a single organization discovery domain specified by ID.
+   *
+   * Retrieve an organization discovery domain by ID
+   *
+   * @throws {RequiredError}
+   */
+  async getDiscoveryDomain(
+    requestParameters: GetDiscoveryDomainsByDiscoveryDomainIdRequest,
+    initOverrides?: InitOverride
+  ): Promise<ApiResponse<GetOrganizationDiscoveryDomainResponseContent>> {
+    runtime.validateRequiredRequestParams(requestParameters, ['id', 'discovery_domain_id']);
+
+    const response = await this.request(
+      {
+        path: `/organizations/{id}/discovery-domains/{discovery_domain_id}`
+          .replace('{id}', encodeURIComponent(String(requestParameters.id)))
+          .replace(
+            '{discovery_domain_id}',
+            encodeURIComponent(String(requestParameters.discovery_domain_id))
+          ),
+        method: 'GET',
+      },
+      initOverrides
+    );
+
+    return runtime.JSONApiResponse.fromResponse(response);
   }
 
   /**
@@ -730,6 +837,41 @@ export class OrganizationsManager extends BaseAPI {
   }
 
   /**
+   * Update the verification status for an organization discovery domain. The <code>status</code> field must be either <code>pending</code> or <code>verified</code>.
+   * Update an organization discovery domain
+   *
+   * @throws {RequiredError}
+   */
+  async updateDiscoveryDomain(
+    requestParameters: PatchDiscoveryDomainsByDiscoveryDomainIdRequest,
+    bodyParameters: UpdateOrganizationDiscoveryDomainRequestContent,
+    initOverrides?: InitOverride
+  ): Promise<ApiResponse<UpdateOrganizationDiscoveryDomainResponseContent>> {
+    runtime.validateRequiredRequestParams(requestParameters, ['id', 'discovery_domain_id']);
+
+    const headerParameters: runtime.HTTPHeaders = {};
+
+    headerParameters['Content-Type'] = 'application/json';
+
+    const response = await this.request(
+      {
+        path: `/organizations/{id}/discovery-domains/{discovery_domain_id}`
+          .replace('{id}', encodeURIComponent(String(requestParameters.id)))
+          .replace(
+            '{discovery_domain_id}',
+            encodeURIComponent(String(requestParameters.discovery_domain_id))
+          ),
+        method: 'PATCH',
+        headers: headerParameters,
+        body: bodyParameters,
+      },
+      initOverrides
+    );
+
+    return runtime.JSONApiResponse.fromResponse(response);
+  }
+
+  /**
    * Modify an enabled_connection belonging to an Organization.
    *
    * Modify an Organizations Connection
@@ -787,6 +929,39 @@ export class OrganizationsManager extends BaseAPI {
           encodeURIComponent(String(requestParameters.id))
         ),
         method: 'PATCH',
+        headers: headerParameters,
+        body: bodyParameters,
+      },
+      initOverrides
+    );
+
+    return runtime.JSONApiResponse.fromResponse(response);
+  }
+
+  /**
+   * Update the verification status for an organization discovery domain. The <code>status</code> field must be either <code>pending</code> or <code>verified</code>.
+   * Create an organization discovery domain
+   *
+   * @throws {RequiredError}
+   */
+  async createDiscoveryDomain(
+    requestParameters: PostDiscoveryDomainsRequest,
+    bodyParameters: CreateOrganizationDiscoveryDomainRequestContent,
+    initOverrides?: InitOverride
+  ): Promise<ApiResponse<CreateOrganizationDiscoveryDomainResponseContent>> {
+    runtime.validateRequiredRequestParams(requestParameters, ['id']);
+
+    const headerParameters: runtime.HTTPHeaders = {};
+
+    headerParameters['Content-Type'] = 'application/json';
+
+    const response = await this.request(
+      {
+        path: `/organizations/{id}/discovery-domains`.replace(
+          '{id}',
+          encodeURIComponent(String(requestParameters.id))
+        ),
+        method: 'POST',
         headers: headerParameters,
         body: bodyParameters,
       },

--- a/src/management/__generated/models/index.ts
+++ b/src/management/__generated/models/index.ts
@@ -262,6 +262,11 @@ export interface Client {
    */
   organization_require_behavior: ClientOrganizationRequireBehaviorEnum;
   /**
+   * Defines the available methods for organization discovery during the `pre_login_prompt`. Users can discover their organization either by `email`, `organization_name` or both.
+   *
+   */
+  organization_discovery_methods?: Array<ClientOrganizationDiscoveryEnum>;
+  /**
    */
   client_authentication_methods: ClientClientAuthenticationMethods | null;
   /**
@@ -1197,6 +1202,11 @@ export interface ClientCreate {
    *
    */
   organization_require_behavior?: ClientCreateOrganizationRequireBehaviorEnum;
+  /**
+   * Defines the available methods for organization discovery during the `pre_login_prompt`. Users can discover their organization either by `email`, `organization_name` or both.
+   *
+   */
+  organization_discovery_methods?: Array<ClientOrganizationDiscoveryEnum>;
   /**
    */
   client_authentication_methods?: ClientCreateClientAuthenticationMethods;
@@ -2477,6 +2487,16 @@ export type ClientOidcLogoutBackchannelLogoutInitiatorsSelectedInitiatorsEnum =
   (typeof ClientOidcLogoutBackchannelLogoutInitiatorsSelectedInitiatorsEnum)[keyof typeof ClientOidcLogoutBackchannelLogoutInitiatorsSelectedInitiatorsEnum];
 
 /**
+ * Method for discovering organizations during the `pre_login_prompt`. `email` allows users to find their organization by entering their email address and performing domain matching, while `organization_name` requires users to enter the organization name directly. These methods can be combined.
+ */
+export const ClientOrganizationDiscoveryEnum = {
+  email: 'email',
+  organization_name: 'organization_name',
+} as const;
+export type ClientOrganizationDiscoveryEnum =
+  (typeof ClientOrganizationDiscoveryEnum)[keyof typeof ClientOrganizationDiscoveryEnum];
+
+/**
  * Refresh token configuration
  */
 export interface ClientRefreshToken {
@@ -2803,6 +2823,11 @@ export interface ClientUpdate {
    *
    */
   organization_require_behavior?: ClientUpdateOrganizationRequireBehaviorEnum;
+  /**
+   * Defines the available methods for organization discovery during the `pre_login_prompt`. Users can discover their organization either by `email`, `organization_name` or both.
+   *
+   */
+  organization_discovery_methods?: Array<ClientOrganizationDiscoveryEnum>;
   /**
    */
   client_authentication_methods?: ClientUpdateClientAuthenticationMethods | null;
@@ -3985,6 +4010,49 @@ export const ConnectionUpdateOptionsSetUserRootAttributesEnum = {
 } as const;
 export type ConnectionUpdateOptionsSetUserRootAttributesEnum =
   (typeof ConnectionUpdateOptionsSetUserRootAttributesEnum)[keyof typeof ConnectionUpdateOptionsSetUserRootAttributesEnum];
+
+/**
+ *
+ */
+export interface CreateOrganizationDiscoveryDomainRequestContent {
+  /**
+   * The domain name to associate with the organization e.g. acme.com.
+   *
+   */
+  domain: string;
+  /**
+   */
+  status?: OrganizationDiscoveryDomainStatus;
+}
+
+/**
+ *
+ */
+export interface CreateOrganizationDiscoveryDomainResponseContent {
+  /**
+   * Organization discovery domain identifier.
+   *
+   */
+  id: string;
+  /**
+   * The domain name to associate with the organization e.g. acme.com.
+   *
+   */
+  domain: string;
+  /**
+   */
+  status: OrganizationDiscoveryDomainStatus;
+  /**
+   * A unique token generated for the discovery domain. This must be placed in a DNS TXT record at the location specified by the verification_host field to prove domain ownership.
+   *
+   */
+  verification_txt: string;
+  /**
+   * The full domain where the TXT record should be added.
+   *
+   */
+  verification_host: string;
+}
 
 /**
  * Phone provider configuration schema
@@ -8279,6 +8347,35 @@ export interface GetOrganizationClientGrants200ResponseOneOfInner {
 /**
  *
  */
+export interface GetOrganizationDiscoveryDomainResponseContent {
+  /**
+   * Organization discovery domain identifier.
+   *
+   */
+  id: string;
+  /**
+   * The domain name to associate with the organization e.g. acme.com.
+   *
+   */
+  domain: string;
+  /**
+   */
+  status: OrganizationDiscoveryDomainStatus;
+  /**
+   * A unique token generated for the discovery domain. This must be placed in a DNS TXT record at the location specified by the verification_host field to prove domain ownership.
+   *
+   */
+  verification_txt: string;
+  /**
+   * The full domain where the TXT record should be added.
+   *
+   */
+  verification_host: string;
+}
+
+/**
+ *
+ */
 export type GetOrganizationMemberRoles200Response =
   | Array<GetOrganizationMemberRoles200ResponseOneOfInner>
   | GetOrganizationMemberRoles200ResponseOneOf;
@@ -10064,6 +10161,17 @@ export type JobFormatEnum = (typeof JobFormatEnum)[keyof typeof JobFormatEnum];
 /**
  *
  */
+export interface ListOrganizationDiscoveryDomainsResponseContent {
+  /**
+   */
+  next?: string;
+  /**
+   */
+  domains: Array<OrganizationDiscoveryDomain>;
+}
+/**
+ *
+ */
 export interface ListPhoneTemplatesResponseContent {
   /**
    */
@@ -10283,6 +10391,45 @@ export interface OrganizationBrandingColors {
    */
   page_background: string;
 }
+/**
+ *
+ */
+export interface OrganizationDiscoveryDomain {
+  /**
+   * Organization discovery domain identifier.
+   *
+   */
+  id: string;
+  /**
+   * The domain name to associate with the organization e.g. acme.com.
+   *
+   */
+  domain: string;
+  /**
+   */
+  status: OrganizationDiscoveryDomainStatus;
+  /**
+   * A unique token generated for the discovery domain. This must be placed in a DNS TXT record at the location specified by the verification_host field to prove domain ownership.
+   *
+   */
+  verification_txt: string;
+  /**
+   * The full domain where the TXT record should be added.
+   *
+   */
+  verification_host: string;
+}
+
+/**
+ * The verification status of the discovery domain.
+ */
+export const OrganizationDiscoveryDomainStatus = {
+  pending: 'pending',
+  verified: 'verified',
+} as const;
+export type OrganizationDiscoveryDomainStatus =
+  (typeof OrganizationDiscoveryDomainStatus)[keyof typeof OrganizationDiscoveryDomainStatus];
+
 /**
  * Metadata associated with the organization, in the form of an object with string values (max 255 chars). Maximum of 25 metadata properties allowed.
  */
@@ -18794,6 +18941,44 @@ export interface TwilioFactorProvider {
 /**
  *
  */
+export interface UpdateOrganizationDiscoveryDomainRequestContent {
+  /**
+   */
+  status?: OrganizationDiscoveryDomainStatus;
+}
+
+/**
+ *
+ */
+export interface UpdateOrganizationDiscoveryDomainResponseContent {
+  /**
+   * Organization discovery domain identifier.
+   *
+   */
+  id: string;
+  /**
+   * The domain name to associate with the organization e.g. acme.com.
+   *
+   */
+  domain: string;
+  /**
+   */
+  status: OrganizationDiscoveryDomainStatus;
+  /**
+   * A unique token generated for the discovery domain. This must be placed in a DNS TXT record at the location specified by the verification_host field to prove domain ownership.
+   *
+   */
+  verification_txt: string;
+  /**
+   * The full domain where the TXT record should be added.
+   *
+   */
+  verification_host: string;
+}
+
+/**
+ *
+ */
 export interface UpdatePhoneProviderRequest {
   /**
    * Name of the phone notification provider
@@ -21784,6 +21969,21 @@ export interface DeleteClientGrantsByGrantIdRequest {
 /**
  *
  */
+export interface DeleteDiscoveryDomainsByDiscoveryDomainIdRequest {
+  /**
+   * ID of the organization.
+   *
+   */
+  id: string;
+  /**
+   * ID of the discovery domain.
+   *
+   */
+  discovery_domain_id: string;
+}
+/**
+ *
+ */
 export interface DeleteEnabledConnectionsByConnectionIdRequest {
   /**
    * Organization identifier
@@ -21845,6 +22045,41 @@ export interface DeleteOrganizationsByIdRequest {
    *
    */
   id: string;
+}
+/**
+ *
+ */
+export interface GetDiscoveryDomainsRequest {
+  /**
+   * ID of the organization.
+   *
+   */
+  id: string;
+  /**
+   * Optional Id from which to start selection.
+   *
+   */
+  from?: string;
+  /**
+   * Number of results per page. Defaults to 50.
+   *
+   */
+  take?: number;
+}
+/**
+ *
+ */
+export interface GetDiscoveryDomainsByDiscoveryDomainIdRequest {
+  /**
+   * ID of the organization.
+   *
+   */
+  id: string;
+  /**
+   * ID of the discovery domain.
+   *
+   */
+  discovery_domain_id: string;
 }
 /**
  *
@@ -22124,6 +22359,21 @@ export interface GetOrganizationsByIdRequest {
 /**
  *
  */
+export interface PatchDiscoveryDomainsByDiscoveryDomainIdRequest {
+  /**
+   * ID of the organization.
+   *
+   */
+  id: string;
+  /**
+   * ID of the discovery domain to update.
+   *
+   */
+  discovery_domain_id: string;
+}
+/**
+ *
+ */
 export interface PatchEnabledConnectionsByConnectionIdOperationRequest {
   /**
    * Organization identifier
@@ -22142,6 +22392,16 @@ export interface PatchEnabledConnectionsByConnectionIdOperationRequest {
 export interface PatchOrganizationsByIdOperationRequest {
   /**
    * ID of the organization to update.
+   *
+   */
+  id: string;
+}
+/**
+ *
+ */
+export interface PostDiscoveryDomainsRequest {
+  /**
+   * ID of the organization.
    *
    */
   id: string;


### PR DESCRIPTION
### Changes

Added `/discovery-domains` entities and updated `/clients` entities-

| Path                                                           | Method Type | Method Name            |
|----------------------------------------------------------------|-------------|-------------------------|
| `/api/v2/organizations/{org_id}/discovery-domains`            | GET         | `getAllDiscoveryDomains` |
| `/api/v2/organizations/{org_id}/discovery-domains/{id}`       | GET         | `getDiscoveryDomain`     |
| `/api/v2/organizations/{org_id}/discovery-domains`            | POST        | `createDiscoveryDomain`  |
| `/api/v2/organizations/{org_id}/discovery-domains/{id}`       | PATCH       | `updateDiscoveryDomain`  |
| `/api/v2/organizations/{org_id}/discovery-domains/{id}`       | DELETE      | `deleteDiscoveryDomain`  |
| `/api/v2/clients`                                       | POST        | `create`                 |
| `/api/v2/clients`                                       | GET         | `getAll`                 |
| `/api/v2/clients/{id}`                                  | PATCH       | `update`                 |
| `/api/v2/clients/{id}`                                  | GET         | `get`  


### Manual Testing Snippets

- Install node autho using npm install auth0
- Initialize your client class with a client ID, client secret and a domain from auth0 dashboard

```
// Create Client with `organization_discovery_methods` as `organization_name` and `organization_require_behavior`:' `pre_login_prompt`'

const createClientPayload: ClientCreate = {
    name : "TestClient",
    organization_discovery_methods: ["organization_name"],
    organization_require_behavior: "pre_login_prompt",
    organization_usage: "require",
  };

  const createClient = await client.clients.create(createClientPayload);
  console.log('createClient Response Data:', createClient.data);

// Patching the client and removing `organization_discovery_methods` and changing to `organization_require_behavior`: '`post_login_prompt`'
  const updateClientPayload: ClientUpdate = {
  organization_discovery_methods: undefined,
  organization_require_behavior: "post_login_prompt",
  oidc_conformant: true
}

  const updateClient = await client.clients.update({ client_id: createClient.data.id! }, updateClientPayload);
  console.log('updateClient Response Data:', updateClient.data);

// Get Client by Client Id
  const getClient = await client.clients.get({ client_id: createClient.data.id! });
  console.log('getClient Response Data:', getClient.data);

// Get All Clients 
  const getAllClients = await client.clients.getAll({ include_totals: true, page: 0, per_page: 10 });
  console.log('getAllClients Response Data:', getAllClients.data);
```

Testing snippets for organization_domains
```
// Create a new domain for the specified {org_id}. Allows setting `status` directly to `verified` or `pending` in the request body and `status` is required and is not defaulted.
  const createDomainDiscoveryPayload: CreateOrganizationDiscoveryDomainRequestContent = {
      domain: 'acme.com',
      status: OrganizationDiscoveryDomainStatus.verified,
  }

  const createDomainDiscovery = await client.organizations.createDiscoveryDomain({id: "<ORG_ID>"},createDomainDiscoveryPayload);
  console.log("createDomainDiscovery", createDomainDiscovery.data);

// Update a domain's properties. Allows updating `status` directly to `verified` or `pending`.
  const updateDomainDiscoveryPayload: UpdateOrganizationDiscoveryDomainRequestContent = {
      status: OrganizationDiscoveryDomainStatus.pending,
  }

  const updateDomainDiscovery = await client.organizations.updateDiscoveryDomain({id: "<ORG_ID>", discovery_domain_id: createDomainDiscovery.data.id!}, updateDomainDiscoveryPayload);
  console.log("updateDomainDiscovery", updateDomainDiscovery.data);

// Retrieve a specific domain by its ID for the specified {org_id}.
  const getDomainDiscovery = await client.organizations.getDiscoveryDomain({id: "<ORG_ID>", discovery_domain_id: createDomainDiscovery.data.id!});
  console.log("getDomainDiscovery", getDomainDiscovery.data);

// Retrieve all domains for the specified {org_id}.
  const getAllDiscoveryDomains = await client.organizations.getAllDiscoveryDomains({id: "<ORG_ID>"});
  console.log("getAllDiscoveryDomains", getAllDiscoveryDomains.data);

// Delete a specific domain.
  const deleteDomainDiscovery = await client.organizations.deleteDiscoveryDomain({id: "<ORG_ID>", discovery_domain_id: createDomainDiscovery.data.id!});
  console.log("deleteDomainDiscovery", deleteDomainDiscovery);
```

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
