### PR TITLE
Migrate from NPM token to OIDC authentication

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -3,8 +3,6 @@ name: Publish release to npm
 inputs:
     node-version:
         required: true
-    npm-token:
-        required: true
     version:
         required: true
     require-build:
@@ -52,5 +50,4 @@ runs:
               fi
               npm publish --provenance --tag $TAG
           env:
-              NODE_AUTH_TOKEN: ${{ inputs.npm-token }}
               VERSION: ${{ inputs.version }}

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -15,8 +15,6 @@ on:
         secrets:
             github-token:
                 required: true
-            npm-token:
-                required: true
 
 ### TODO: Replace instances of './.github/actions/' w/ `auth0/dx-sdk-actions/` and append `@latest` after the common `dx-sdk-actions` repo is made public.
 ### TODO: Also remove `get-prerelease`, `get-version`, `release-create`, `tag-create` and `tag-exists` actions from this repo's .github/actions folder once the repo is public.
@@ -26,6 +24,9 @@ jobs:
         if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
         runs-on: ubuntu-latest
         environment: release
+        permissions:
+            contents: write
+            id-token: write
 
         steps:
             # Checkout the code
@@ -70,7 +71,6 @@ jobs:
                   require-build: ${{ inputs.require-build }}
                   release-directory: ${{ inputs.release-directory }}
                   version: ${{ steps.get_version.outputs.version }}
-                  npm-token: ${{ secrets.npm-token }}
 
             # Create a release for the tag
             - uses: ./.github/actions/release-create

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,5 +21,4 @@ jobs:
             node-version: 22
             require-build: true
         secrets:
-            npm-token: ${{ secrets.NPM_TOKEN }}
             github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Changes

This PR migrates the npm publishing workflow from static token-based authentication to OIDC (OpenID Connect) authentication.

**What's changing:**
- Removed `npm-token` secret requirement from all workflows
- Added `permissions: id-token: write` to the release job in `npm-release.yml`
- Removed `NODE_AUTH_TOKEN` environment variable from the npm publish step
- No changes to npm or yarn versions - using pre-installed npm 10.8.2 on ubuntu-latest runner

**Why this is important:**
- npm is deprecating long-lived authentication tokens in mid-November 2025
- OIDC provides better security through short-lived tokens automatically issued by GitHub Actions
- Eliminates need to manage and rotate NPM_TOKEN secret

**Files changed:**
- `.github/workflows/npm-release.yml` - Added permissions, removed npm-token secret
- `.github/workflows/release.yml` - Removed npm-token from secrets
- `.github/actions/npm-publish/action.yml` - Removed npm-token input and NODE_AUTH_TOKEN env var

### References

- npm OIDC Publishing Documentation: https://docs.npmjs.com/generating-provenance-statements
- GitHub Actions OIDC: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect

### Testing

⚠️ **IMPORTANT: Before merging, trusted publishing must be configured on npmjs.com**

1. Go to https://www.npmjs.com/package/auth0/access
2. Navigate to "Publishing access" → "Configure trusted publisher"
3. Select "GitHub Actions" as provider
4. Configure:
   - Organization: `auth0`
   - Repository: `node-auth0`
   - Workflow: `release.yml`
   - Environment: `release`

**Testing approach:**
- After configuring trusted publishing on npm, trigger a test release with an alpha version
- Verify the workflow completes successfully with OIDC authentication
- Check that provenance information appears on the npm package page
- Once verified, remove the `NPM_TOKEN` secret from repository settings

**What's NOT tested:**
- This cannot be fully tested until trusted publishing is configured on npmjs.com
- The changes are minimal and follow GitHub's official OIDC migration guide

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] This change does not require new tests (workflow configuration change only)