### PR TITLE
Update API documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,8 @@ const actions = await client.actions.list(listParams);
 
 ### Generated Documentation
 
-- [Full Reference](./reference.md) - complete API reference guide
+- [API Documentation](http://auth0.github.io/node-auth0/) - complete API documentation
+- [Full Reference](./reference.md) - complete API reference guide in markdown format
 
 ### Key Classes
 


### PR DESCRIPTION
### Changes

The API documentation link was missing in the README.

### References

closes #1239

### Testing

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
