### PR TITLE
chore: update .fernignore, remove browser tests, and fix type definitions

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -20,6 +20,7 @@ src/management/tests/unit/request-options.test.ts
 tests/
 v5_MIGRATION_GUIDE.md
 CHANGELOG.md
+AGENTS.md
 .version
 docs/
 

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -35,17 +35,6 @@ export default {
             setupFilesAfterEnv: [],
         },
         {
-            displayName: "browser",
-            preset: "ts-jest",
-            testEnvironment: "<rootDir>/src/management/tests/BrowserTestEnvironment.ts",
-            moduleNameMapper: {
-                "^(\\.{1,2}/.*)\\.js$": "$1",
-            },
-            roots: ["<rootDir>/src/management/tests"],
-            testMatch: ["<rootDir>/src/management/tests/unit/**/?(*.)+(browser).(spec|test).[jt]s?(x)"],
-            setupFilesAfterEnv: [],
-        },
-        {
             displayName: "wire",
             preset: "ts-jest",
             testEnvironment: "node",

--- a/src/management/wrapper/ManagementClient.ts
+++ b/src/management/wrapper/ManagementClient.ts
@@ -253,7 +253,7 @@ function isClientOptionsWithToken(
  */
 function createTelemetryHeaders(
     _options: ManagementClientConfig,
-): Record<string, string | core.Supplier<string | undefined> | undefined> {
+): Record<string, string | core.Supplier<string | null | undefined> | null | undefined> {
     const headers = { ...(_options.headers ?? {}) };
 
     if (_options.telemetry !== false) {


### PR DESCRIPTION
### Changes

This PR includes the following changes:

- **Added `AGENTS.md` to `.fernignore`**: Prevents Fern from modifying the AGENTS.md documentation file
- **Removed browser test configuration**: Removed the browser test project from `jest.config.mjs` as it's no longer needed
- **Updated type signature in ManagementClient**: Changed the return type of `createTelemetryHeaders` to include `null` alongside `undefined` for better type safety in `Record<string, string | core.Supplier<string | null | undefined> | null | undefined>`

### References


### Testing

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

These are configuration and type definition updates that don't require new tests. Existing tests should continue to pass.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors