### PR TITLE
Update npm to latest for OIDC support

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -28,6 +28,10 @@ runs:
           shell: bash
           run: yarn install --frozen-lockfile
 
+        - name: Update npm to latest
+          shell: bash
+          run: npm install -g npm@latest
+
         - name: Build package
           if: inputs.require-build == 'true'
           shell: bash


### PR DESCRIPTION
### Changes

Updated npm to the latest version in the npm-publish GitHub action to ensure full OIDC (OpenID Connect) authentication support for npm publishing.

- Added npm update step in  to install latest npm version
- Ensures compatibility with npm's OIDC authentication feature

### References

- npm is deprecating authentication tokens in favor of OIDC
- Latest npm versions have improved OIDC support and bug fixes

### Testing

- [ ] This change adds unit test coverage - N/A (infrastructure change)
- [ ] This change adds integration test coverage - N/A (infrastructure change)

This will be tested during the next release workflow execution.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors