### PR TITLE
Chore: Bump uuid dependency to version 11.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ build
 test-results.xml
 .nyc_output
 dist/
+.npmrc

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,12 @@
       "dependencies": {
         "jose": "^4.13.2",
         "undici-types": "^6.15.0",
-        "uuid": "^9.0.0"
+        "uuid": "11.1.1"
       },
       "devDependencies": {
         "@types/jest": "^29.5.0",
         "@types/node": "^16.18.37",
         "@types/node-fetch": "^2.6.3",
-        "@types/uuid": "^9.0.1",
         "@typescript-eslint/eslint-plugin": "^5.58.0",
         "@typescript-eslint/parser": "^5.58.0",
         "c8": "^7.13.0",
@@ -1500,12 +1499,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-      "dev": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -7303,11 +7296,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -8697,12 +8695,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-      "dev": true
-    },
-    "@types/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
       "dev": true
     },
     "@types/yargs": {
@@ -12922,9 +12914,9 @@
       }
     },
     "uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -52,13 +52,12 @@
   "dependencies": {
     "jose": "^4.13.2",
     "undici-types": "^6.15.0",
-    "uuid": "^9.0.0"
+    "uuid": "11.1.1"
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",
     "@types/node": "^16.18.37",
     "@types/node-fetch": "^2.6.3",
-    "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "^5.58.0",
     "@typescript-eslint/parser": "^5.58.0",
     "c8": "^7.13.0",


### PR DESCRIPTION


Bumps the `uuid` dependency from `^9.0.0` to `11.1.1`.

## Changes

- Updated `uuid` to `11.1.1` in `package.json`
- Updated `package-lock.json`

## Testing

- `npm run build` passes cleanly


**Base branch:** `v4`
