### PR TITLE
fix: update uuid dependency to version 14.0.0 and refactor import in …

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "validate": "yarn lint:check && yarn format --check && yarn build && yarn test && yarn lint:package"
     },
     "dependencies": {
-        "uuid": "^11.1.0",
+        "uuid": "^14.0.0",
         "jose": "^4.13.2",
         "auth0-legacy": "npm:auth0@^4.27.0"
     },

--- a/src/auth/client-authentication.ts
+++ b/src/auth/client-authentication.ts
@@ -1,5 +1,4 @@
 import * as jose from "jose";
-import { v4 as uuid } from "uuid";
 
 export interface AddClientAuthenticationPayload {
     client_id?: string;
@@ -41,6 +40,7 @@ export const addClientAuthentication = async ({
     if (clientAssertionSigningKey && !payload.client_assertion) {
         const alg = clientAssertionSigningAlg || "RS256";
         const privateKey = await jose.importPKCS8(clientAssertionSigningKey, alg);
+        const { v4: uuid } = await import("uuid");
 
         payload.client_assertion = await new jose.SignJWT({})
             .setProtectedHeader({ alg })

--- a/src/management/tests/unit/management-client-custom-domain.test.ts
+++ b/src/management/tests/unit/management-client-custom-domain.test.ts
@@ -23,10 +23,6 @@ jest.mock("jose", () => ({
     },
 }));
 
-jest.mock("uuid", () => ({
-    v4: jest.fn(() => "test-uuid"),
-}));
-
 // Mock the core fetcher to avoid actual HTTP calls
 jest.mock("../../core/index.js", () => {
     const actual = jest.requireActual("../../core/index.js");


### PR DESCRIPTION
## upgrade uuid to v14

### Why
uuid v14 dropped CommonJS (CJS) support - it's ESM-only. The previous static import was compiled by TypeScript to `require("uuid")` in the CJS build, which throws `ERR_REQUIRE_ESM` at runtime.

### Changes
- **`package.json`** - bumped `uuid` from `^11.1.0` to `^14.0.0`
- **`src/auth/client-authentication.ts`** - replaced static import with dynamic `await import("uuid")` inside the function, so the CJS build works correctly


### Notes
- Dynamic import is inside the `if (clientAssertionSigningKey ...)` block - uuid is only loaded when building a client assertion JWT
- No functional behavior change
