### PR TITLE
fix: bump Node.js publish version to 22.23.1 to unblock npm@12 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     release:
         uses: ./.github/workflows/npm-release.yml
         with:
-            node-version: 22.22.1
+            node-version: 22.23.1
             require-build: true
         secrets:
             github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Changes

Bumps the Node.js version used in the release workflow from 22.22.1 to 22.23.1.                                                                                           
                                                                                                                                                                            
Why: npm@latest recently released v12.0.0, which requires Node ^22.22.2 at minimum. The workflow was pinned to 22.22.1 (one patch behind) as a temporary workaround for a Node.js regression (nodejs/node#62425) where the bundled npm was missing the promise-retry module. That regression has since been fixed in 22.22.3+, making it safe to bump the pin and unblock releases.                                                                                                                                        
                                                                                                                                                                            
No SDK code, public API, or functionality is affected — this is a CI-only change.

### References

 - [nodejs/node#62425](https://github.com/nodejs/node/issues/62425) — upstream Node.js regression (closed/fixed)

### Testing

This change can be verified by triggering the release workflow and confirming the npm install -g npm@latest step completes successfully on Node 22.23.1.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
