### PR TITLE
fix: pin npm to ^11 to avoid broken npm@12 bundled dependencies

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -30,7 +30,7 @@ runs:
 
         - name: Update npm to latest
           shell: bash
-          run: npm install -g npm@latest
+          run: npm install -g npm@^11
 
         - name: Build package
           if: inputs.require-build == 'true'


### PR DESCRIPTION
### Changes

Pins npm in the publish action from @latest to @^11 to avoid breakage from `npm@12.0.0`, which ships with missing bundled dependencies (sigstore, promise-retry) that cause npm publish `--provenance` to fail.                                                                                                                                         
                                                                                                                                                                          
npm@^11 is the latest stable major that correctly supports provenance publishing. Using @latest meant any new npm major release could silently break the release pipeline, as happened here with npm@12.0.0.                                                                                                                                       
                                                                                                                                                                            
No SDK code, public API, or functionality is affected, this is a CI-only change.

### References

 - [nodejs/node#62425](https://github.com/nodejs/node/issues/62425) - related bundled dependency regression in Node.js                                                                                                    
 - [npm/cli#9722 ](https://github.com/npm/cli/issues/9722)- npm@12 missing sigstore module, breaking npm publish --provenance (open)

### Testing

Verified by triggering the release workflow and confirming npm publish `--provenance` completes successfully with `npm@^11` on Node 22.23.1.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
